### PR TITLE
Fixes for using as an external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,10 @@ target_link_libraries(faabric
         util
         )
 
-target_include_directories(faabric PUBLIC ${FAABRIC_INCLUDE_DIR})
+target_include_directories(faabric PUBLIC 
+    ${FAABRIC_INCLUDE_DIR}
+    ${THIRD_PARTY_INSTALL_DIR}/include
+)
 
 # Tests
 if(FAABRIC_BUILD_TESTS)

--- a/tasks/git.py
+++ b/tasks/git.py
@@ -6,15 +6,20 @@ from subprocess import run
 
 
 @task
-def tag(ctx):
+def tag(ctx, force=False):
     """
     Creates git tag from the current tree
     """
     git_tag = "v{}".format(get_version())
-    run("git tag {}".format(git_tag), shell=True, check=True, cwd=PROJ_ROOT)
+    run(
+        "git tag {} {}".format("--force" if force else "", git_tag),
+        shell=True,
+        check=True,
+        cwd=PROJ_ROOT,
+    )
 
     run(
-        "git push origin {}".format(git_tag),
+        "git push origin {} {}".format("--force" if force else "", git_tag),
         shell=True,
         check=True,
         cwd=PROJ_ROOT,


### PR DESCRIPTION
Related to https://github.com/faasm/faasm/issues/314 

- Declare import directories properly
- Allow overwriting tags already pushed to GH