### PR TITLE
Support for MPI_MIN in reduce operations

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -804,6 +804,7 @@ void MpiWorld::op_reduce(faabric_op_t* operation,
             throw std::runtime_error("Unsupported type for max reduction");
         }
     } else {
+        logger->error("Reduce operation not implemented: {}", operation->id);
         throw std::runtime_error("Not yet implemented reduce operation");
     }
 }

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -748,7 +748,67 @@ void MpiWorld::op_reduce(faabric_op_t* operation,
 
     logger->trace(
       "MPI - reduce op: {} datatype {}", operation->id, datatype->id);
-    if (operation->id == faabric_op_sum.id) {
+    if (operation->id == faabric_op_max.id) {
+        if (datatype->id == FAABRIC_INT) {
+            auto inBufferCast = reinterpret_cast<int*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<int*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::max(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else if (datatype->id == FAABRIC_DOUBLE) {
+            auto inBufferCast = reinterpret_cast<double*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<double*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::max(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else if (datatype->id == FAABRIC_LONG_LONG) {
+            auto inBufferCast = reinterpret_cast<long long*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<long long*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::max(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else {
+            logger->error("Unsupported type for max reduction (datatype={})",
+                          datatype->id);
+            throw std::runtime_error("Unsupported type for max reduction");
+        }
+    } else if (operation->id == faabric_op_min.id) {
+        if (datatype->id == FAABRIC_INT) {
+            auto inBufferCast = reinterpret_cast<int*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<int*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::min(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else if (datatype->id == FAABRIC_DOUBLE) {
+            auto inBufferCast = reinterpret_cast<double*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<double*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::min(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else if (datatype->id == FAABRIC_LONG_LONG) {
+            auto inBufferCast = reinterpret_cast<long long*>(inBuffer);
+            auto outBufferCast = reinterpret_cast<long long*>(outBuffer);
+
+            for (int slot = 0; slot < count; slot++) {
+                outBufferCast[slot] =
+                  std::min(outBufferCast[slot], inBufferCast[slot]);
+            }
+        } else {
+            logger->error("Unsupported type for min reduction (datatype={})",
+                          datatype->id);
+            throw std::runtime_error("Unsupported type for min reduction");
+        }
+    } else if (operation->id == faabric_op_sum.id) {
         if (datatype->id == FAABRIC_INT) {
             auto inBufferCast = reinterpret_cast<int*>(inBuffer);
             auto outBufferCast = reinterpret_cast<int*>(outBuffer);
@@ -774,34 +834,6 @@ void MpiWorld::op_reduce(faabric_op_t* operation,
             logger->error("Unsupported type for sum reduction (datatype={})",
                           datatype->id);
             throw std::runtime_error("Unsupported type for sum reduction");
-        }
-    } else if (operation->id == faabric_op_max.id) {
-        if (datatype->id == FAABRIC_INT) {
-            auto inBufferCast = reinterpret_cast<int*>(inBuffer);
-            auto outBufferCast = reinterpret_cast<int*>(outBuffer);
-
-            for (int slot = 0; slot < count; slot++) {
-                outBufferCast[slot] =
-                  std::max(outBufferCast[slot], inBufferCast[slot]);
-            }
-        } else if (datatype->id == FAABRIC_DOUBLE) {
-            auto inBufferCast = reinterpret_cast<double*>(inBuffer);
-            auto outBufferCast = reinterpret_cast<double*>(outBuffer);
-
-            for (int slot = 0; slot < count; slot++) {
-                outBufferCast[slot] =
-                  std::max(outBufferCast[slot], inBufferCast[slot]);
-            }
-        } else if (datatype->id == FAABRIC_LONG_LONG) {
-            auto inBufferCast = reinterpret_cast<long long*>(inBuffer);
-            auto outBufferCast = reinterpret_cast<long long*>(outBuffer);
-
-            for (int slot = 0; slot < count; slot++) {
-                outBufferCast[slot] =
-                  std::max(outBufferCast[slot], inBufferCast[slot]);
-            }
-        } else {
-            throw std::runtime_error("Unsupported type for max reduction");
         }
     } else {
         logger->error("Reduce operation not implemented: {}", operation->id);

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -1090,64 +1090,6 @@ TEST_CASE("Test operator reduce", "[mpi]")
         world.registerRank(r);
     }
 
-    SECTION("Sum")
-    {
-        SECTION("Integers")
-        {
-            std::vector<int> input = { 1, 1, 1 };
-            std::vector<int> output = { 1, 1, 1 };
-            std::vector<int> expected = { 2, 2, 2 };
-
-            world.op_reduce(MPI_SUM,
-                            MPI_INT,
-                            3,
-                            (uint8_t*)input.data(),
-                            (uint8_t*)output.data());
-            REQUIRE(output == expected);
-        }
-
-        SECTION("Doubles")
-        {
-            std::vector<double> input = { 1, 1, 1 };
-            std::vector<double> output = { 1, 1, 1 };
-            std::vector<double> expected = { 2, 2, 2 };
-
-            world.op_reduce(MPI_SUM,
-                            MPI_DOUBLE,
-                            3,
-                            (uint8_t*)input.data(),
-                            (uint8_t*)output.data());
-            REQUIRE(output == expected);
-        }
-
-        SECTION("Long long")
-        {
-            std::vector<long long> input = { 1, 1, 1 };
-            std::vector<long long> output = { 1, 1, 1 };
-            std::vector<long long> expected = { 2, 2, 2 };
-
-            world.op_reduce(MPI_SUM,
-                            MPI_LONG_LONG,
-                            3,
-                            (uint8_t*)input.data(),
-                            (uint8_t*)output.data());
-            REQUIRE(output == expected);
-        }
-
-        SECTION("Unsupported type")
-        {
-            std::vector<int> input = { 1, 1, 1 };
-            std::vector<int> output = { 1, 1, 1 };
-            std::vector<int> expected = { 2, 2, 2 };
-
-            REQUIRE_THROWS(world.op_reduce(MPI_SUM,
-                                           MPI_DATATYPE_NULL,
-                                           3,
-                                           (uint8_t*)input.data(),
-                                           (uint8_t*)output.data()));
-        }
-    }
-
     SECTION("Max")
     {
         SECTION("Integers")
@@ -1196,9 +1138,122 @@ TEST_CASE("Test operator reduce", "[mpi]")
         {
             std::vector<int> input = { 1, 1, 1 };
             std::vector<int> output = { 1, 1, 1 };
-            std::vector<int> expected = { 2, 2, 2 };
 
             REQUIRE_THROWS(world.op_reduce(MPI_MAX,
+                                           MPI_DATATYPE_NULL,
+                                           3,
+                                           (uint8_t*)input.data(),
+                                           (uint8_t*)output.data()));
+        }
+    }
+
+    SECTION("Min")
+    {
+        SECTION("Integers")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 2, 2, 2 };
+            std::vector<int> expected = { 1, 1, 1 };
+
+            world.op_reduce(MPI_MIN,
+                            MPI_INT,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Doubles")
+        {
+            std::vector<double> input = { 2, 2, 2 };
+            std::vector<double> output = { 1, 1, 1 };
+            std::vector<double> expected = { 1, 1, 1 };
+
+            world.op_reduce(MPI_MIN,
+                            MPI_DOUBLE,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Long long")
+        {
+            std::vector<long long> input = { 2, 2, 2 };
+            std::vector<long long> output = { 1, 1, 1 };
+            std::vector<long long> expected = { 1, 1, 1 };
+
+            world.op_reduce(MPI_MIN,
+                            MPI_LONG_LONG,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Unsupported type")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 1, 1, 1 };
+
+            REQUIRE_THROWS(world.op_reduce(MPI_MIN,
+                                           MPI_DATATYPE_NULL,
+                                           3,
+                                           (uint8_t*)input.data(),
+                                           (uint8_t*)output.data()));
+        }
+    }
+
+    SECTION("Sum")
+    {
+        SECTION("Integers")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 1, 1, 1 };
+            std::vector<int> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_SUM,
+                            MPI_INT,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Doubles")
+        {
+            std::vector<double> input = { 1, 1, 1 };
+            std::vector<double> output = { 1, 1, 1 };
+            std::vector<double> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_SUM,
+                            MPI_DOUBLE,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Long long")
+        {
+            std::vector<long long> input = { 1, 1, 1 };
+            std::vector<long long> output = { 1, 1, 1 };
+            std::vector<long long> expected = { 2, 2, 2 };
+
+            world.op_reduce(MPI_SUM,
+                            MPI_LONG_LONG,
+                            3,
+                            (uint8_t*)input.data(),
+                            (uint8_t*)output.data());
+            REQUIRE(output == expected);
+        }
+
+        SECTION("Unsupported type")
+        {
+            std::vector<int> input = { 1, 1, 1 };
+            std::vector<int> output = { 1, 1, 1 };
+
+            REQUIRE_THROWS(world.op_reduce(MPI_SUM,
                                            MPI_DATATYPE_NULL,
                                            3,
                                            (uint8_t*)input.data(),


### PR DESCRIPTION
Profiling tells us what MPI calls are made, but not the actual parameters. Reducing with the `MPI_MIN` operation is needed in LAMMPS.