### PR TITLE
Update workon script to correctly tab-complete in zsh

### DIFF
--- a/workon.sh
+++ b/workon.sh
@@ -24,6 +24,11 @@ _complete_invoke() {
     COMPREPLY=( $(compgen -W "${candidates}" -- $2) )
 }
 
+# If running from zsh, run autoload for tab completion
+if [ "$(ps -o comm= -p $$)" = "zsh" ]; then
+    autoload bashcompinit
+    bashcompinit
+fi
 complete -F _complete_invoke -o default invoke inv
 
 # -----------------------------


### PR DESCRIPTION
Similarly to what I did in faasm/faasm#307, I added the necessary shell jargon for adequate tab completion in `zsh`.