### PR TITLE
MPI_Scan implementation

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -133,6 +133,13 @@ class MpiWorld
                    uint8_t* inBuffer,
                    uint8_t* resultBuffer);
 
+    void scan(int rank,
+              uint8_t* sendBuffer,
+              uint8_t* recvBuffer,
+              faabric_datatype_t* datatype,
+              int count,
+              faabric_op_t* operation);
+
     void allToAll(int rank,
                   uint8_t* sendBuffer,
                   faabric_datatype_t* sendType,

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -31,9 +31,10 @@ message MPIMessage {
         GATHER = 4;
         ALLGATHER = 5;
         REDUCE = 6;
-        ALLREDUCE = 7;
-        ALLTOALL = 8;
-        RMA_WRITE = 9;
+        SCAN = 7;
+        ALLREDUCE = 8;
+        ALLTOALL = 9;
+        RMA_WRITE = 10;
     };
 
     MPIMessageType messageType = 1;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -757,6 +757,7 @@ void MpiWorld::scan(int rank,
                     int count,
                     faabric_op_t* operation)
 {
+    /*
     const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
     logger->trace("MPI - scan");
     // If rank 0, just copy send into recv
@@ -778,6 +779,7 @@ void MpiWorld::scan(int rank,
     if (rank < (size - 1)) {
         send(rank, rank + 1, sendBuffer, datatype, count);
     }
+    */
 }
 
 void MpiWorld::allToAll(int rank,


### PR DESCRIPTION
Implementation of the scan call, as in [`MPI_Scan`](https://www.open-mpi.org/doc/v4.0/man3/MPI_Scan.3.php).

Scan performs an inclusive prefix reduce. This is, process `i` will return the accumulated value for processes `[0, ..., i]` and pass it's result to the next process.