### PR TITLE
Flush as a top-level RPC

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,10 @@ jobs:
         run: git fetch origin ${GITHUB_REF}:ci-branch
       - name: "Check out branch"
         run: git checkout --force ci-branch
+      - name: "Run cmake"
+        run: inv dev.cmake
+      - name: "Rerun build to ensure code is up to date"
+        run: inv dev.cc faabric_tests 
       # --- Formatting checks ---
       - name: "Python formatting check"
         run: ./bin/check_python.sh

--- a/bin/run_clang_tidy.sh
+++ b/bin/run_clang_tidy.sh
@@ -4,26 +4,50 @@ set -e
 
 BUILD_PATH=/build/faabric/static/
 CONFIG=${FAABRIC_ROOT}/.clang-tidy
+DUMP_OUTPUT=true
 
-FILES=$(git ls-files {src,tests}/{"*.h","*.cpp","*.c"})
+# Function to actually run clang-tidy
+function do_tidy {
+    FILES="($@)"
+    run-clang-tidy-10.py \
+        -config '' \
+        -j `nproc` \
+        -fix \
+        -format \
+        -style 'file' \
+        -p ${BUILD_PATH} \
+        -quiet \
+        ${FILES}
+}
 
-if [ -z "$1" ]; then
-    :
-else
+# Support passing a file, directory or nothing
+if [ -f "$1" ]; then
+    echo "Running on file $1"
+    FILES=($1)
+
+    # Assume we want to see output if running on a single file
+    unset DUMP_OUTPUT
+
+elif [ -d "$1" ]; then
     pushd $1 >> /dev/null
+    echo "Running on directory $1"
     FILES=$(git ls-files {"*.h","*.cpp","*.c"})
+
+elif [ -z "$1" ]; then
+    echo "Running on cwd at $(pwd)"
+    FILES=$(git ls-files {func,libs,src,tests}/{"*.h","*.cpp","*.c"})
+
+else
+    echo "First argument must be a file or directory"
+    exit 1
 fi
 
-# Run clang-tidy on a set of files
-run-clang-tidy-10.py \
-    -config '' \
-    -j `nproc` \
-    -fix \
-    -format \
-    -style 'file' \
-    -p ${BUILD_PATH} \
-    -quiet \
-    ${FILES} > /dev/null
+# Dump output or not
+if [ -z "$DUMP_OUTPUT" ]; then
+    do_tidy ${FILES[@]}
+else
+    do_tidy ${FILES[@]} > /dev/null
+fi
 
 popd >> /dev/null || true
 

--- a/include/faabric/executor/FaabricExecutor.h
+++ b/include/faabric/executor/FaabricExecutor.h
@@ -25,7 +25,7 @@ class FaabricExecutor
 
     void finish();
 
-    void flush();
+    virtual void flush();
 
     std::string id;
 
@@ -41,8 +41,6 @@ class FaabricExecutor
                                const std::string& errorMsg);
 
     virtual void postFinish();
-
-    virtual void postFlush();
 
     bool _isBound = false;
 

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -25,6 +25,8 @@ class FunctionCallClient
     std::unique_ptr<faabric::FunctionRPCService::Stub> stub;
 
     void shareFunctionCall(const faabric::Message& call);
+    
+    void sendFunctionFlush(const faabric::Message& call);
 
     void sendMPIMessage(const faabric::MPIMessage& msg);
 };

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -25,7 +25,7 @@ class FunctionCallClient
     std::unique_ptr<faabric::FunctionRPCService::Stub> stub;
 
     void shareFunctionCall(const faabric::Message& call);
-    
+
     void sendFunctionFlush(const faabric::Message& call);
 
     void sendMPIMessage(const faabric::MPIMessage& msg);

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -26,7 +26,7 @@ class FunctionCallClient
 
     void shareFunctionCall(const faabric::Message& call);
 
-    void sendFunctionFlush(const faabric::Message& call);
+    void sendFlush();
 
     void sendMPIMessage(const faabric::MPIMessage& msg);
 };

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -20,6 +20,10 @@ class FunctionCallServer final
                          const faabric::Message* request,
                          faabric::FunctionStatusResponse* response) override;
 
+    Status FlushFunction(ServerContext* context,
+                         const faabric::Message* request,
+                         faabric::FunctionStatusResponse* response) override;
+
     Status MPICall(ServerContext* context,
                    const faabric::MPIMessage* request,
                    faabric::FunctionStatusResponse* response) override;

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -20,9 +20,9 @@ class FunctionCallServer final
                          const faabric::Message* request,
                          faabric::FunctionStatusResponse* response) override;
 
-    Status FlushFunction(ServerContext* context,
-                         const faabric::Message* request,
-                         faabric::FunctionStatusResponse* response) override;
+    Status Flush(ServerContext* context,
+                 const faabric::Message* request,
+                 faabric::FunctionStatusResponse* response) override;
 
     Status MPICall(ServerContext* context,
                    const faabric::MPIMessage* request,

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -46,8 +46,8 @@ class Scheduler
 
     std::string getFunctionWarmSetNameFromStr(const std::string& funcStr);
 
-    void clear();
-
+    void shutdown();
+    
     long getFunctionWarmNodeCount(const faabric::Message& msg);
 
     long getTotalWarmNodeCount();
@@ -79,9 +79,9 @@ class Scheduler
 
     std::string getThisHost();
 
-    void broadcastFlush(const faabric::Message& msg);
+    void broadcastFlush();
 
-    void flushLocalNodes(const faabric::Message& msg);
+    void flushLocally();
 
     void preflightPythonCall();
 

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -46,8 +46,10 @@ class Scheduler
 
     std::string getFunctionWarmSetNameFromStr(const std::string& funcStr);
 
+    void reset();
+
     void shutdown();
-    
+
     long getFunctionWarmNodeCount(const faabric::Message& msg);
 
     long getTotalWarmNodeCount();

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -80,6 +80,8 @@ class Scheduler
     std::string getThisHost();
 
     void broadcastFlush(const faabric::Message& msg);
+    
+    void flushLocalNodes(const faabric::Message& msg);
 
     void preflightPythonCall();
 

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -80,7 +80,7 @@ class Scheduler
     std::string getThisHost();
 
     void broadcastFlush(const faabric::Message& msg);
-    
+
     void flushLocalNodes(const faabric::Message& msg);
 
     void preflightPythonCall();

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -85,8 +85,6 @@ class Scheduler
 
     void flushLocally();
 
-    void preflightPythonCall();
-
     std::string getMessageStatus(unsigned int messageId);
 
     void setFunctionResult(faabric::Message& msg);

--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -14,6 +14,14 @@ class QueueTimeoutException : public faabric::util::FaabricException
     {}
 };
 
+class ExecutorFinishedException : public faabric::util::FaabricException
+{
+  public:
+    explicit ExecutorFinishedException(std::string message)
+      : FaabricException(std::move(message))
+    {}
+};
+
 template<typename T>
 class Queue
 {

--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -58,7 +58,7 @@ class Queue
 
     T dequeue(long timeoutMs = 0) { return doDequeue(timeoutMs, true); }
 
-    void waitToEmpty(long timeoutMs)
+    void waitToDrain(long timeoutMs)
     {
         UniqueLock lock(enqueueMutex);
 
@@ -74,6 +74,15 @@ class Queue
             } else {
                 emptyNotifier.wait(lock);
             }
+        }
+    }
+
+    void drain()
+    {
+        UniqueLock lock(enqueueMutex);
+
+        while (!mq.empty()) {
+            mq.pop();
         }
     }
 

--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -57,6 +57,10 @@ class Queue
 
     T dequeue(long timeoutMs = 0) { return doDequeue(timeoutMs, true); }
 
+    void waitToEmpty() {
+
+    }
+
     long size()
     {
         UniqueLock lock(mx);

--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -20,7 +20,7 @@ class Queue
   public:
     void enqueue(T value)
     {
-        UniqueLock lock(enqueueMutex);
+        UniqueLock lock(mx);
 
         mq.push(value);
 
@@ -29,7 +29,7 @@ class Queue
 
     T doDequeue(long timeoutMs, bool pop)
     {
-        UniqueLock lock(enqueueMutex);
+        UniqueLock lock(mx);
 
         while (mq.empty()) {
             if (timeoutMs > 0) {
@@ -60,7 +60,7 @@ class Queue
 
     void waitToDrain(long timeoutMs)
     {
-        UniqueLock lock(enqueueMutex);
+        UniqueLock lock(mx);
 
         while (!mq.empty()) {
             if (timeoutMs > 0) {
@@ -79,7 +79,7 @@ class Queue
 
     void drain()
     {
-        UniqueLock lock(enqueueMutex);
+        UniqueLock lock(mx);
 
         while (!mq.empty()) {
             mq.pop();
@@ -88,13 +88,13 @@ class Queue
 
     long size()
     {
-        UniqueLock lock(enqueueMutex);
+        UniqueLock lock(mx);
         return mq.size();
     }
 
     void reset()
     {
-        UniqueLock lock(enqueueMutex);
+        UniqueLock lock(mx);
 
         std::queue<T> empty;
         std::swap(mq, empty);
@@ -104,7 +104,7 @@ class Queue
     std::queue<T> mq;
     std::condition_variable enqueueNotifier;
     std::condition_variable emptyNotifier;
-    std::mutex enqueueMutex;
+    std::mutex mx;
 };
 
 class TokenPool

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -64,12 +64,12 @@ std::string FaabricEndpointHandler::handleFunction(
               sched.getFunctionExecGraph(msg.id());
             responseStr = faabric::scheduler::execGraphToJson(execGraph);
 
-        } else if (msg.isflushrequest()) {
+        } else if (msg.type() == faabric::Message_MessageType_FLUSH) {
             const std::shared_ptr<spdlog::logger>& logger =
               faabric::util::getLogger();
             logger->debug("Broadcasting flush request");
 
-            sched.broadcastFlush(msg);
+            sched.broadcastFlush();
         } else {
             responseStr = executeFunction(msg);
         }

--- a/src/executor/FaabricExecutor.cpp
+++ b/src/executor/FaabricExecutor.cpp
@@ -20,24 +20,6 @@ FaabricExecutor::FaabricExecutor(int threadIdxIn)
     currentQueue = scheduler.getBindQueue();
 }
 
-void FaabricExecutor::flush()
-{
-    const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
-    logger->warn("Flushing host {}",
-                 faabric::util::getSystemConfig().endpointHost);
-
-    // Clear out any cached state
-    faabric::state::getGlobalState().forceClearAll(false);
-
-    // Reset scheduler
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.clear();
-    sch.addHostToGlobalSet();
-
-    // Hook
-    this->postFlush();
-}
-
 void FaabricExecutor::bindToFunction(const faabric::Message& msg, bool force)
 {
     // If already bound, will be an error, unless forced to rebind to the same
@@ -217,6 +199,6 @@ void FaabricExecutor::preFinishCall(faabric::Message& call,
 
 void FaabricExecutor::postFinish() {}
 
-void FaabricExecutor::postFlush() {}
+void FaabricExecutor::flush() {}
 
 }

--- a/src/executor/FaabricExecutor.cpp
+++ b/src/executor/FaabricExecutor.cpp
@@ -132,7 +132,7 @@ std::string FaabricExecutor::processNextMessage()
     faabric::Message msg = currentQueue->dequeue(timeoutMs);
 
     std::string errorMessage;
-    if (msg.isflushrequest()) {
+    if (msg.type() == faabric::Message_MessageType_FLUSH) {
         flush();
 
     } else if (msg.type() == faabric::Message_MessageType_BIND) {

--- a/src/executor/FaabricExecutor.cpp
+++ b/src/executor/FaabricExecutor.cpp
@@ -1,3 +1,4 @@
+#include "faabric/util/queue.h"
 #include <faabric/executor/FaabricExecutor.h>
 
 #include <faabric/state/State.h>
@@ -106,6 +107,10 @@ void FaabricExecutor::run()
             if (!errorMessage.empty()) {
                 break;
             }
+        } catch (faabric::util::ExecutorFinishedException& e) {
+            // Executor has notified us it's finished
+            logger->debug("{} finished", this->id);
+            break;
         } catch (faabric::util::QueueTimeoutException& e) {
             // At this point we've received no message, so die off
             logger->debug("{} got no messages. Finishing", this->id);

--- a/src/executor/FaabricMain.cpp
+++ b/src/executor/FaabricMain.cpp
@@ -30,7 +30,7 @@ void FaabricMain::shutdown()
     const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
     logger->info("Removing from global working set");
 
-    scheduler.clear();
+    scheduler.shutdown();
 
     pool.shutdown();
 }

--- a/src/executor/FaabricPool.cpp
+++ b/src/executor/FaabricPool.cpp
@@ -82,9 +82,6 @@ void FaabricPool::startThreadPool()
 
         // Will die gracefully at this point
     });
-
-    // Prepare the python runtime (no-op if not necessary)
-    scheduler.preflightPythonCall();
 }
 
 void FaabricPool::reset()

--- a/src/proto/RPCServer.cpp
+++ b/src/proto/RPCServer.cpp
@@ -20,14 +20,14 @@ void RPCServer::start(bool background)
     _isBackground = background;
 
     if (background) {
-        logger->debug("Starting state server in background thread");
+        logger->debug("Starting RPC server in background thread");
         // Run the serving thread in the background. This is necessary to
         // be able to kill it from the main thread.
         servingThread =
           std::thread([this, serverAddr] { doStart(serverAddr); });
 
     } else {
-        logger->debug("Starting state server in this thread");
+        logger->debug("Starting RPC server in this thread");
         doStart(serverAddr);
     }
 }
@@ -36,15 +36,15 @@ void RPCServer::stop()
 {
     const std::shared_ptr<spdlog::logger>& logger = getLogger();
     if (!_started) {
-        logger->info("Not stopping state server, never started");
+        logger->info("Not stopping RPC server, never started");
         return;
     }
 
-    logger->info("State server stopping");
+    logger->info("RPC server stopping");
     server->Shutdown();
 
     if (_isBackground) {
-        logger->debug("Waiting for state server background thread");
+        logger->debug("Waiting for server background thread");
         if (servingThread.joinable()) {
             servingThread.join();
         }

--- a/src/proto/RPCServer.cpp
+++ b/src/proto/RPCServer.cpp
@@ -44,7 +44,7 @@ void RPCServer::stop()
     server->Shutdown();
 
     if (_isBackground) {
-        logger->debug("Waiting for server background thread");
+        logger->debug("Waiting for RPC server background thread");
         if (servingThread.joinable()) {
             servingThread.join();
         }

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -10,6 +10,9 @@ service FunctionRPCService {
     rpc ShareFunction (Message) returns (FunctionStatusResponse) {
     }
 
+    rpc FlushFunction (Message) returns (FunctionStatusResponse) {
+    }
+
     rpc MPICall (MPIMessage) returns (FunctionStatusResponse) {
     }
 }

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -10,7 +10,7 @@ service FunctionRPCService {
     rpc ShareFunction (Message) returns (FunctionStatusResponse) {
     }
 
-    rpc FlushFunction (Message) returns (FunctionStatusResponse) {
+    rpc Flush (Message) returns (FunctionStatusResponse) {
     }
 
     rpc MPICall (MPIMessage) returns (FunctionStatusResponse) {
@@ -65,6 +65,7 @@ message Message {
         BIND = 1;
         KILL = 2;
         EMPTY = 3;
+        FLUSH = 4;
     }
 
     MessageType type = 8;
@@ -84,7 +85,6 @@ message Message {
     bool isTypescript = 19;
     bool isStatusRequest = 20;
     bool isExecGraphRequest = 21;
-    bool isFlushRequest = 22;
 
     bytes inputData = 23;
     bytes outputData = 24;

--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -13,4 +13,4 @@ set(LIB_FILES
 
 faabric_lib(scheduler "${LIB_FILES}")
 
-target_link_libraries(scheduler faabricmpi redis)
+target_link_libraries(scheduler state faabricmpi redis)

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -23,7 +23,7 @@ void FunctionCallClient::shareFunctionCall(const faabric::Message& call)
 void FunctionCallClient::sendFlush()
 {
     ClientContext context;
-        
+
     faabric::Message call;
     faabric::FunctionStatusResponse response;
     CHECK_RPC("function_flush", stub->Flush(&context, call, &response));

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -20,6 +20,13 @@ void FunctionCallClient::shareFunctionCall(const faabric::Message& call)
     CHECK_RPC("function_share", stub->ShareFunction(&context, call, &response));
 }
 
+void FunctionCallClient::sendFunctionFlush(const faabric::Message& call)
+{
+    ClientContext context;
+    faabric::FunctionStatusResponse response;
+    CHECK_RPC("function_flush", stub->FlushFunction(&context, call, &response));
+}
+
 void FunctionCallClient::sendMPIMessage(const faabric::MPIMessage& msg)
 {
     ClientContext context;

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -20,11 +20,13 @@ void FunctionCallClient::shareFunctionCall(const faabric::Message& call)
     CHECK_RPC("function_share", stub->ShareFunction(&context, call, &response));
 }
 
-void FunctionCallClient::sendFunctionFlush(const faabric::Message& call)
+void FunctionCallClient::sendFlush()
 {
     ClientContext context;
+        
+    faabric::Message call;
     faabric::FunctionStatusResponse response;
-    CHECK_RPC("function_flush", stub->FlushFunction(&context, call, &response));
+    CHECK_RPC("function_flush", stub->Flush(&context, call, &response));
 }
 
 void FunctionCallClient::sendMPIMessage(const faabric::MPIMessage& msg)

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -52,15 +52,14 @@ Status FunctionCallServer::ShareFunction(
     return Status::OK;
 }
 
-Status FunctionCallServer::FlushFunction(
+Status FunctionCallServer::Flush(
   ServerContext* context,
   const faabric::Message* request,
   faabric::FunctionStatusResponse* response)
 {
     auto logger = faabric::util::getLogger();
 
-    // Flush locally
-    scheduler.flushLocalNodes(*request);
+    scheduler.flushLocally();
 
     return Status::OK;
 }

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -1,6 +1,6 @@
 #include <faabric/scheduler/FunctionCallServer.h>
 #include <faabric/scheduler/MpiWorldRegistry.h>
-
+#include <faabric/state/State.h>
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 
@@ -52,14 +52,20 @@ Status FunctionCallServer::ShareFunction(
     return Status::OK;
 }
 
-Status FunctionCallServer::Flush(
-  ServerContext* context,
-  const faabric::Message* request,
-  faabric::FunctionStatusResponse* response)
+Status FunctionCallServer::Flush(ServerContext* context,
+                                 const faabric::Message* request,
+                                 faabric::FunctionStatusResponse* response)
 {
     auto logger = faabric::util::getLogger();
 
+    // Clear out any cached state
+    faabric::state::getGlobalState().forceClearAll(false);
+
+    // Clear the scheduler
     scheduler.flushLocally();
+
+    // Reset the scheduler
+    scheduler.reset();
 
     return Status::OK;
 }

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -59,7 +59,8 @@ Status FunctionCallServer::FlushFunction(
 {
     auto logger = faabric::util::getLogger();
 
-
+    // Flush locally
+    scheduler.flushLocalNodes(*request);
 
     return Status::OK;
 }

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -52,6 +52,18 @@ Status FunctionCallServer::ShareFunction(
     return Status::OK;
 }
 
+Status FunctionCallServer::FlushFunction(
+  ServerContext* context,
+  const faabric::Message* request,
+  faabric::FunctionStatusResponse* response)
+{
+    auto logger = faabric::util::getLogger();
+
+
+
+    return Status::OK;
+}
+
 Status FunctionCallServer::MPICall(ServerContext* context,
                                    const faabric::MPIMessage* request,
                                    faabric::FunctionStatusResponse* response)

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -603,29 +603,6 @@ void Scheduler::flushLocally()
     }
 }
 
-void Scheduler::preflightPythonCall()
-{
-    const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
-
-    if (conf.pythonPreload != "on") {
-        logger->info("Not preloading python runtime");
-        return;
-    }
-
-    logger->info("Preparing python runtime");
-
-    faabric::Message msg =
-      faabric::util::messageFactory(PYTHON_USER, PYTHON_FUNC);
-    msg.set_ispython(true);
-    msg.set_pythonuser("python");
-    msg.set_pythonfunction("noop");
-    faabric::util::setMessageId(msg);
-
-    callFunction(msg, true);
-
-    logger->info("Python runtime prepared");
-}
-
 void Scheduler::setFunctionResult(faabric::Message& msg)
 {
     redis::Redis& redis = redis::Redis::getQueue();

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -67,6 +67,12 @@ void Scheduler::shutdown()
     // Clear out locally first
     flushLocally();
 
+    // Records
+    setTestMode(false);
+    recordedMessagesAll.clear();
+    recordedMessagesLocal.clear();
+    recordedMessagesShared.clear();
+
     // Remove this host
     this->removeHostFromGlobalSet();
 }
@@ -558,7 +564,7 @@ void Scheduler::flushLocally()
 
     // Remove this host from all the global warm sets
     for (const auto& iter : queueMap) {
-        this->removeHostFromWarmSet(iter.first);
+        removeHostFromWarmSet(iter.first);
     }
 
     // Ensure host is set correctly
@@ -594,12 +600,6 @@ void Scheduler::flushLocally()
     inFlightCountMap.clear();
     opinionMap.clear();
     _hasHostCapacity = true;
-
-    // Records
-    setTestMode(false);
-    recordedMessagesAll.clear();
-    recordedMessagesLocal.clear();
-    recordedMessagesShared.clear();
 }
 
 void Scheduler::preflightPythonCall()

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -576,8 +576,9 @@ void Scheduler::flushLocally()
             continue;
         }
 
-        // Get the queue
+        // Clear any existing messages in the queue
         std::shared_ptr<InMemoryMessageQueue> queue = queueMap[p.first];
+        queue->drain();
 
         // Dispatch a flush message for each warm node
         for (int i = 0; i < p.second; i++) {
@@ -589,7 +590,7 @@ void Scheduler::flushLocally()
 
     // Wait for flush messages to be consumed, then clear the queues
     for (const auto& p : queueMap) {
-        p.second->waitToEmpty(FLUSH_TIMEOUT_MS);
+        p.second->waitToDrain(FLUSH_TIMEOUT_MS);
         p.second->reset();
     }
     queueMap.clear();

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -598,6 +598,7 @@ void Scheduler::flushLocally()
 
     // Wait for flush messages to be consumed, then clear the queues
     for (const auto& p : queueMap) {
+        logger->debug("Waiting for {} to drain on flush", p.first);
         p.second->waitToDrain(FLUSH_TIMEOUT_MS);
         p.second->reset();
     }

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -66,6 +66,7 @@ void Scheduler::reset()
     // Remove this host from all the global warm sets
     for (const auto& iter : queueMap) {
         removeHostFromWarmSet(iter.first);
+        iter.second->reset();
     }
     queueMap.clear();
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -9,6 +9,7 @@
 #include <faabric/util/timing.h>
 
 #define CHAINED_SET_PREFIX "chained_"
+#define FLUSH_TIMEOUT_MS 10000
 
 using namespace faabric::util;
 
@@ -582,7 +583,7 @@ void Scheduler::flushLocally()
 
     // Wait for flush messages to be consumed, then clear the queues
     for (const auto& p : queueMap) {
-        p.second->waitToEmpty();
+        p.second->waitToEmpty(FLUSH_TIMEOUT_MS);
         p.second->reset();
     }
     queueMap.clear();

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -222,6 +222,9 @@ std::string getStringFromJson(Document& doc,
 faabric::Message jsonToMessage(const std::string& jsonIn)
 {
     PROF_START(jsonDecode)
+    auto logger = faabric::util::getLogger();
+
+    logger->info(jsonIn.c_str());
 
     MemoryStream ms(jsonIn.c_str(), jsonIn.size());
     Document d;
@@ -232,7 +235,6 @@ faabric::Message jsonToMessage(const std::string& jsonIn)
     // Set the message type
     int msgType = getIntFromJson(d, "type", 0);
     if (!faabric::Message::MessageType_IsValid(msgType)) {
-        auto logger = faabric::util::getLogger();
         logger->error("Bad message type: {}", msgType);
         throw std::runtime_error("Invalid message type");
     }
@@ -265,8 +267,6 @@ faabric::Message jsonToMessage(const std::string& jsonIn)
 
     msg.set_resultkey(getStringFromJson(d, "result_key", ""));
     msg.set_statuskey(getStringFromJson(d, "status_key", ""));
-
-    msg.set_type(faabric::Message_MessageType_CALL);
 
     msg.set_ismpi(getBoolFromJson(d, "mpi", false));
     msg.set_mpiworldid(getIntFromJson(d, "mpi_world_id", 0));

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -1,5 +1,5 @@
-#include "faabric/util/logging.h"
 #include <faabric/util/json.h>
+#include <faabric/util/logging.h>
 #include <faabric/util/timing.h>
 
 #include <rapidjson/document.h>
@@ -223,8 +223,6 @@ faabric::Message jsonToMessage(const std::string& jsonIn)
 {
     PROF_START(jsonDecode)
     auto logger = faabric::util::getLogger();
-
-    logger->info(jsonIn.c_str());
 
     MemoryStream ms(jsonIn.c_str(), jsonIn.size());
     Document d;

--- a/tests/test/proto/test_proto.cpp
+++ b/tests/test/proto/test_proto.cpp
@@ -51,7 +51,6 @@ TEST_CASE("Test protobuf classes", "[proto]")
     funcCall.set_ispython(true);
     funcCall.set_istypescript(true);
     funcCall.set_isstatusrequest(true);
-    funcCall.set_isflushrequest(true);
 
     funcCall.set_type(faabric::Message_MessageType_BIND);
 
@@ -82,7 +81,6 @@ TEST_CASE("Test protobuf classes", "[proto]")
     REQUIRE(newFuncCall.ispython());
     REQUIRE(newFuncCall.istypescript());
     REQUIRE(newFuncCall.isstatusrequest());
-    REQUIRE(newFuncCall.isflushrequest());
 
     REQUIRE(cmdline == newFuncCall.cmdline());
 

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -120,6 +120,13 @@ TEST_CASE("Test sending flush message", "[scheduler]")
     server.start();
     usleep(1000 * 100);
 
+    // Set up some state
+    faabric::state::State& state = faabric::state::getGlobalState();
+    state.getKV("demo", "blah", 10);
+    state.getKV("other", "foo", 30);
+
+    REQUIRE(state.getKVCount() == 2);
+
     // Execute a couple of functions
     faabric::Message msgA = faabric::util::messageFactory("demo", "foo");
     faabric::Message msgB = faabric::util::messageFactory("demo", "bar");
@@ -180,5 +187,8 @@ TEST_CASE("Test sending flush message", "[scheduler]")
 
     REQUIRE(!redis.sismember(warmSetNameA, thisHost));
     REQUIRE(!redis.sismember(warmSetNameB, thisHost));
+
+    // Check state has been cleared
+    REQUIRE(state.getKVCount() == 0);
 }
 }

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -1,15 +1,15 @@
 #include <catch.hpp>
 
-#include "faabric/redis/Redis.h"
-#include "faabric/scheduler/Scheduler.h"
-#include "faabric/util/func.h"
 #include "faabric_utils.h"
 
+#include <faabric/redis/Redis.h>
 #include <faabric/scheduler/FunctionCallClient.h>
 #include <faabric/scheduler/FunctionCallServer.h>
 #include <faabric/scheduler/MpiWorld.h>
 #include <faabric/scheduler/MpiWorldRegistry.h>
+#include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/config.h>
+#include <faabric/util/func.h>
 #include <faabric/util/network.h>
 
 using namespace scheduler;

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -35,8 +35,8 @@ TEST_CASE("Test scheduler clear-up", "[scheduler]")
     REQUIRE(redis.sismember(AVAILABLE_HOST_SET, thisHost));
     REQUIRE(redis.sismember(funcSet, thisHost));
 
-    // Run clear-up
-    s.clear();
+    // Run shutdown
+    s.shutdown();
 
     // After clear-up has run this host should no longer be part of either set
     REQUIRE(!redis.sismember(AVAILABLE_HOST_SET, thisHost));

--- a/tests/test/util/test_json.cpp
+++ b/tests/test/util/test_json.cpp
@@ -10,6 +10,7 @@ namespace tests {
 TEST_CASE("Test message to JSON round trip", "[util]")
 {
     faabric::Message msg;
+    msg.set_type(faabric::Message_MessageType_FLUSH);
     msg.set_user("user 1");
     msg.set_function("great function");
     msg.set_hops(34);

--- a/tests/test/util/test_json.cpp
+++ b/tests/test/util/test_json.cpp
@@ -25,7 +25,6 @@ TEST_CASE("Test message to JSON round trip", "[util]")
     msg.set_istypescript(true);
     msg.set_isstatusrequest(true);
     msg.set_isexecgraphrequest(true);
-    msg.set_isflushrequest(true);
 
     msg.set_ismpi(true);
     msg.set_mpiworldid(1234);

--- a/tests/test/util/test_queue.cpp
+++ b/tests/test/util/test_queue.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Test wait for empty queue", "[util]")
 {
     // Just need to check this doesn't fail
     IntQueue q;
-    q.waitToEmpty(100);
+    q.waitToDrain(100);
 }
 
 TEST_CASE("Test wait for queue with elements", "[util]")
@@ -59,7 +59,7 @@ TEST_CASE("Test wait for queue with elements", "[util]")
         }
     });
 
-    q.waitToEmpty(2000);
+    q.waitToDrain(2000);
 
     if (t.joinable()) {
         t.join();

--- a/tests/test/util/test_queue.cpp
+++ b/tests/test/util/test_queue.cpp
@@ -30,14 +30,29 @@ TEST_CASE("Test queue operations", "[util]")
     REQUIRE_THROWS(q.dequeue(1));
 }
 
-TEST_CASE("Test wait for empty queue", "[util]")
+TEST_CASE("Test drain queue", "[util]")
+{
+    IntQueue q;
+
+    q.enqueue(1);
+    q.enqueue(2);
+    q.enqueue(3);
+
+    REQUIRE(q.size() == 3);
+
+    q.drain();
+
+    REQUIRE(q.size() == 0);
+}
+
+TEST_CASE("Test wait for draining empty queue", "[util]")
 {
     // Just need to check this doesn't fail
     IntQueue q;
     q.waitToDrain(100);
 }
 
-TEST_CASE("Test wait for queue with elements", "[util]")
+TEST_CASE("Test wait for draining queue with elements", "[util]")
 {
     IntQueue q;
     int nElems = 5;

--- a/tests/test/util/test_queue.cpp
+++ b/tests/test/util/test_queue.cpp
@@ -1,6 +1,7 @@
 #include <catch.hpp>
 #include <faabric/util/bytes.h>
 #include <faabric/util/queue.h>
+#include <thread>
 
 using namespace faabric::util;
 
@@ -27,5 +28,43 @@ TEST_CASE("Test queue operations", "[util]")
     REQUIRE(q.dequeue() == 5);
 
     REQUIRE_THROWS(q.dequeue(1));
+}
+
+TEST_CASE("Test wait for empty queue", "[util]")
+{
+    // Just need to check this doesn't fail
+    IntQueue q;
+    q.waitToEmpty(100);
+}
+
+TEST_CASE("Test wait for queue with elements", "[util]")
+{
+    IntQueue q;
+    int nElems = 5;
+    std::vector<int> dequeued;
+    std::vector<int> expected;
+
+    for (int i = 0; i < nElems; i++) {
+        q.enqueue(i);
+        expected.emplace_back(i);
+    }
+
+    // Background thread to consume elements
+    std::thread t([&q, &dequeued, nElems] {
+        for (int i = 0; i < nElems; i++) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            int j = q.dequeue();
+            dequeued.emplace_back(j);
+        }
+    });
+
+    q.waitToEmpty(2000);
+
+    if (t.joinable()) {
+        t.join();
+    }
+
+    REQUIRE(dequeued == expected);
 }
 }

--- a/tests/utils/message_utils.cpp
+++ b/tests/utils/message_utils.cpp
@@ -7,6 +7,7 @@ void checkMessageEquality(const faabric::Message& msgA,
                           const faabric::Message& msgB)
 {
     REQUIRE(msgA.id() == msgB.id());
+    REQUIRE(msgA.type() == msgB.type());
 
     REQUIRE(msgA.user() == msgB.user());
     REQUIRE(msgA.function() == msgB.function());
@@ -35,7 +36,6 @@ void checkMessageEquality(const faabric::Message& msgA,
 
     REQUIRE(msgA.resultkey() == msgB.resultkey());
     REQUIRE(msgA.statuskey() == msgB.statuskey());
-    REQUIRE(msgA.type() == msgB.type());
 
     REQUIRE(msgA.ismpi() == msgB.ismpi());
     REQUIRE(msgA.mpiworldid() == msgB.mpiworldid());

--- a/tests/utils/message_utils.cpp
+++ b/tests/utils/message_utils.cpp
@@ -27,7 +27,6 @@ void checkMessageEquality(const faabric::Message& msgA,
     REQUIRE(msgA.istypescript() == msgB.istypescript());
     REQUIRE(msgA.isstatusrequest() == msgB.isstatusrequest());
     REQUIRE(msgA.isexecgraphrequest() == msgB.isexecgraphrequest());
-    REQUIRE(msgA.isflushrequest() == msgB.isflushrequest());
 
     REQUIRE(msgA.returnvalue() == msgB.returnvalue());
 

--- a/tests/utils/system_utils.cpp
+++ b/tests/utils/system_utils.cpp
@@ -26,7 +26,7 @@ void cleanFaabric()
 
     // Reset scheduler
     scheduler::Scheduler& sch = scheduler::getScheduler();
-    sch.clear();
+    sch.shutdown();
     sch.addHostToGlobalSet();
 
     // Reset system config


### PR DESCRIPTION
Flush was previously a bit of a hack, implemented as a flag on an existing message. Instead, it should really be a top-level RPC operation so that each host can handle its own flushing operation (rather than letting an individual executor handle it on each host).