### PR TITLE
Adding Link Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ add_dependencies(faabric pistache_ext spdlog_ext)
 
 target_link_libraries(faabric
     ${Protobuf_LIBRARIES}
+    faabricmpi
     gRPC::grpc++
     gRPC::grpc++_reflection
     hiredis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ target_link_libraries(faabric
     gRPC::grpc++
     gRPC::grpc++_reflection
     hiredis
+    pistache
     boost_system
     boost_filesystem
     )


### PR DESCRIPTION
With faasm/faasm#377 (in which I bump faabric's version to include #44 ), I was having trouble compiling the `dev.tools` as the linker would error out with errors like:
```
/usr/bin/ld: /build/faasm/_deps/faabric_ext-src/src/scheduler/MpiWorld.cpp:988: undefined reference to `faabric_type_int'
```
I think this error appeared just now, as it is inherent to when we compile `faabric` through CMake's `add_subdirectory`, implicit in `FetchContent_MakeAvailable`. The workaround (thus, solution?) I've found to fix the problem is to link `faabricmpi` to `faabric`. This is similar to what's done with the `examples` so I am pretty sure it makes sense.

The same thing happens with `pistache`. In this case, adding it to `faasm`'s `faaslet_lib` [CMake's](https://github.com/faasm/faasm/blob/2a7421df552b0d14b3d03f2c4353123f35413e52/src/faaslet/CMakeLists.txt#L15) also solved the problem, but I think it makes more sense to change this upstream.