### PR TITLE
Change the build flag to avoid extra CMake arguments

### DIFF
--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -22,7 +22,8 @@ set_target_properties(faabricmpi
     PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}"
     )
 
-if(FAASM_BUILD_TYPE STREQUAL "wasm")
+if(CMAKE_SYSTEM_NAME STREQUAL "Wasm")
+    message(STATUS "Faabric MPI WebAssembly build")
     set(LIB_DIRECTORY ${CMAKE_SYSROOT}/lib/wasm32-wasi)
     
     install(TARGETS faabricmpi
@@ -31,6 +32,7 @@ if(FAASM_BUILD_TYPE STREQUAL "wasm")
         PUBLIC_HEADER DESTINATION ${CMAKE_SYSROOT}/include/faabric/mpi
     )
 else()
+    message(STATUS "Faabric MPI native build")
     install(TARGETS faabricmpi
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/faabric/mpi
     )


### PR DESCRIPTION
Before we had to pass a specific `CMake` flag (`FAASM_BUILD_TYPE`) in order to install the header and library files in the right `sysroot`. This is unnnecessary as we can directly query the system name in a WebAssembly build.

Note that this was making the `toolchain` installation and subsequent builds fail, as it would create broken symlinks to non-existing `faabric` header files.