### PR TITLE
Solving sendRecv issue + Regression test

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -93,11 +93,12 @@ class MpiWorld
     void sendRecv(uint8_t* sendBuffer,
                   int sendcount,
                   faabric_datatype_t* sendDataType,
-                  int recvRank,
+                  int sendRank,
                   uint8_t* recvBuffer,
                   int recvCount,
                   faabric_datatype_t* recvDataType,
-                  int sendRank,
+                  int recvRank,
+                  int myRank,
                   MPI_Status* status);
 
     void scatter(int sendRank,

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -331,15 +331,20 @@ void MpiWorld::send(int sendRank,
 void MpiWorld::sendRecv(uint8_t* sendBuffer,
                         int sendCount,
                         faabric_datatype_t* sendDataType,
-                        int recvRank,
+                        int sendRank,
                         uint8_t* recvBuffer,
                         int recvCount,
                         faabric_datatype_t* recvDataType,
-                        int sendRank,
+                        int recvRank,
+                        int myRank,
                         MPI_Status* status)
 {
     auto logger = faabric::util::getLogger();
-    logger->trace("MPI - Sendrecv");
+    logger->trace(
+      "MPI - Sendrecv. Rank {}. Sending to: {} - Receiving from: {}",
+      myRank,
+      sendRank,
+      recvRank);
 
     if (recvRank > this->size - 1) {
         throw std::runtime_error(fmt::format(
@@ -352,14 +357,14 @@ void MpiWorld::sendRecv(uint8_t* sendBuffer,
 
     // Post async recv
     int recvId = irecv(recvRank,
-                       sendRank,
+                       myRank,
                        recvBuffer,
                        recvDataType,
                        recvCount,
                        faabric::MPIMessage::SENDRECV);
     // Then send the message
-    send(sendRank,
-         recvRank,
+    send(myRank,
+         sendRank,
          sendBuffer,
          sendDataType,
          sendCount,


### PR DESCRIPTION
In this PR I solve a bug I had introduced when implementing the `sendRecv` operator. The previous implementation would only work if only two processes were involved.

`sendRecv` (basing on `MPI_Sendrecv`) performs a blocking `Send + Recv` (note that the block granularity is of two ops. not one) where the recipient of the `send` (`sendRank`) and the sender of the `recv` (`recvRank`) _need not_ to be the same process. Before it would only work if these two processes were indeed the same.

This operator is particularly useful as it allows to perform a shift operator on a ring of processes where everybody sends to their right, and receives from their left, without having to worry about dead-locks originating from poorly matched `Send+Recv`, `Sendrecv` handles this automatically.

I also include a test for this particular setting.
