### PR TITLE
Encapsulate reduce operator

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -123,6 +123,12 @@ class MpiWorld
                    int count,
                    faabric_op_t* operation);
 
+    void op_reduce(faabric_op_t* operation,
+                   faabric_datatype_t* datatype,
+                   int count,
+                   uint8_t* inBuffer,
+                   uint8_t* resultBuffer);
+
     void allToAll(int rank,
                   uint8_t* sendBuffer,
                   faabric_datatype_t* sendType,

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -585,61 +585,7 @@ void MpiWorld::reduce(int sendRank,
                      faabric::MPIMessage::REDUCE);
             }
 
-            if (operation->id == faabric_op_sum.id) {
-                if (datatype->id == FAABRIC_INT) {
-                    auto recvBufferCast = reinterpret_cast<int*>(recvBuffer);
-                    auto rankDataCast = reinterpret_cast<int*>(rankData);
-
-                    for (int slot = 0; slot < count; slot++) {
-                        recvBufferCast[slot] += rankDataCast[slot];
-                    }
-                } else if (datatype->id == FAABRIC_DOUBLE) {
-                    auto recvBufferCast = reinterpret_cast<double*>(recvBuffer);
-                    auto rankDataCast = reinterpret_cast<double*>(rankData);
-
-                    for (int slot = 0; slot < count; slot++) {
-                        recvBufferCast[slot] += rankDataCast[slot];
-                    }
-                } else if (datatype->id == FAABRIC_LONG_LONG) {
-                    auto recvBufferCast =
-                      reinterpret_cast<long long*>(recvBuffer);
-                    auto rankDataCast = reinterpret_cast<long long*>(rankData);
-
-                    for (int slot = 0; slot < count; slot++) {
-                        recvBufferCast[slot] += rankDataCast[slot];
-                    }
-                } else {
-                    logger->error(
-                      "Unsupported type for sum reduction (datatype={})",
-                      datatype->id);
-                    throw std::runtime_error(
-                      "Unsupported type for sum reduction");
-                }
-            } else if (operation->id == faabric_op_max.id) {
-                if (datatype->id == FAABRIC_INT) {
-                    auto recvBufferCast = reinterpret_cast<int*>(recvBuffer);
-                    auto rankDataCast = reinterpret_cast<int*>(rankData);
-
-                    for (int slot = 0; slot < count; slot++) {
-                        recvBufferCast[slot] =
-                          std::max(recvBufferCast[slot], rankDataCast[slot]);
-                    }
-                } else if (datatype->id == FAABRIC_DOUBLE) {
-                    auto recvBufferCast = reinterpret_cast<double*>(recvBuffer);
-                    auto rankDataCast = reinterpret_cast<double*>(rankData);
-
-                    for (int slot = 0; slot < count; slot++) {
-                        recvBufferCast[slot] =
-                          std::max(recvBufferCast[slot], rankDataCast[slot]);
-                    }
-                } else {
-                    throw std::runtime_error(
-                      "Unsupported type for max reduction");
-                }
-            } else {
-                throw std::runtime_error(
-                  "Not yet implemented reduce operation");
-            }
+            op_reduce(operation, datatype, count, rankData, recvBuffer);
 
             if (r != recvRank) {
                 delete[] rankData;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -687,6 +687,76 @@ void MpiWorld::allReduce(int rank,
     }
 }
 
+void MpiWorld::op_reduce(faabric_op_t* operation,
+                         faabric_datatype_t* datatype,
+                         int count,
+                         uint8_t* inBuffer,
+                         uint8_t* outBuffer)
+{
+    const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
+
+    logger->trace(
+      "MPI - reduce op: {} datatype {}", operation->id, datatype->id);
+    if (operation->id == faabric_op_sum.id) {
+        if (datatype->id == FAABRIC_INT) {
+            auto inBufferCast = reinterpret_cast<int*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<int*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] += inBufferCast[slot];
+            }
+        } else if (datatype->id == FAABRIC_DOUBLE) {
+            auto inBufferCast = reinterpret_cast<double*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<double*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] += inBufferCast[slot];
+            }
+        } else if (datatype->id == FAABRIC_LONG_LONG) {
+            auto inBufferCast = reinterpret_cast<long long*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<long long*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] += inBufferCast[slot];
+            }
+        } else {
+            logger->error("Unsupported type for sum reduction (datatype={})",
+                          datatype->id);
+            throw std::runtime_error("Unsupported type for sum reduction");
+        }
+    } else if (operation->id == faabric_op_max.id) {
+        if (datatype->id == FAABRIC_INT) {
+            auto inBufferCast = reinterpret_cast<int*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<int*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::max(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else if (datatype->id == FAABRIC_DOUBLE) {
+            auto inBufferCast = reinterpret_cast<double*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<double*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::max(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else if (datatype->id == FAABRIC_LONG_LONG) {
+            auto inBufferCast = reinterpret_cast<long long*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<long long*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::max(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else {
+            throw std::runtime_error("Unsupported type for max reduction");
+        }
+    } else {
+        throw std::runtime_error("Not yet implemented reduce operation");
+    }
+}
+
 void MpiWorld::allToAll(int rank,
                         uint8_t* sendBuffer,
                         faabric_datatype_t* sendType,

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -954,6 +954,137 @@ TEST_CASE("Test reduce", "[mpi]")
     }
 }
 
+TEST_CASE("Test operator reduce", "[mpi]")
+{
+    cleanFaabric();
+
+    const faabric::Message& msg = faabric::util::messageFactory(user, func);
+    scheduler::MpiWorld world;
+    int thisWorldSize = 5;
+    world.create(msg, worldId, thisWorldSize);
+
+    // Register the ranks
+    for (int r = 1; r < thisWorldSize; r++) {
+        world.registerRank(r);
+    }
+
+    SECTION("Sum")
+    {
+        SECTION("Integers")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 1, 1, 1 };
+            std::vector<int> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_SUM,
+                            MPI_INT,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Doubles")
+        {
+            std::vector<double> input = { 1, 1, 1 };
+            std::vector<double> output = { 1, 1, 1 };
+            std::vector<double> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_SUM,
+                            MPI_DOUBLE,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Long long")
+        {
+            std::vector<long long> input = { 1, 1, 1 };
+            std::vector<long long> output = { 1, 1, 1 };
+            std::vector<long long> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_SUM,
+                            MPI_LONG_LONG,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Unsupported type")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 1, 1, 1 };
+            std::vector<int> expected = { 2, 2, 2 };
+
+            REQUIRE_THROWS(world.op_reduce(MPI_SUM,
+                                           MPI_DATATYPE_NULL,
+                                           3,
+                                           (uint8_t*)input.data(),
+                                           (uint8_t*)output.data()));
+        }
+    }
+
+    SECTION("Max")
+    {
+        SECTION("Integers")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 2, 2, 2 };
+            std::vector<int> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_MAX,
+                            MPI_INT,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Doubles")
+        {
+            std::vector<double> input = { 2, 2, 2 };
+            std::vector<double> output = { 1, 1, 1 };
+            std::vector<double> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_MAX,
+                            MPI_DOUBLE,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Long long")
+        {
+            std::vector<long long> input = { 2, 2, 2 };
+            std::vector<long long> output = { 1, 1, 1 };
+            std::vector<long long> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_MAX,
+                            MPI_LONG_LONG,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Unsupported type")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 1, 1, 1 };
+            std::vector<int> expected = { 2, 2, 2 };
+
+            REQUIRE_THROWS(world.op_reduce(MPI_MAX,
+                                           MPI_DATATYPE_NULL,
+                                           3,
+                                           (uint8_t*)input.data(),
+                                           (uint8_t*)output.data()));
+        }
+    }
+}
+
 TEST_CASE("Test gather and allgather", "[mpi]")
 {
     cleanFaabric();


### PR DESCRIPTION
In this PR I abstract the current reduce logic from `reduce` itself to `op_reduce`. Reducing an operator, this is accumulating two arrays of `faabric_datatype_t` using a `faabric_operator_t`, is something we might need in more collective communication calls other than `reduce`.

For instance, `MPI_Scan`, which performs a [partial reduce](https://www.open-mpi.org/doc/v4.0/man3/MPI_Scan.3.php), would also use this method.

Further, I find it cleaner for implementation, testing, and debugging purposes to have the logic separated. Specially as we include more types and operators.