### PR TITLE
Rebuild with latest gRPC root

### DIFF
--- a/docker/faabric.dockerfile
+++ b/docker/faabric.dockerfile
@@ -1,4 +1,4 @@
-FROM faasm/grpc-root:0.0.5
+FROM faasm/grpc-root:0.0.11
 ARG FAABRIC_VERSION
 
 # Note - the version of grpc-root here can be quite behind as it's rebuilt very


### PR DESCRIPTION
Removes about 1.2GB of size