### PR TITLE
Adding message type to asynchronous send/recv

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -60,7 +60,9 @@ class MpiWorld
               int recvRank,
               const uint8_t* buffer,
               faabric_datatype_t* dataType,
-              int count);
+              int count,
+              faabric::MPIMessage::MPIMessageType messageType =
+                faabric::MPIMessage::NORMAL);
 
     void broadcast(int sendRank,
                    const uint8_t* buffer,
@@ -82,7 +84,9 @@ class MpiWorld
               int recvRank,
               uint8_t* buffer,
               faabric_datatype_t* dataType,
-              int count);
+              int count,
+              faabric::MPIMessage::MPIMessageType messageType =
+                faabric::MPIMessage::NORMAL);
 
     void awaitAsyncRequest(int requestId);
 
@@ -220,7 +224,9 @@ class MpiWorld
                     const uint8_t* sendBuffer,
                     uint8_t* recvBuffer,
                     faabric_datatype_t* dataType,
-                    int count);
+                    int count,
+                    faabric::MPIMessage::MPIMessageType messageType =
+                      faabric::MPIMessage::NORMAL);
 
     void pushToState();
 };

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -227,6 +227,19 @@ TEST_CASE("Test send and recv on same host", "[mpi]")
         REQUIRE(status.MPI_SOURCE == rankA1);
         REQUIRE(status.bytesSize == messageData.size() * sizeof(int));
     }
+
+    SECTION("Test recv with type missmatch")
+    {
+        // Receive a message from a different type
+        auto buffer = new int[messageData.size()];
+        REQUIRE_THROWS(world.recv(rankA1,
+                                  rankA2,
+                                  BYTES(buffer),
+                                  MPI_INT,
+                                  messageData.size(),
+                                  nullptr,
+                                  faabric::MPIMessage::SENDRECV));
+    }
 }
 
 TEST_CASE("Test sendrecv", "[mpi]")


### PR DESCRIPTION
Included the optional `MPIMessage` parameter for asynchronous send and receive. This was needed for `MPI_sendRecv` when a blocking send is matched with a non-blocking receive.

Additionally, this can prove useful if we implement non-blocking collective communication as in MPI-3.

I also include a test case covering this case (which was already guarded with a runtime exception).