### PR TITLE
Fix includes for inclusion as an external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,17 +13,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Compile comamnds for clang tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Library funcs
-function(faabric_lib lib_name lib_deps)
-    add_library(${lib_name} ${lib_deps})
-
-    add_library(${lib_name}_obj OBJECT ${lib_deps})
-
-    if(BUILD_SHARED_LIBS)
-        target_compile_options(${lib_name} PRIVATE "-fPIC")
-        target_compile_options(${lib_name}_obj PRIVATE "-fPIC")
-    endif()    
-endfunction()
+# Global include dir
+set(FAABRIC_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
 
 # Output directories
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -33,11 +24,25 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # External libraries
 include(cmake/ExternalProjects.cmake)
 
-# Global include dir
-set(FAABRIC_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
+# Library funcs
+function(faabric_lib lib_name lib_deps)
+    add_library(${lib_name} ${lib_deps})
 
-# Include directories
-include_directories(${FAABRIC_INCLUDE_DIR})
+    add_library(${lib_name}_obj OBJECT ${lib_deps})
+
+    # Include directories
+    target_include_directories(${lib_name} 
+        PUBLIC ${FAABRIC_INCLUDE_DIR}
+        PUBLIC ${PISTACHE_INCLUDE_DIR}
+        PUBLIC ${SPDLOG_INCLUDE_DIR}
+        PUBLIC ${RAPIDJSON_INCLUDE_DIR}
+        )
+
+    if(BUILD_SHARED_LIBS)
+        target_compile_options(${lib_name} PRIVATE "-fPIC")
+        target_compile_options(${lib_name}_obj PRIVATE "-fPIC")
+    endif()    
+endfunction()
 
 add_subdirectory(src/endpoint)
 add_subdirectory(src/executor)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,13 @@ function(faabric_lib lib_name lib_deps)
         PUBLIC ${RAPIDJSON_INCLUDE_DIR}
         )
 
+    target_include_directories(${lib_name}_obj 
+        PUBLIC ${FAABRIC_INCLUDE_DIR}
+        PUBLIC ${PISTACHE_INCLUDE_DIR}
+        PUBLIC ${SPDLOG_INCLUDE_DIR}
+        PUBLIC ${RAPIDJSON_INCLUDE_DIR}
+        )
+
     if(BUILD_SHARED_LIBS)
         target_compile_options(${lib_name} PRIVATE "-fPIC")
         target_compile_options(${lib_name}_obj PRIVATE "-fPIC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ add_library(faabric
     $<TARGET_OBJECTS:util_obj>
 )
 
-add_dependencies(faabric pistache_ext)
+add_dependencies(faabric pistache_ext spdlog_ext)
 
 target_link_libraries(faabric
     ${Protobuf_LIBRARIES}

--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -36,7 +36,7 @@ ExternalProject_Add(pistache_ext
     CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}"
 )
 ExternalProject_Get_Property(pistache_ext SOURCE_DIR)
-include_directories(${SOURCE_DIR}/include)
+set(PISTACHE_INCLUDE_DIR ${SOURCE_DIR}/include)
 
 # RapidJSON
 ExternalProject_Add(rapidjson_ext
@@ -48,7 +48,7 @@ ExternalProject_Add(rapidjson_ext
     CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}"
 )
 ExternalProject_Get_Property(rapidjson_ext SOURCE_DIR)
-include_directories(${SOURCE_DIR}/include)
+set(RAPIDJSON_INCLUDE_DIR ${SOURCE_DIR}/include)
 
 # spdlog
 ExternalProject_Add(spdlog_ext
@@ -57,7 +57,7 @@ ExternalProject_Add(spdlog_ext
     CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}"
 )
 ExternalProject_Get_Property(spdlog_ext SOURCE_DIR)
-include_directories(${SOURCE_DIR}/include)
+set(SPDLOG_INCLUDE_DIR ${SOURCE_DIR}/include)
 
 if(FAABRIC_BUILD_TESTS)
     # Catch (tests)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,12 +14,18 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 function(add_example example_name)
     add_executable(${example_name} ${example_name}.cpp)
 
-    set(FAABRIC_LIBS libfaabric.so libfaabricmpi.so)
-
     target_link_libraries(${example_name}
-        ${FAABRIC_LIBS}
+        faabric
+        faabricmpi
+        protobuf
+        pthread
         pistache
-        )
+        hiredis
+        grpc++
+        grpc++_reflection
+        boost_system
+        boost_filesystem
+    )
     
     set(ALL_EXAMPLES ${ALL_EXAMPLES} ${example_name} PARENT_SCOPE)   
 endfunction()

--- a/include/faabric/executor/FaabricMain.h
+++ b/include/faabric/executor/FaabricMain.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "FaabricPool.h"
-
+#include <faabric/executor/FaabricPool.h>
 #include <faabric/state/StateServer.h>
 #include <faabric/util/config.h>
 

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Scheduler.h"
+#include <faabric/scheduler/Scheduler.h>
 
 #include <faabric/proto/RPCServer.h>
 #include <faabric/proto/faabric.grpc.pb.h>

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "ExecGraph.h"
-#include "InMemoryMessageQueue.h"
+#include <faabric/scheduler/ExecGraph.h>
+#include <faabric/scheduler/InMemoryMessageQueue.h>
 
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>

--- a/include/faabric/state/DummyStateServer.h
+++ b/include/faabric/state/DummyStateServer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "StateServer.h"
+#include <faabric/state/StateServer.h>
 
 namespace faabric::state {
 class DummyStateServer

--- a/include/faabric/state/InMemoryStateKeyValue.h
+++ b/include/faabric/state/InMemoryStateKeyValue.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "InMemoryStateRegistry.h"
-#include "StateClient.h"
-#include "StateKeyValue.h"
+#include <faabric/state/InMemoryStateRegistry.h>
+#include <faabric/state/StateClient.h>
+#include <faabric/state/StateKeyValue.h>
 
 #include <faabric/proto/faabric.grpc.pb.h>
 #include <faabric/proto/faabric.pb.h>

--- a/include/faabric/state/RedisStateKeyValue.h
+++ b/include/faabric/state/RedisStateKeyValue.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "StateKeyValue.h"
+#include <faabric/state/StateKeyValue.h>
 
 #include <faabric/redis/Redis.h>
 #include <faabric/util/clock.h>

--- a/include/faabric/state/State.h
+++ b/include/faabric/state/State.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "StateKeyValue.h"
+#include <faabric/state/StateKeyValue.h>
 
 #include <shared_mutex>
 #include <string>

--- a/include/faabric/state/StateClient.h
+++ b/include/faabric/state/StateClient.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "InMemoryStateRegistry.h"
-#include "State.h"
+#include <faabric/state/InMemoryStateRegistry.h>
+#include <faabric/state/State.h>
 
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/include/faabric/state/StateServer.h
+++ b/include/faabric/state/StateServer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "State.h"
+#include <faabric/state/State.h>
 
 #include <faabric/proto/RPCServer.h>
 #include <faabric/proto/faabric.grpc.pb.h>

--- a/include/faabric/util/chaining.h
+++ b/include/faabric/util/chaining.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <faabric/util/exception.h>
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/util/exception.h>
 
 namespace faabric::util {
 class ChainedCallFailedException : public faabric::util::FaabricException

--- a/include/faabric/util/chaining.h
+++ b/include/faabric/util/chaining.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "exception.h"
+#include <faabric/util/exception.h>
 #include <faabric/proto/faabric.pb.h>
 
 namespace faabric::util {

--- a/include/faabric/util/files.h
+++ b/include/faabric/util/files.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "exception.h"
+#include <faabric/util/exception.h>
 #include <string>
 #include <vector>
 

--- a/include/faabric/util/func.h
+++ b/include/faabric/util/func.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "exception.h"
+#include <faabric/util/exception.h>
 #include <faabric/proto/faabric.pb.h>
 #include <string>
 #include <vector>

--- a/include/faabric/util/func.h
+++ b/include/faabric/util/func.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <faabric/util/exception.h>
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/util/exception.h>
 #include <string>
 #include <vector>
 

--- a/include/faabric/util/http.h
+++ b/include/faabric/util/http.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "exception.h"
+#include <faabric/util/exception.h>
 #include <pistache/http_header.h>
 #include <string>
 #include <vector>

--- a/include/faabric/util/json.h
+++ b/include/faabric/util/json.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <faabric/util/exception.h>
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/util/exception.h>
 
 namespace faabric::util {
 std::string messageToJson(const faabric::Message& msg);

--- a/include/faabric/util/json.h
+++ b/include/faabric/util/json.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "exception.h"
+#include <faabric/util/exception.h>
 #include <faabric/proto/faabric.pb.h>
 
 namespace faabric::util {

--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "exception.h"
-#include "locks.h"
+#include <faabric/util/exception.h>
+#include <faabric/util/locks.h>
 
 #include <queue>
 

--- a/src/endpoint/CMakeLists.txt
+++ b/src/endpoint/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${FAABRIC_INCLUDE_DIR}/faabric/endpoint)
-
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/endpoint/*.h")
 
 set(LIB_FILES

--- a/src/endpoint/Endpoint.cpp
+++ b/src/endpoint/Endpoint.cpp
@@ -1,4 +1,4 @@
-#include "faabric/endpoint/Endpoint.h"
+#include <faabric/endpoint/Endpoint.h>
 
 #include <faabric/util/logging.h>
 #include <pistache/endpoint.h>

--- a/src/endpoint/FaabricEndpoint.cpp
+++ b/src/endpoint/FaabricEndpoint.cpp
@@ -1,5 +1,5 @@
-#include "FaabricEndpoint.h"
-#include "FaabricEndpointHandler.h"
+#include <faabric/endpoint/FaabricEndpoint.h>
+#include <faabric/endpoint/FaabricEndpointHandler.h>
 
 namespace faabric::endpoint {
 FaabricEndpoint::FaabricEndpoint()

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -1,4 +1,4 @@
-#include "FaabricEndpointHandler.h"
+#include <faabric/endpoint/FaabricEndpointHandler.h>
 
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/Scheduler.h>

--- a/src/executor/CMakeLists.txt
+++ b/src/executor/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${FAABRIC_INCLUDE_DIR}/faabric/executor)
-
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/executor/*.h")
 
 set(LIB_FILES

--- a/src/executor/FaabricExecutor.cpp
+++ b/src/executor/FaabricExecutor.cpp
@@ -1,4 +1,4 @@
-#include "FaabricExecutor.h"
+#include <faabric/executor/FaabricExecutor.h>
 
 #include <faabric/state/State.h>
 #include <faabric/util/config.h>

--- a/src/executor/FaabricMain.cpp
+++ b/src/executor/FaabricMain.cpp
@@ -1,5 +1,4 @@
-#include "FaabricMain.h"
-
+#include <faabric/executor/FaabricMain.h>
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 

--- a/src/executor/FaabricPool.cpp
+++ b/src/executor/FaabricPool.cpp
@@ -1,5 +1,5 @@
-#include <faabric/executor/FaabricPool.h>
 #include <faabric/executor/FaabricExecutor.h>
+#include <faabric/executor/FaabricPool.h>
 #include <faabric/util/logging.h>
 
 namespace faabric::executor {

--- a/src/executor/FaabricPool.cpp
+++ b/src/executor/FaabricPool.cpp
@@ -1,5 +1,4 @@
-#include "FaabricPool.h"
-
+#include <faabric/executor/FaabricPool.h>
 #include <faabric/executor/FaabricExecutor.h>
 #include <faabric/util/logging.h>
 

--- a/src/mpi/mpi.cpp
+++ b/src/mpi/mpi.cpp
@@ -1,4 +1,4 @@
-#include "faabric/mpi/mpi.h"
+#include <faabric/mpi/mpi.h>
 
 #include <stdexcept>
 #include <stdint.h>

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -25,6 +25,7 @@ add_custom_command(
 # Copy the generated headers into place
 add_custom_command(
     OUTPUT "${PB_HEADER_COPIED}"
+    DEPENDS "${PB_HEADER}"
     COMMAND ${CMAKE_COMMAND} -E copy
     ${PB_HEADER}
     ${FAABRIC_INCLUDE_DIR}/faabric/proto/
@@ -32,6 +33,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT "${GRPC_HEADER_COPIED}"
+    DEPENDS "${GRPC_HEADER}"
     COMMAND ${CMAKE_COMMAND} -E copy
     ${GRPC_HEADER}
     ${FAABRIC_INCLUDE_DIR}/faabric/proto/

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 set(PB_HEADER "${CMAKE_CURRENT_BINARY_DIR}/faabric.pb.h")
 set(GRPC_HEADER "${CMAKE_CURRENT_BINARY_DIR}/faabric.grpc.pb.h")
+
+set(PB_HEADER_COPIED "${FAABRIC_INCLUDE_DIR}/faabric/proto/faabric.pb.h")
+set(GRPC_HEADER_COPIED "${FAABRIC_INCLUDE_DIR}/faabric/proto/faabric.grpc.pb.h")
+
 set(PB_SRC "${CMAKE_CURRENT_BINARY_DIR}/faabric.pb.cc")
 set(GRPC_SRC "${CMAKE_CURRENT_BINARY_DIR}/faabric.grpc.pb.cc")
 
@@ -18,17 +22,35 @@ add_custom_command(
     DEPENDS faabric.proto
 )
 
+# Copy the generated headers into place
+add_custom_command(
+    OUTPUT "${PB_HEADER_COPIED}"
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PB_HEADER}
+    ${FAABRIC_INCLUDE_DIR}/faabric/proto/
+    )
+
+add_custom_command(
+    OUTPUT "${GRPC_HEADER_COPIED}"
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${GRPC_HEADER}
+    ${FAABRIC_INCLUDE_DIR}/faabric/proto/
+    )
+
 # ----------------------------------------------
 # Faabric wrapper library
 # ----------------------------------------------
 
-file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/proto/*.h")
+set(HEADERS
+    ${FAABRIC_INCLUDE_DIR}/faabric/proto/macros.h
+    ${FAABRIC_INCLUDE_DIR}/faabric/proto/RPCServer.h
+    ${PB_HEADER_COPIED}
+    ${GRPC_HEADER_COPIED}
+    )
 
 set(LIB_FILES
     RPCServer.cpp
     ${HEADERS}
-    ${PB_HEADER}
-    ${GRPC_HEADER}
     ${PB_SRC}
     ${GRPC_SRC}
     )
@@ -43,15 +65,3 @@ target_link_libraries(proto
     gRPC::grpc++_reflection
     )
 
-# Copy the generated headers into place
-add_custom_command(TARGET proto POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy 
-    ${PB_HEADER}
-    ${FAABRIC_INCLUDE_DIR}/faabric/proto/
-    )
-
-add_custom_command(TARGET proto POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy 
-    ${GRPC_HEADER}
-    ${FAABRIC_INCLUDE_DIR}/faabric/proto/
-    )

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -22,8 +22,6 @@ add_custom_command(
 # Faabric wrapper library
 # ----------------------------------------------
 
-include_directories(${FAABRIC_INCLUDE_DIR}/faabric/proto/)
-
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/proto/*.h")
 
 set(LIB_FILES

--- a/src/proto/RPCServer.cpp
+++ b/src/proto/RPCServer.cpp
@@ -1,4 +1,4 @@
-#include "RPCServer.h"
+#include <faabric/proto/RPCServer.h>
 
 #include <faabric/util/logging.h>
 #include <grpcpp/grpcpp.h>

--- a/src/redis/CMakeLists.txt
+++ b/src/redis/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${FAABRIC_INCLUDE_DIR}/faabric/redis)
-
 set(LIB_FILES
         Redis.cpp
         ${FAABRIC_INCLUDE_DIR}/faabric/redis/Redis.h

--- a/src/redis/Redis.cpp
+++ b/src/redis/Redis.cpp
@@ -1,4 +1,4 @@
-#include "Redis.h"
+#include <faabric/redis/Redis.h>
 
 #include <faabric/util/logging.h>
 #include <faabric/util/network.h>

--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${FAABRIC_INCLUDE_DIR}/faabric/scheduler)
-
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/scheduler/*.h")
 
 set(LIB_FILES

--- a/src/scheduler/ExecGraph.cpp
+++ b/src/scheduler/ExecGraph.cpp
@@ -1,4 +1,4 @@
-#include "ExecGraph.h"
+#include <faabric/scheduler/ExecGraph.h>
 
 #include <faabric/util/json.h>
 #include <sstream>

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -1,4 +1,4 @@
-#include "FunctionCallClient.h"
+#include <faabric/scheduler/FunctionCallClient.h>
 
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -1,5 +1,5 @@
-#include "FunctionCallServer.h"
-#include "MpiWorldRegistry.h"
+#include <faabric/scheduler/FunctionCallServer.h>
+#include <faabric/scheduler/MpiWorldRegistry.h>
 
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>

--- a/src/scheduler/MpiContext.cpp
+++ b/src/scheduler/MpiContext.cpp
@@ -1,5 +1,5 @@
-#include "MpiContext.h"
-#include "MpiWorldRegistry.h"
+#include <faabric/scheduler/MpiContext.h>
+#include <faabric/scheduler/MpiWorldRegistry.h>
 
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/util/gids.h>

--- a/src/scheduler/MpiWorldRegistry.cpp
+++ b/src/scheduler/MpiWorldRegistry.cpp
@@ -1,4 +1,4 @@
-#include "MpiWorldRegistry.h"
+#include <faabric/scheduler/MpiWorldRegistry.h>
 
 #include <faabric/util/config.h>
 #include <faabric/util/locks.h>

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1,4 +1,4 @@
-#include "Scheduler.h"
+#include <faabric/scheduler/Scheduler.h>
 
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/FunctionCallClient.h>

--- a/src/state/CMakeLists.txt
+++ b/src/state/CMakeLists.txt
@@ -1,7 +1,3 @@
-include_directories(
-        ${FAABRIC_INCLUDE_DIR}/faabric/state
-)
-
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/state/*.h")
 
 set(LIB_FILES

--- a/src/state/DummyStateServer.cpp
+++ b/src/state/DummyStateServer.cpp
@@ -1,4 +1,4 @@
-#include "DummyStateServer.h"
+#include <faabric/state/DummyStateServer.h>
 
 #include <faabric/state/InMemoryStateKeyValue.h>
 #include <faabric/util/logging.h>

--- a/src/state/InMemoryStateKeyValue.cpp
+++ b/src/state/InMemoryStateKeyValue.cpp
@@ -1,4 +1,4 @@
-#include "InMemoryStateKeyValue.h"
+#include <faabric/state/InMemoryStateKeyValue.h>
 
 #include <cstdio>
 

--- a/src/state/InMemoryStateRegistry.cpp
+++ b/src/state/InMemoryStateRegistry.cpp
@@ -1,4 +1,4 @@
-#include "InMemoryStateRegistry.h"
+#include <faabric/state/InMemoryStateRegistry.h>
 
 #include <vector>
 

--- a/src/state/RedisStateKeyValue.cpp
+++ b/src/state/RedisStateKeyValue.cpp
@@ -1,4 +1,4 @@
-#include "RedisStateKeyValue.h"
+#include <faabric/state/RedisStateKeyValue.h>
 
 #include <faabric/util/logging.h>
 #include <faabric/util/macros.h>

--- a/src/state/State.cpp
+++ b/src/state/State.cpp
@@ -1,6 +1,6 @@
-#include "State.h"
-#include "InMemoryStateKeyValue.h"
-#include "RedisStateKeyValue.h"
+#include <faabric/state/State.h>
+#include <faabric/state/InMemoryStateKeyValue.h>
+#include <faabric/state/RedisStateKeyValue.h>
 
 #include <faabric/util/config.h>
 #include <faabric/util/locks.h>

--- a/src/state/State.cpp
+++ b/src/state/State.cpp
@@ -1,6 +1,6 @@
-#include <faabric/state/State.h>
 #include <faabric/state/InMemoryStateKeyValue.h>
 #include <faabric/state/RedisStateKeyValue.h>
+#include <faabric/state/State.h>
 
 #include <faabric/util/config.h>
 #include <faabric/util/locks.h>

--- a/src/state/StateClient.cpp
+++ b/src/state/StateClient.cpp
@@ -1,4 +1,4 @@
-#include "StateClient.h"
+#include <faabric/state/StateClient.h>
 
 #include <faabric/proto/macros.h>
 #include <faabric/util/logging.h>

--- a/src/state/StateKeyValue.cpp
+++ b/src/state/StateKeyValue.cpp
@@ -1,4 +1,4 @@
-#include "StateKeyValue.h"
+#include <faabric/state/StateKeyValue.h>
 
 #include <faabric/util/config.h>
 #include <faabric/util/locks.h>

--- a/src/state/StateServer.cpp
+++ b/src/state/StateServer.cpp
@@ -1,4 +1,4 @@
-#include "StateServer.h"
+#include <faabric/state/StateServer.h>
 
 #include <faabric/proto/macros.h>
 #include <faabric/state/InMemoryStateKeyValue.h>

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${FAABRIC_INCLUDE_DIR}/faabric/util)
-
 find_package(RapidJSON)
 
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/util/*.h")

--- a/src/util/barrier.cpp
+++ b/src/util/barrier.cpp
@@ -1,5 +1,5 @@
-#include "barrier.h"
-#include "locks.h"
+#include <faabric/util/barrier.h>
+#include <faabric/util/locks.h>
 
 namespace faabric::util {
 Barrier::Barrier(int count)

--- a/src/util/bytes.cpp
+++ b/src/util/bytes.cpp
@@ -1,4 +1,4 @@
-#include "bytes.h"
+#include <faabric/util/bytes.h>
 
 #include <vector>
 

--- a/src/util/clock.cpp
+++ b/src/util/clock.cpp
@@ -1,4 +1,4 @@
-#include "clock.h"
+#include <faabric/util/clock.h>
 
 namespace faabric::util {
 Clock& getGlobalClock()

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1,7 +1,7 @@
-#include "config.h"
-#include "environment.h"
-#include "locks.h"
-#include "logging.h"
+#include <faabric/util/config.h>
+#include <faabric/util/environment.h>
+#include <faabric/util/locks.h>
+#include <faabric/util/logging.h>
 
 #include <faabric/util/network.h>
 

--- a/src/util/environment.cpp
+++ b/src/util/environment.cpp
@@ -1,4 +1,4 @@
-#include "environment.h"
+#include <faabric/util/environment.h>
 
 #include <thread>
 

--- a/src/util/files.cpp
+++ b/src/util/files.cpp
@@ -1,5 +1,5 @@
-#include <faabric/util/files.h>
 #include <faabric/util/bytes.h>
+#include <faabric/util/files.h>
 #include <faabric/util/logging.h>
 
 #include <cstdlib>

--- a/src/util/files.cpp
+++ b/src/util/files.cpp
@@ -1,6 +1,6 @@
-#include "files.h"
-#include "bytes.h"
-#include "logging.h"
+#include <faabric/util/files.h>
+#include <faabric/util/bytes.h>
+#include <faabric/util/logging.h>
 
 #include <cstdlib>
 #include <cstring>

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -1,4 +1,4 @@
-#include "func.h"
+#include <faabric/util/func.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>

--- a/src/util/gids.cpp
+++ b/src/util/gids.cpp
@@ -1,4 +1,4 @@
-#include "gids.h"
+#include <faabric/util/gids.h>
 
 #include <atomic>
 #include <mutex>

--- a/src/util/http.cpp
+++ b/src/util/http.cpp
@@ -1,6 +1,6 @@
-#include "http.h"
-#include "bytes.h"
-#include "logging.h"
+#include <faabric/util/http.h>
+#include <faabric/util/bytes.h>
+#include <faabric/util/logging.h>
 
 #include <pistache/async.h>
 #include <pistache/client.h>

--- a/src/util/http.cpp
+++ b/src/util/http.cpp
@@ -1,5 +1,5 @@
-#include <faabric/util/http.h>
 #include <faabric/util/bytes.h>
+#include <faabric/util/http.h>
 #include <faabric/util/logging.h>
 
 #include <pistache/async.h>

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -1,5 +1,5 @@
-#include "json.h"
-#include "timing.h"
+#include <faabric/util/json.h>
+#include <faabric/util/timing.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -1,5 +1,5 @@
-#include "logging.h"
-#include "config.h"
+#include <faabric/util/logging.h>
+#include <faabric/util/config.h>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -1,5 +1,5 @@
-#include <faabric/util/logging.h>
 #include <faabric/util/config.h>
+#include <faabric/util/logging.h>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 

--- a/src/util/memory.cpp
+++ b/src/util/memory.cpp
@@ -1,4 +1,4 @@
-#include "memory.h"
+#include <faabric/util/memory.h>
 
 #include <cstdint>
 

--- a/src/util/network.cpp
+++ b/src/util/network.cpp
@@ -1,4 +1,4 @@
-#include "network.h"
+#include <faabric/util/network.h>
 
 #include <arpa/inet.h>
 #include <ifaddrs.h>

--- a/src/util/queue.cpp
+++ b/src/util/queue.cpp
@@ -1,4 +1,4 @@
-#include "queue.h"
+#include <faabric/util/queue.h>
 
 namespace faabric::util {
 TokenPool::TokenPool(int nTokens)

--- a/src/util/random.cpp
+++ b/src/util/random.cpp
@@ -1,4 +1,4 @@
-#include "faabric/util/random.h"
+#include <faabric/util/random.h>
 
 #include <random>
 

--- a/src/util/state.cpp
+++ b/src/util/state.cpp
@@ -1,5 +1,5 @@
-#include <faabric/util/state.h>
 #include <faabric/util/logging.h>
+#include <faabric/util/state.h>
 
 namespace faabric::util {
 std::string keyForUser(const std::string& user, const std::string& key)

--- a/src/util/state.cpp
+++ b/src/util/state.cpp
@@ -1,5 +1,4 @@
-#include "state.h"
-
+#include <faabric/util/state.h>
 #include <faabric/util/logging.h>
 
 namespace faabric::util {

--- a/src/util/timing.cpp
+++ b/src/util/timing.cpp
@@ -1,5 +1,4 @@
-#include "timing.h"
-
+#include <faabric/util/timing.h>
 #include <faabric/util/logging.h>
 
 namespace faabric::util {

--- a/src/util/timing.cpp
+++ b/src/util/timing.cpp
@@ -1,5 +1,5 @@
-#include <faabric/util/timing.h>
 #include <faabric/util/logging.h>
+#include <faabric/util/timing.h>
 
 namespace faabric::util {
 faabric::util::TimePoint startTimer()

--- a/tasks/examples.py
+++ b/tasks/examples.py
@@ -27,19 +27,22 @@ def build(ctx, clean=False):
         makedirs(BUILD_DIR)
 
     # Cmake
+    cmake_cmd = " ".join(
+        [
+            "cmake",
+            "-GNinja",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_CXX_FLAGS=-I{}".format(INCLUDE_DIR),
+            "-DCMAKE_EXE_LINKER_FLAGS=-L{}".format(LIB_DIR),
+            "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-10",
+            "-DCMAKE_C_COMPILER=/usr/bin/clang-10",
+            EXAMPLES_DIR,
+        ]
+    )
+    print(cmake_cmd)
+
     run(
-        " ".join(
-            [
-                "cmake",
-                "-GNinja",
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_CXX_FLAGS=-I{}".format(INCLUDE_DIR),
-                "-DCMAKE_EXE_LINKER_FLAGS=-L{}".format(LIB_DIR),
-                "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-10",
-                "-DCMAKE_C_COMPILER=/usr/bin/clang-10",
-                EXAMPLES_DIR,
-            ]
-        ),
+        cmake_cmd,
         shell=True,
         cwd=BUILD_DIR,
     )
@@ -49,6 +52,7 @@ def build(ctx, clean=False):
         "cmake --build . --target all_examples",
         cwd=BUILD_DIR,
         shell=True,
+        check=True,
     )
 
 
@@ -69,4 +73,4 @@ def execute(ctx, example):
         }
     )
 
-    run(exe_path, env=shell_env, shell=True)
+    run(exe_path, env=shell_env, shell=True, check=True)


### PR DESCRIPTION
When using Faabric as an external project it can either be added with `add_subdirectory` in which case we need the public `target_include_directories` or as an installed library in which case the transitive header includes should still work.