### PR TITLE
MPI_sendRecv support: implementation and test

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -86,6 +86,16 @@ class MpiWorld
 
     void awaitAsyncRequest(int requestId);
 
+    void sendRecv(uint8_t* sendBuffer,
+                  int sendcount,
+                  faabric_datatype_t* sendDataType,
+                  int recvRank,
+                  uint8_t* recvBuffer,
+                  int recvCount,
+                  faabric_datatype_t* recvDataType,
+                  int sendRank,
+                  MPI_Status* status);
+
     void scatter(int sendRank,
                  int recvRank,
                  const uint8_t* sendBuffer,

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -35,6 +35,7 @@ message MPIMessage {
         ALLREDUCE = 8;
         ALLTOALL = 9;
         RMA_WRITE = 10;
+        SENDRECV = 11;
     };
 
     MPIMessageType messageType = 1;


### PR DESCRIPTION
[`MPI_sendRecv`](https://www.open-mpi.org/doc/v4.0/man3/MPI_Sendrecv.3.php) performs both a send and a receive, and ensures completion (i.e. no deadlocks) regardless of the order they are issued in.

In this PR I include the implementation in `faabric` together with a test case. As mentioned in the `TODO` I will now change the signature of `doISendRecv` to allow async `recv`s to have a message type as well. But this will be in a different PR.

This is, hopefully, the last call to be implemented prior to running LAMMPS @ Faasm :tada: 