### PR TITLE
Actually update to latest gRPC root

### DIFF
--- a/docker/faabric.dockerfile
+++ b/docker/faabric.dockerfile
@@ -1,4 +1,4 @@
-FROM faasm/grpc-root:0.0.11
+FROM faasm/grpc-root:0.0.12
 ARG FAABRIC_VERSION
 
 # Note - the version of grpc-root here can be quite behind as it's rebuilt very


### PR DESCRIPTION
Turns out my local master was super out of date, so I thought 0.0.11 was latest :man_facepalming: 