### PR TITLE
Logging enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build/
-logs
 
 # Clang
 .clangd

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+logs
 
 # Clang
 .clangd

--- a/docs/mpi_native.md
+++ b/docs/mpi_native.md
@@ -5,8 +5,8 @@ used in [Faasm](https://github.com/faasm/faasm). This way, you can test the
 compliance of your MPI application with our API (a subset of the standard)
 without the burden of cross-compiling to WebAssembly.
 
-To run native MPI applications you need to first modify your binary matching
-the examples provided, and then build the worker image running:
+To run native MPI applications you need to first modify your binary
+matching the examples provided, and then build the worker image running:
 ```
 inv container.build-mpi-native
 ```

--- a/examples/check.cpp
+++ b/examples/check.cpp
@@ -3,7 +3,6 @@
 
 int main()
 {
-    faabric::util::initLogging();
     auto logger = faabric::util::getLogger();
 
     // Build a message just to check things work

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -17,7 +17,6 @@ FAABRIC_EXECUTOR()
 
 int main()
 {
-    faabric::util::initLogging();
     const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
 
     // Start the worker pool

--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -56,6 +56,8 @@ class SystemConfig
 
     // MPI
     int defaultMpiWorldSize;
+    std::string mpiLogLevel;
+    std::string mpiLogFile;
 
     // Endpoint
     std::string endpointInterface;

--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -21,6 +21,7 @@ class SystemConfig
     std::string cgroupMode;
     std::string netNsMode;
     std::string logLevel;
+    std::string logFile;
     std::string pythonPreload;
     std::string captureStdout;
     std::string stateMode;
@@ -56,8 +57,6 @@ class SystemConfig
 
     // MPI
     int defaultMpiWorldSize;
-    std::string mpiLogLevel;
-    std::string mpiLogFile;
 
     // Endpoint
     std::string endpointInterface;

--- a/include/faabric/util/logging.h
+++ b/include/faabric/util/logging.h
@@ -3,7 +3,9 @@
 #include <spdlog/spdlog.h>
 
 namespace faabric::util {
+void initMpiLogging();
+
 void initLogging();
 
-std::shared_ptr<spdlog::logger> getLogger();
+std::shared_ptr<spdlog::logger> getLogger(const std::string& name = "default");
 }

--- a/include/faabric/util/logging.h
+++ b/include/faabric/util/logging.h
@@ -3,9 +3,5 @@
 #include <spdlog/spdlog.h>
 
 namespace faabric::util {
-void initMpiLogging();
-
-void initLogging();
-
 std::shared_ptr<spdlog::logger> getLogger(const std::string& name = "default");
 }

--- a/src/mpi_native/mpi_native.cpp
+++ b/src/mpi_native/mpi_native.cpp
@@ -25,7 +25,7 @@ faabric::scheduler::MpiWorld& getExecutingWorld()
 
 static void notImplemented(const std::string& funcName)
 {
-    auto logger = faabric::util::getLogger();
+    auto logger = faabric::util::getLogger("mpi");
     logger->debug("{}", funcName);
 
     throw std::runtime_error(funcName + " not implemented.");
@@ -45,7 +45,11 @@ int MPI_Init(int* argc, char*** argv)
         executingContext.joinWorld(*call);
     }
 
+    // Initialise MPI-specific logging
     int thisRank = executingContext.getRank();
+    faabric::util::initMpiLogging(thisRank);
+    faabric::util::getLogger("mpi")->debug("MPI_Init");
+
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
     world.barrier(thisRank);
 
@@ -54,7 +58,7 @@ int MPI_Init(int* argc, char*** argv)
 
 int MPI_Comm_rank(MPI_Comm comm, int* rank)
 {
-    faabric::util::getLogger()->debug("MPI_Comm_rank");
+    faabric::util::getLogger("mpi")->debug("MPI_Comm_rank");
 
     *rank = executingContext.getRank();
 
@@ -63,7 +67,7 @@ int MPI_Comm_rank(MPI_Comm comm, int* rank)
 
 int MPI_Comm_size(MPI_Comm comm, int* size)
 {
-    faabric::util::getLogger()->debug("MPI_Comm_size");
+    faabric::util::getLogger("mpi")->debug("MPI_Comm_size");
     *size = getExecutingWorld().getSize();
 
     return MPI_SUCCESS;
@@ -71,7 +75,7 @@ int MPI_Comm_size(MPI_Comm comm, int* size)
 
 int MPI_Finalize()
 {
-    faabric::util::getLogger()->debug("MPI_Finalize");
+    faabric::util::getLogger("mpi")->debug("MPI_Finalize");
 
     return MPI_SUCCESS;
 }
@@ -90,7 +94,7 @@ int MPI_Send(const void* buf,
              int tag,
              MPI_Comm comm)
 {
-    faabric::util::getLogger()->debug(
+    faabric::util::getLogger("mpi")->debug(
       fmt::format("MPI_Send {} -> {}", executingContext.getRank(), dest));
     getExecutingWorld().send(executingContext.getRank(),
                              dest,
@@ -122,7 +126,7 @@ int MPI_Recv(void* buf,
              MPI_Comm comm,
              MPI_Status* status)
 {
-    faabric::util::getLogger()->debug(
+    faabric::util::getLogger("mpi")->debug(
       fmt::format("MPI_Recv {} <- {}", executingContext.getRank(), source));
     getExecutingWorld().recv(source,
                              executingContext.getRank(),
@@ -148,7 +152,7 @@ int MPI_Sendrecv(const void* sendbuf,
                  MPI_Comm comm,
                  MPI_Status* status)
 {
-    faabric::util::getLogger()->debug(
+    faabric::util::getLogger("mpi")->debug(
       fmt::format("MPI_Sendrecv {} -> {} and {} <- {}",
                   executingContext.getRank(),
                   dest,
@@ -170,7 +174,7 @@ int MPI_Sendrecv(const void* sendbuf,
 
 int MPI_Abort(MPI_Comm comm, int errorcode)
 {
-    auto logger = faabric::util::getLogger();
+    auto logger = faabric::util::getLogger("mpi");
     logger->debug("MPI_Abort");
 
     return MPI_SUCCESS;
@@ -178,7 +182,7 @@ int MPI_Abort(MPI_Comm comm, int errorcode)
 
 int MPI_Get_count(const MPI_Status* status, MPI_Datatype datatype, int* count)
 {
-    auto logger = faabric::util::getLogger();
+    auto logger = faabric::util::getLogger("mpi");
     logger->debug("MPI_Get_count");
 
     if (status->bytesSize % datatype->size != 0) {
@@ -195,7 +199,7 @@ int MPI_Get_count(const MPI_Status* status, MPI_Datatype datatype, int* count)
 
 int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status* status)
 {
-    faabric::util::getLogger()->debug("MPI_Probe");
+    faabric::util::getLogger("mpi")->debug("MPI_Probe");
     getExecutingWorld().probe(source, executingContext.getRank(), status);
 
     return MPI_SUCCESS;
@@ -203,7 +207,7 @@ int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status* status)
 
 int MPI_Barrier(MPI_Comm comm)
 {
-    faabric::util::getLogger()->debug("MPI_Barrier");
+    faabric::util::getLogger("mpi")->debug("MPI_Barrier");
     getExecutingWorld().barrier(executingContext.getRank());
 
     return MPI_SUCCESS;
@@ -215,7 +219,7 @@ int MPI_Bcast(void* buffer,
               int root,
               MPI_Comm comm)
 {
-    auto logger = faabric::util::getLogger();
+    auto logger = faabric::util::getLogger("mpi");
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
 
     int rank = executingContext.getRank();
@@ -246,7 +250,7 @@ int MPI_Scatter(const void* sendbuf,
                 int root,
                 MPI_Comm comm)
 {
-    faabric::util::getLogger()->debug(
+    faabric::util::getLogger("mpi")->debug(
       fmt::format("MPI_Scatter {} -> {}", root, executingContext.getRank()));
     getExecutingWorld().scatter(root,
                                 executingContext.getRank(),
@@ -273,7 +277,7 @@ int MPI_Gather(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger()->debug("MPI_Gather");
+    faabric::util::getLogger("mpi")->debug("MPI_Gather");
     getExecutingWorld().gather(executingContext.getRank(),
                                root,
                                (uint8_t*)sendbuf,
@@ -298,7 +302,7 @@ int MPI_Allgather(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger()->debug("MPI_Allgather");
+    faabric::util::getLogger("mpi")->debug("MPI_Allgather");
     getExecutingWorld().allGather(executingContext.getRank(),
                                   (uint8_t*)sendbuf,
                                   sendtype,
@@ -336,7 +340,7 @@ int MPI_Reduce(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger()->debug("MPI_Reduce");
+    faabric::util::getLogger("mpi")->debug("MPI_Reduce");
     getExecutingWorld().reduce(executingContext.getRank(),
                                root,
                                (uint8_t*)sendbuf,
@@ -371,7 +375,7 @@ int MPI_Allreduce(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger()->debug("MPI_Allreduce");
+    faabric::util::getLogger("mpi")->debug("MPI_Allreduce");
     getExecutingWorld().allReduce(executingContext.getRank(),
                                   (uint8_t*)sendbuf,
                                   (uint8_t*)recvbuf,
@@ -393,7 +397,7 @@ int MPI_Scan(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger()->debug("MPI_Scan");
+    faabric::util::getLogger("mpi")->debug("MPI_Scan");
     getExecutingWorld().scan(executingContext.getRank(),
                              (uint8_t*)sendbuf,
                              (uint8_t*)recvbuf,
@@ -412,7 +416,7 @@ int MPI_Alltoall(const void* sendbuf,
                  MPI_Datatype recvtype,
                  MPI_Comm comm)
 {
-    faabric::util::getLogger()->debug("MPI_Alltoall");
+    faabric::util::getLogger("mpi")->debug("MPI_Alltoall");
     getExecutingWorld().allToAll(executingContext.getRank(),
                                  (uint8_t*)sendbuf,
                                  sendtype,
@@ -431,7 +435,7 @@ int MPI_Cart_create(MPI_Comm old_comm,
                     int reorder,
                     MPI_Comm* comm)
 {
-    faabric::util::getLogger()->debug("MPI_Cart_create");
+    faabric::util::getLogger("mpi")->debug("MPI_Cart_create");
 
     *comm = old_comm;
 
@@ -440,7 +444,7 @@ int MPI_Cart_create(MPI_Comm old_comm,
 
 int MPI_Cart_rank(MPI_Comm comm, int coords[], int* rank)
 {
-    faabric::util::getLogger()->debug("MPI_Cart_rank");
+    faabric::util::getLogger("mpi")->debug("MPI_Cart_rank");
     getExecutingWorld().getRankFromCoords(rank, coords);
 
     return MPI_SUCCESS;
@@ -452,7 +456,7 @@ int MPI_Cart_get(MPI_Comm comm,
                  int periods[],
                  int coords[])
 {
-    faabric::util::getLogger()->debug("MPI_Cart_get");
+    faabric::util::getLogger("mpi")->debug("MPI_Cart_get");
     getExecutingWorld().getCartesianRank(
       executingContext.getRank(), dims, periods, coords);
 
@@ -465,7 +469,7 @@ int MPI_Cart_shift(MPI_Comm comm,
                    int* rank_source,
                    int* rank_dest)
 {
-    faabric::util::getLogger()->debug("MPI_Cart_shift");
+    faabric::util::getLogger("mpi")->debug("MPI_Cart_shift");
 
     rank_source = rank_dest;
 
@@ -474,7 +478,7 @@ int MPI_Cart_shift(MPI_Comm comm,
 
 int MPI_Type_size(MPI_Datatype type, int* size)
 {
-    faabric::util::getLogger()->debug("MPI_Type_size");
+    faabric::util::getLogger("mpi")->debug("MPI_Type_size");
 
     *size = type->size;
 
@@ -490,7 +494,7 @@ int MPI_Type_free(MPI_Datatype* datatype)
 
 int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void* baseptr)
 {
-    faabric::util::getLogger()->debug("MPI_Alloc_mem");
+    faabric::util::getLogger("mpi")->debug("MPI_Alloc_mem");
 
     if (info != MPI_INFO_NULL) {
         throw std::runtime_error("Non-null info not supported");
@@ -503,7 +507,7 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void* baseptr)
 
 int MPI_Win_fence(int assert, MPI_Win win)
 {
-    faabric::util::getLogger()->debug("MPI_Win_fence");
+    faabric::util::getLogger("mpi")->debug("MPI_Win_fence");
     getExecutingWorld().barrier(executingContext.getRank());
 
     return MPI_SUCCESS;
@@ -518,7 +522,7 @@ int MPI_Get(void* origin_addr,
             MPI_Datatype target_datatype,
             MPI_Win win)
 {
-    faabric::util::getLogger()->debug("MPI_Get");
+    faabric::util::getLogger("mpi")->debug("MPI_Get");
     getExecutingWorld().rmaGet(target_rank,
                                target_datatype,
                                target_count,
@@ -538,7 +542,7 @@ int MPI_Put(const void* origin_addr,
             MPI_Datatype target_datatype,
             MPI_Win win)
 {
-    faabric::util::getLogger()->debug("MPI_Put");
+    faabric::util::getLogger("mpi")->debug("MPI_Put");
     getExecutingWorld().rmaPut(executingContext.getRank(),
                                (uint8_t*)origin_addr,
                                origin_datatype,
@@ -552,7 +556,7 @@ int MPI_Put(const void* origin_addr,
 
 int MPI_Win_free(MPI_Win* win)
 {
-    faabric::util::getLogger()->debug("MPI_Win_free");
+    faabric::util::getLogger("mpi")->debug("MPI_Win_free");
     free(*win);
 
     return MPI_SUCCESS;
@@ -565,7 +569,7 @@ int MPI_Win_create(void* base,
                    MPI_Comm comm,
                    MPI_Win* win)
 {
-    faabric::util::getLogger()->debug("MPI_Win_create");
+    faabric::util::getLogger("mpi")->debug("MPI_Win_create");
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
 
     (*win) = (faabric_win_t*)malloc(sizeof(faabric_win_t));
@@ -581,7 +585,7 @@ int MPI_Win_create(void* base,
 
 int MPI_Get_processor_name(char* name, int* resultlen)
 {
-    faabric::util::getLogger()->debug("MPI_Get_processor_name");
+    faabric::util::getLogger("mpi")->debug("MPI_Get_processor_name");
 
     std::string host = faabric::util::getSystemConfig().endpointHost;
     strncpy(name, host.c_str(), host.length());
@@ -595,7 +599,7 @@ int MPI_Win_get_attr(MPI_Win win,
                      void* attribute_val,
                      int* flag)
 {
-    faabric::util::getLogger()->debug("MPI_Win_get_attr");
+    faabric::util::getLogger("mpi")->debug("MPI_Win_get_attr");
 
     *flag = 1;
     if (win_keyval == MPI_WIN_BASE) {
@@ -616,7 +620,7 @@ int MPI_Win_get_attr(MPI_Win win,
 
 int MPI_Free_mem(void* base)
 {
-    faabric::util::getLogger()->debug("MPI_Free_mem");
+    faabric::util::getLogger("mpi")->debug("MPI_Free_mem");
 
     return MPI_SUCCESS;
 }
@@ -630,14 +634,14 @@ int MPI_Request_free(MPI_Request* request)
 
 int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-    faabric::util::getLogger()->debug("MPI_Type_contiguous");
+    faabric::util::getLogger("mpi")->debug("MPI_Type_contiguous");
 
     return MPI_SUCCESS;
 }
 
 int MPI_Type_commit(MPI_Datatype* type)
 {
-    faabric::util::getLogger()->debug("MPI_Type_commit");
+    faabric::util::getLogger("mpi")->debug("MPI_Type_commit");
 
     return MPI_SUCCESS;
 }
@@ -650,7 +654,7 @@ int MPI_Isend(const void* buf,
               MPI_Comm comm,
               MPI_Request* request)
 {
-    faabric::util::getLogger()->debug(
+    faabric::util::getLogger("mpi")->debug(
       "MPI_Isend {} -> {}", executingContext.getRank(), dest);
 
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
@@ -670,7 +674,7 @@ int MPI_Irecv(void* buf,
               MPI_Comm comm,
               MPI_Request* request)
 {
-    faabric::util::getLogger()->debug(
+    faabric::util::getLogger("mpi")->debug(
       "MPI_Irecv {} <- {}", executingContext.getRank(), source);
 
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
@@ -684,14 +688,14 @@ int MPI_Irecv(void* buf,
 
 double MPI_Wtime()
 {
-    faabric::util::getLogger()->debug("MPI_Wtime");
+    faabric::util::getLogger("mpi")->debug("MPI_Wtime");
 
     return getExecutingWorld().getWTime();
 }
 
 int MPI_Wait(MPI_Request* request, MPI_Status* status)
 {
-    faabric::util::getLogger()->debug("MPI_Wait");
+    faabric::util::getLogger("mpi")->debug("MPI_Wait");
     getExecutingWorld().awaitAsyncRequest((*request)->id);
 
     return MPI_SUCCESS;
@@ -739,7 +743,7 @@ MPI_Comm MPI_Comm_f2c(MPI_Fint comm)
 
 int MPI_Comm_free(MPI_Comm* comm)
 {
-    faabric::util::getLogger()->debug("MPI_Comm_free");
+    faabric::util::getLogger("mpi")->debug("MPI_Comm_free");
 
     return MPI_SUCCESS;
 }

--- a/src/mpi_native/mpi_native.cpp
+++ b/src/mpi_native/mpi_native.cpp
@@ -8,8 +8,18 @@
 
 using namespace faabric::executor;
 
-static faabric::scheduler::MpiContext executingContext;
-static std::string logName;
+static thread_local faabric::scheduler::MpiContext executingContext;
+static thread_local std::shared_ptr<spdlog::logger> mpiLogger = nullptr;
+
+std::shared_ptr<spdlog::logger> getMpiLogger()
+{
+    if (mpiLogger == nullptr) {
+        int mpiRank = executingContext.getRank();
+        mpiLogger = faabric::util::getLogger(fmt::format("MPI-{}", mpiRank));
+    }
+
+    return mpiLogger;
+}
 
 faabric::Message* getExecutingCall()
 {
@@ -26,8 +36,7 @@ faabric::scheduler::MpiWorld& getExecutingWorld()
 
 static void notImplemented(const std::string& funcName)
 {
-    auto logger = faabric::util::getLogger(logName);
-    logger->debug("{}", funcName);
+    getMpiLogger()->debug("{}", funcName);
 
     throw std::runtime_error(funcName + " not implemented.");
 }
@@ -48,8 +57,7 @@ int MPI_Init(int* argc, char*** argv)
 
     // Initialise MPI-specific logging
     int thisRank = executingContext.getRank();
-    logName = fmt::format("MPI-{}", thisRank);
-    faabric::util::getLogger(logName)->debug("MPI_Init");
+    getMpiLogger()->debug("MPI_Init");
 
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
     world.barrier(thisRank);
@@ -59,7 +67,7 @@ int MPI_Init(int* argc, char*** argv)
 
 int MPI_Comm_rank(MPI_Comm comm, int* rank)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Comm_rank");
+    getMpiLogger()->debug("MPI_Comm_rank");
 
     *rank = executingContext.getRank();
 
@@ -68,7 +76,7 @@ int MPI_Comm_rank(MPI_Comm comm, int* rank)
 
 int MPI_Comm_size(MPI_Comm comm, int* size)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Comm_size");
+    getMpiLogger()->debug("MPI_Comm_size");
     *size = getExecutingWorld().getSize();
 
     return MPI_SUCCESS;
@@ -76,7 +84,7 @@ int MPI_Comm_size(MPI_Comm comm, int* size)
 
 int MPI_Finalize()
 {
-    faabric::util::getLogger(logName)->debug("MPI_Finalize");
+    getMpiLogger()->debug("MPI_Finalize");
 
     return MPI_SUCCESS;
 }
@@ -95,7 +103,7 @@ int MPI_Send(const void* buf,
              int tag,
              MPI_Comm comm)
 {
-    faabric::util::getLogger(logName)->debug(
+    getMpiLogger()->debug(
       fmt::format("MPI_Send {} -> {}", executingContext.getRank(), dest));
     getExecutingWorld().send(executingContext.getRank(),
                              dest,
@@ -127,7 +135,7 @@ int MPI_Recv(void* buf,
              MPI_Comm comm,
              MPI_Status* status)
 {
-    faabric::util::getLogger(logName)->debug(
+    getMpiLogger()->debug(
       fmt::format("MPI_Recv {} <- {}", executingContext.getRank(), source));
     getExecutingWorld().recv(source,
                              executingContext.getRank(),
@@ -153,12 +161,11 @@ int MPI_Sendrecv(const void* sendbuf,
                  MPI_Comm comm,
                  MPI_Status* status)
 {
-    faabric::util::getLogger(logName)->debug(
-      fmt::format("MPI_Sendrecv {} -> {} and {} <- {}",
-                  executingContext.getRank(),
-                  dest,
-                  executingContext.getRank(),
-                  source));
+    getMpiLogger()->debug(fmt::format("MPI_Sendrecv {} -> {} and {} <- {}",
+                                      executingContext.getRank(),
+                                      dest,
+                                      executingContext.getRank(),
+                                      source));
     getExecutingWorld().sendRecv((uint8_t*)sendbuf,
                                  sendcount,
                                  sendtype,
@@ -175,15 +182,14 @@ int MPI_Sendrecv(const void* sendbuf,
 
 int MPI_Abort(MPI_Comm comm, int errorcode)
 {
-    auto logger = faabric::util::getLogger(logName);
-    logger->debug("MPI_Abort");
+    getMpiLogger()->debug("MPI_Abort");
 
     return MPI_SUCCESS;
 }
 
 int MPI_Get_count(const MPI_Status* status, MPI_Datatype datatype, int* count)
 {
-    auto logger = faabric::util::getLogger(logName);
+    auto logger = getMpiLogger();
     logger->debug("MPI_Get_count");
 
     if (status->bytesSize % datatype->size != 0) {
@@ -200,7 +206,7 @@ int MPI_Get_count(const MPI_Status* status, MPI_Datatype datatype, int* count)
 
 int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status* status)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Probe");
+    getMpiLogger()->debug("MPI_Probe");
     getExecutingWorld().probe(source, executingContext.getRank(), status);
 
     return MPI_SUCCESS;
@@ -208,7 +214,7 @@ int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status* status)
 
 int MPI_Barrier(MPI_Comm comm)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Barrier");
+    getMpiLogger()->debug("MPI_Barrier");
     getExecutingWorld().barrier(executingContext.getRank());
 
     return MPI_SUCCESS;
@@ -220,7 +226,7 @@ int MPI_Bcast(void* buffer,
               int root,
               MPI_Comm comm)
 {
-    auto logger = faabric::util::getLogger(logName);
+    auto logger = getMpiLogger();
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
 
     int rank = executingContext.getRank();
@@ -251,7 +257,7 @@ int MPI_Scatter(const void* sendbuf,
                 int root,
                 MPI_Comm comm)
 {
-    faabric::util::getLogger(logName)->debug(
+    getMpiLogger()->debug(
       fmt::format("MPI_Scatter {} -> {}", root, executingContext.getRank()));
     getExecutingWorld().scatter(root,
                                 executingContext.getRank(),
@@ -278,7 +284,7 @@ int MPI_Gather(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger(logName)->debug("MPI_Gather");
+    getMpiLogger()->debug("MPI_Gather");
     getExecutingWorld().gather(executingContext.getRank(),
                                root,
                                (uint8_t*)sendbuf,
@@ -303,7 +309,7 @@ int MPI_Allgather(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger(logName)->debug("MPI_Allgather");
+    getMpiLogger()->debug("MPI_Allgather");
     getExecutingWorld().allGather(executingContext.getRank(),
                                   (uint8_t*)sendbuf,
                                   sendtype,
@@ -341,7 +347,7 @@ int MPI_Reduce(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger(logName)->debug("MPI_Reduce");
+    getMpiLogger()->debug("MPI_Reduce");
     getExecutingWorld().reduce(executingContext.getRank(),
                                root,
                                (uint8_t*)sendbuf,
@@ -376,7 +382,7 @@ int MPI_Allreduce(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger(logName)->debug("MPI_Allreduce");
+    getMpiLogger()->debug("MPI_Allreduce");
     getExecutingWorld().allReduce(executingContext.getRank(),
                                   (uint8_t*)sendbuf,
                                   (uint8_t*)recvbuf,
@@ -398,7 +404,7 @@ int MPI_Scan(const void* sendbuf,
         sendbuf = recvbuf;
     }
 
-    faabric::util::getLogger(logName)->debug("MPI_Scan");
+    getMpiLogger()->debug("MPI_Scan");
     getExecutingWorld().scan(executingContext.getRank(),
                              (uint8_t*)sendbuf,
                              (uint8_t*)recvbuf,
@@ -417,7 +423,7 @@ int MPI_Alltoall(const void* sendbuf,
                  MPI_Datatype recvtype,
                  MPI_Comm comm)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Alltoall");
+    getMpiLogger()->debug("MPI_Alltoall");
     getExecutingWorld().allToAll(executingContext.getRank(),
                                  (uint8_t*)sendbuf,
                                  sendtype,
@@ -436,7 +442,7 @@ int MPI_Cart_create(MPI_Comm old_comm,
                     int reorder,
                     MPI_Comm* comm)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Cart_create");
+    getMpiLogger()->debug("MPI_Cart_create");
 
     *comm = old_comm;
 
@@ -445,7 +451,7 @@ int MPI_Cart_create(MPI_Comm old_comm,
 
 int MPI_Cart_rank(MPI_Comm comm, int coords[], int* rank)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Cart_rank");
+    getMpiLogger()->debug("MPI_Cart_rank");
     getExecutingWorld().getRankFromCoords(rank, coords);
 
     return MPI_SUCCESS;
@@ -457,7 +463,7 @@ int MPI_Cart_get(MPI_Comm comm,
                  int periods[],
                  int coords[])
 {
-    faabric::util::getLogger(logName)->debug("MPI_Cart_get");
+    getMpiLogger()->debug("MPI_Cart_get");
     getExecutingWorld().getCartesianRank(
       executingContext.getRank(), dims, periods, coords);
 
@@ -470,7 +476,7 @@ int MPI_Cart_shift(MPI_Comm comm,
                    int* rank_source,
                    int* rank_dest)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Cart_shift");
+    getMpiLogger()->debug("MPI_Cart_shift");
 
     rank_source = rank_dest;
 
@@ -479,7 +485,7 @@ int MPI_Cart_shift(MPI_Comm comm,
 
 int MPI_Type_size(MPI_Datatype type, int* size)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Type_size");
+    getMpiLogger()->debug("MPI_Type_size");
 
     *size = type->size;
 
@@ -495,7 +501,7 @@ int MPI_Type_free(MPI_Datatype* datatype)
 
 int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void* baseptr)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Alloc_mem");
+    getMpiLogger()->debug("MPI_Alloc_mem");
 
     if (info != MPI_INFO_NULL) {
         throw std::runtime_error("Non-null info not supported");
@@ -508,7 +514,7 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void* baseptr)
 
 int MPI_Win_fence(int assert, MPI_Win win)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Win_fence");
+    getMpiLogger()->debug("MPI_Win_fence");
     getExecutingWorld().barrier(executingContext.getRank());
 
     return MPI_SUCCESS;
@@ -523,7 +529,7 @@ int MPI_Get(void* origin_addr,
             MPI_Datatype target_datatype,
             MPI_Win win)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Get");
+    getMpiLogger()->debug("MPI_Get");
     getExecutingWorld().rmaGet(target_rank,
                                target_datatype,
                                target_count,
@@ -543,7 +549,7 @@ int MPI_Put(const void* origin_addr,
             MPI_Datatype target_datatype,
             MPI_Win win)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Put");
+    getMpiLogger()->debug("MPI_Put");
     getExecutingWorld().rmaPut(executingContext.getRank(),
                                (uint8_t*)origin_addr,
                                origin_datatype,
@@ -557,7 +563,7 @@ int MPI_Put(const void* origin_addr,
 
 int MPI_Win_free(MPI_Win* win)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Win_free");
+    getMpiLogger()->debug("MPI_Win_free");
     free(*win);
 
     return MPI_SUCCESS;
@@ -570,7 +576,7 @@ int MPI_Win_create(void* base,
                    MPI_Comm comm,
                    MPI_Win* win)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Win_create");
+    getMpiLogger()->debug("MPI_Win_create");
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
 
     (*win) = (faabric_win_t*)malloc(sizeof(faabric_win_t));
@@ -586,7 +592,7 @@ int MPI_Win_create(void* base,
 
 int MPI_Get_processor_name(char* name, int* resultlen)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Get_processor_name");
+    getMpiLogger()->debug("MPI_Get_processor_name");
 
     std::string host = faabric::util::getSystemConfig().endpointHost;
     strncpy(name, host.c_str(), host.length());
@@ -600,7 +606,7 @@ int MPI_Win_get_attr(MPI_Win win,
                      void* attribute_val,
                      int* flag)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Win_get_attr");
+    getMpiLogger()->debug("MPI_Win_get_attr");
 
     *flag = 1;
     if (win_keyval == MPI_WIN_BASE) {
@@ -621,7 +627,7 @@ int MPI_Win_get_attr(MPI_Win win,
 
 int MPI_Free_mem(void* base)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Free_mem");
+    getMpiLogger()->debug("MPI_Free_mem");
 
     return MPI_SUCCESS;
 }
@@ -635,14 +641,14 @@ int MPI_Request_free(MPI_Request* request)
 
 int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Type_contiguous");
+    getMpiLogger()->debug("MPI_Type_contiguous");
 
     return MPI_SUCCESS;
 }
 
 int MPI_Type_commit(MPI_Datatype* type)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Type_commit");
+    getMpiLogger()->debug("MPI_Type_commit");
 
     return MPI_SUCCESS;
 }
@@ -655,7 +661,7 @@ int MPI_Isend(const void* buf,
               MPI_Comm comm,
               MPI_Request* request)
 {
-    faabric::util::getLogger(logName)->debug(
+    getMpiLogger()->debug(
       "MPI_Isend {} -> {}", executingContext.getRank(), dest);
 
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
@@ -675,7 +681,7 @@ int MPI_Irecv(void* buf,
               MPI_Comm comm,
               MPI_Request* request)
 {
-    faabric::util::getLogger(logName)->debug(
+    getMpiLogger()->debug(
       "MPI_Irecv {} <- {}", executingContext.getRank(), source);
 
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
@@ -689,14 +695,14 @@ int MPI_Irecv(void* buf,
 
 double MPI_Wtime()
 {
-    faabric::util::getLogger(logName)->debug("MPI_Wtime");
+    getMpiLogger()->debug("MPI_Wtime");
 
     return getExecutingWorld().getWTime();
 }
 
 int MPI_Wait(MPI_Request* request, MPI_Status* status)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Wait");
+    getMpiLogger()->debug("MPI_Wait");
     getExecutingWorld().awaitAsyncRequest((*request)->id);
 
     return MPI_SUCCESS;
@@ -744,7 +750,7 @@ MPI_Comm MPI_Comm_f2c(MPI_Fint comm)
 
 int MPI_Comm_free(MPI_Comm* comm)
 {
-    faabric::util::getLogger(logName)->debug("MPI_Comm_free");
+    getMpiLogger()->debug("MPI_Comm_free");
 
     return MPI_SUCCESS;
 }

--- a/src/mpi_native/mpi_native.cpp
+++ b/src/mpi_native/mpi_native.cpp
@@ -47,7 +47,6 @@ int MPI_Init(int* argc, char*** argv)
 
     // Initialise MPI-specific logging
     int thisRank = executingContext.getRank();
-    faabric::util::initMpiLogging(thisRank);
     faabric::util::getLogger("mpi")->debug("MPI_Init");
 
     faabric::scheduler::MpiWorld& world = getExecutingWorld();

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -27,7 +27,7 @@ void SystemConfig::initialise()
     cgroupMode = getEnvVar("CGROUP_MODE", "on");
     netNsMode = getEnvVar("NETNS_MODE", "off");
     logLevel = getEnvVar("LOG_LEVEL", "info");
-    logFile = getEnvVar("LOG_FILE", "on");
+    logFile = getEnvVar("LOG_FILE", "off");
     pythonPreload = getEnvVar("PYTHON_PRELOAD", "off");
     captureStdout = getEnvVar("CAPTURE_STDOUT", "off");
     stateMode = getEnvVar("STATE_MODE", "inmemory");
@@ -110,6 +110,7 @@ void SystemConfig::print()
     logger->info("CGROUP_MODE                {}", cgroupMode);
     logger->info("NETNS_MODE                 {}", netNsMode);
     logger->info("LOG_LEVEL                  {}", logLevel);
+    logger->info("LOG_FILE                   {}", logFile);
     logger->info("PYTHON_PRELOAD             {}", pythonPreload);
     logger->info("CAPTURE_STDOUT             {}", captureStdout);
     logger->info("STATE_MODE                 {}", stateMode);

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -27,6 +27,7 @@ void SystemConfig::initialise()
     cgroupMode = getEnvVar("CGROUP_MODE", "on");
     netNsMode = getEnvVar("NETNS_MODE", "off");
     logLevel = getEnvVar("LOG_LEVEL", "info");
+    logFile = getEnvVar("LOG_FILE", "on");
     pythonPreload = getEnvVar("PYTHON_PRELOAD", "off");
     captureStdout = getEnvVar("CAPTURE_STDOUT", "off");
     stateMode = getEnvVar("STATE_MODE", "inmemory");
@@ -69,8 +70,6 @@ void SystemConfig::initialise()
     // MPI
     defaultMpiWorldSize =
       this->getSystemConfIntParam("DEFAULT_MPI_WORLD_SIZE", "5");
-    mpiLogLevel = getEnvVar("MPI_LOG_LEVEL", "on");
-    mpiLogFile = getEnvVar("MPI_LOG_FILE", "logs/faabric_mpi.log");
 
     // Endpoint
     endpointInterface = getEnvVar("ENDPOINT_INTERFACE", "");

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -69,6 +69,8 @@ void SystemConfig::initialise()
     // MPI
     defaultMpiWorldSize =
       this->getSystemConfIntParam("DEFAULT_MPI_WORLD_SIZE", "5");
+    mpiLogLevel = getEnvVar("MPI_LOG_LEVEL", "on");
+    mpiLogFile = getEnvVar("MPI_LOG_FILE", "logs/faabric_mpi.log");
 
     // Endpoint
     endpointInterface = getEnvVar("ENDPOINT_INTERFACE", "");

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -1,42 +1,103 @@
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 
+#include "spdlog/sinks/basic_file_sink.h"
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace faabric::util {
-static std::shared_ptr<spdlog::logger> logger;
-static bool isInitialised = false;
+static std::shared_ptr<spdlog::logger> defaultLogger;
+static std::shared_ptr<spdlog::logger> mpiLogger;
+// static bool isInitialised = false;
 
-void initLogging()
+void initMpiLogging(int rank)
 {
-    if (isInitialised) {
+    // To set up the MPI logging, we must wait until we know our rank.
+    // Logging to both console + file or only file is supported.
+    if (mpiLogger != nullptr) {
         return;
     }
 
-    // Initialise the logger
-    logger = spdlog::stderr_color_mt("console");
+    faabric::util::getLogger()->debug("Initialising MPI logger");
+    SystemConfig& conf = faabric::util::getSystemConfig();
+    if (conf.mpiLogLevel == "on") {
+        try {
+            // Initialise the logger with two sinks
+            auto console_sink =
+              std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+            console_sink->set_level(spdlog::level::debug);
+            console_sink->set_pattern(fmt::format("[MPI - Rank: {}] %v", rank));
+
+            auto file_sink =
+              std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+                "logs/multisink.txt", true);
+            file_sink->set_level(spdlog::level::debug);
+            file_sink->set_pattern(fmt::format("[MPI - Rank: {}] %v", rank));
+
+            spdlog::sinks_init_list sink_list = { file_sink, console_sink };
+            mpiLogger = std::make_shared<spdlog::logger>(
+              "mpi_logger", sink_list.begin(), sink_list.end());
+            mpiLogger->set_level(spdlog::level::debug);
+        } catch (const spdlog::spdlog_ex& e) {
+            faabric::util::getLogger()->error(
+              "MPI Logger initialization failed: {}", e.what());
+        }
+    } else if (conf.mpiLogLevel == "file") {
+        try {
+            mpiLogger = spdlog::basic_logger_mt("mpi_logger", "logs/test.txt");
+            mpiLogger->set_level(spdlog::level::debug);
+            mpiLogger->set_pattern(fmt::format("[MPI - Rank: {}] %v", rank));
+        } catch (const spdlog::spdlog_ex& e) {
+            faabric::util::getLogger()->error(
+              "MPI logger initialization failed: {}", e.what());
+        }
+    } else {
+        faabric::util::getLogger()->warn(
+          "MPI logging has not been enabled in the system's config.");
+        faabric::util::getLogger()->warn("Reverting to the default logger.");
+        mpiLogger = defaultLogger;
+    }
+}
+
+void initLogging()
+{
+    if (defaultLogger != nullptr) {
+        return;
+    }
+
+    // Initialise the default logger
+    defaultLogger = spdlog::stderr_color_mt("console");
 
     // Work out log level from environment
     SystemConfig& conf = faabric::util::getSystemConfig();
     if (conf.logLevel == "debug") {
-        spdlog::set_level(spdlog::level::debug);
+        defaultLogger->set_level(spdlog::level::debug);
     } else if (conf.logLevel == "trace") {
-        spdlog::set_level(spdlog::level::trace);
+        defaultLogger->set_level(spdlog::level::trace);
     } else if (conf.logLevel == "off") {
-        spdlog::set_level(spdlog::level::off);
+        defaultLogger->set_level(spdlog::level::off);
     } else {
-        spdlog::set_level(spdlog::level::info);
+        defaultLogger->set_level(spdlog::level::info);
     }
 
-    isInitialised = true;
+    // isInitialised = true;
 }
 
-std::shared_ptr<spdlog::logger> getLogger()
+std::shared_ptr<spdlog::logger> getLogger(const std::string& logger)
 {
-    if (!isInitialised) {
-        initLogging();
+    if (logger == "default") {
+        if (defaultLogger == nullptr) {
+            initLogging();
+        }
+        return defaultLogger;
+    } else if (logger == "mpi") {
+        if (mpiLogger == nullptr) {
+            // We need to explicitly initialise the MPI logger with our rank
+            throw std::runtime_error("Use of uninitialized MPI logger");
+        }
+        return mpiLogger;
+    } else {
+        throw std::runtime_error(
+          fmt::format("Unrecognized logger: {}", logger));
     }
-
-    return logger;
 }
 }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -2,13 +2,15 @@
 #include <faabric/util/logging.h>
 
 #include "spdlog/sinks/basic_file_sink.h"
-#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/stdout_sinks.h>
+//#include "spdlog/sinks/stdout_color_sinks.h"
 
 namespace faabric::util {
 static std::shared_ptr<spdlog::logger> defaultLogger;
 static std::shared_ptr<spdlog::logger> mpiLogger;
-// static bool isInitialised = false;
+static std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> loggers;
 
+/*
 void initMpiLogging(int rank)
 {
     // To set up the MPI logging, we must wait until we know our rank.
@@ -65,25 +67,75 @@ void initLogging()
     }
 
     // Initialise the default logger
-    defaultLogger = spdlog::stderr_color_mt("console");
+    loggers["default"] = spdlog::stderr_color_mt("console");
 
     // Work out log level from environment
     SystemConfig& conf = faabric::util::getSystemConfig();
     if (conf.logLevel == "debug") {
-        defaultLogger->set_level(spdlog::level::debug);
+        loggers["default"]->set_level(spdlog::level::debug);
     } else if (conf.logLevel == "trace") {
-        defaultLogger->set_level(spdlog::level::trace);
+        loggers["default"]->set_level(spdlog::level::trace);
     } else if (conf.logLevel == "off") {
-        defaultLogger->set_level(spdlog::level::off);
+        loggers["default"]->set_level(spdlog::level::off);
     } else {
-        defaultLogger->set_level(spdlog::level::info);
+        loggers["default"]->set_level(spdlog::level::info);
     }
+}
+*/
 
-    // isInitialised = true;
+static void initLogging(const std::string& name)
+{
+    SystemConfig& conf = faabric::util::getSystemConfig();
+    
+    // Configure the sink list. By default all loggers _at least_ log to
+    // the console
+    try {
+        std::vector<spdlog::sink_ptr> sinks;
+        // Issue with color in multiple sinks requires this trick
+        // https://github.com/gabime/spdlog/issues/290#issuecomment-250716701
+        //auto stdout_sink = spdlog::sinks::stdout_sink_mt::instance();
+        //auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(stdout_sink);
+        auto stdout_sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
+        sinks.push_back(stdout_sink);
+
+        // If log level is set to file add an additional file sink
+        if (conf.logFile == "on") {
+            sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+              fmt::format("/var/log/faabric/{}.log", name)));
+        }
+
+        // Initialize the logger and set level
+        loggers[name] =
+          std::make_shared<spdlog::logger>(name, sinks.begin(), sinks.end());
+        if (conf.logLevel == "debug") {
+            loggers[name]->set_level(spdlog::level::debug);
+        } else if (conf.logLevel == "trace") {
+            loggers[name]->set_level(spdlog::level::trace);
+        } else if (conf.logLevel == "off") {
+            loggers[name]->set_level(spdlog::level::off);
+        } else {
+            loggers[name]->set_level(spdlog::level::info);
+        }
+
+        // Add custom pattern. See here the formatting options:
+        // https://github.com/gabime/spdlog/wiki/3.-Custom-formatting#pattern-flags
+        // <timestamp> [log-level] [logger-name] [rank] <message>
+        loggers[name]->set_pattern("%D %T [%n] (%l) %v");
+    } catch (const spdlog::spdlog_ex& e) {
+        throw std::runtime_error(fmt::format("Error initializing {} logger: {}", name, e.what()));
+    }
 }
 
-std::shared_ptr<spdlog::logger> getLogger(const std::string& logger)
+std::shared_ptr<spdlog::logger> getLogger(const std::string& name)
 {
+    // Lazy-initialize logger
+    // TODO consider using loggers.contains(<key>) when C++20 support
+    if (loggers.count(name) == 0) {
+        initLogging(name);
+    }
+
+    return loggers[name];
+    /*
     if (logger == "default") {
         if (defaultLogger == nullptr) {
             initLogging();
@@ -99,5 +151,6 @@ std::shared_ptr<spdlog::logger> getLogger(const std::string& logger)
         throw std::runtime_error(
           fmt::format("Unrecognized logger: {}", logger));
     }
+    */
 }
 }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -2,103 +2,24 @@
 #include <faabric/util/logging.h>
 
 #include "spdlog/sinks/basic_file_sink.h"
-#include <spdlog/sinks/stdout_sinks.h>
-//#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 
 namespace faabric::util {
-static std::shared_ptr<spdlog::logger> defaultLogger;
-static std::shared_ptr<spdlog::logger> mpiLogger;
 static std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> loggers;
-
-/*
-void initMpiLogging(int rank)
-{
-    // To set up the MPI logging, we must wait until we know our rank.
-    // Logging to both console + file or only file is supported.
-    if (mpiLogger != nullptr) {
-        return;
-    }
-
-    faabric::util::getLogger()->debug("Initialising MPI logger");
-    SystemConfig& conf = faabric::util::getSystemConfig();
-    if (conf.mpiLogLevel == "on") {
-        try {
-            // Initialise the logger with two sinks
-            auto console_sink =
-              std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-            console_sink->set_level(spdlog::level::debug);
-            console_sink->set_pattern(fmt::format("[MPI - Rank: {}] %v", rank));
-
-            auto file_sink =
-              std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-                "logs/multisink.txt", true);
-            file_sink->set_level(spdlog::level::debug);
-            file_sink->set_pattern(fmt::format("[MPI - Rank: {}] %v", rank));
-
-            spdlog::sinks_init_list sink_list = { file_sink, console_sink };
-            mpiLogger = std::make_shared<spdlog::logger>(
-              "mpi_logger", sink_list.begin(), sink_list.end());
-            mpiLogger->set_level(spdlog::level::debug);
-        } catch (const spdlog::spdlog_ex& e) {
-            faabric::util::getLogger()->error(
-              "MPI Logger initialization failed: {}", e.what());
-        }
-    } else if (conf.mpiLogLevel == "file") {
-        try {
-            mpiLogger = spdlog::basic_logger_mt("mpi_logger", "logs/test.txt");
-            mpiLogger->set_level(spdlog::level::debug);
-            mpiLogger->set_pattern(fmt::format("[MPI - Rank: {}] %v", rank));
-        } catch (const spdlog::spdlog_ex& e) {
-            faabric::util::getLogger()->error(
-              "MPI logger initialization failed: {}", e.what());
-        }
-    } else {
-        faabric::util::getLogger()->warn(
-          "MPI logging has not been enabled in the system's config.");
-        faabric::util::getLogger()->warn("Reverting to the default logger.");
-        mpiLogger = defaultLogger;
-    }
-}
-
-void initLogging()
-{
-    if (defaultLogger != nullptr) {
-        return;
-    }
-
-    // Initialise the default logger
-    loggers["default"] = spdlog::stderr_color_mt("console");
-
-    // Work out log level from environment
-    SystemConfig& conf = faabric::util::getSystemConfig();
-    if (conf.logLevel == "debug") {
-        loggers["default"]->set_level(spdlog::level::debug);
-    } else if (conf.logLevel == "trace") {
-        loggers["default"]->set_level(spdlog::level::trace);
-    } else if (conf.logLevel == "off") {
-        loggers["default"]->set_level(spdlog::level::off);
-    } else {
-        loggers["default"]->set_level(spdlog::level::info);
-    }
-}
-*/
 
 static void initLogging(const std::string& name)
 {
     SystemConfig& conf = faabric::util::getSystemConfig();
-    
+
     // Configure the sink list. By default all loggers _at least_ log to
     // the console
     try {
         std::vector<spdlog::sink_ptr> sinks;
-        // Issue with color in multiple sinks requires this trick
-        // https://github.com/gabime/spdlog/issues/290#issuecomment-250716701
-        //auto stdout_sink = spdlog::sinks::stdout_sink_mt::instance();
-        //auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(stdout_sink);
-        auto stdout_sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
+        auto stdout_sink =
+          std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
         sinks.push_back(stdout_sink);
 
-        // If log level is set to file add an additional file sink
+        // If file logging is set, add an additional file sink
         if (conf.logFile == "on") {
             sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(
               fmt::format("/var/log/faabric/{}.log", name)));
@@ -120,9 +41,10 @@ static void initLogging(const std::string& name)
         // Add custom pattern. See here the formatting options:
         // https://github.com/gabime/spdlog/wiki/3.-Custom-formatting#pattern-flags
         // <timestamp> [log-level] [logger-name] [rank] <message>
-        loggers[name]->set_pattern("%D %T [%n] (%l) %v");
+        loggers[name]->set_pattern("%^%D %T [%n] (%l)%$ %v");
     } catch (const spdlog::spdlog_ex& e) {
-        throw std::runtime_error(fmt::format("Error initializing {} logger: {}", name, e.what()));
+        throw std::runtime_error(
+          fmt::format("Error initializing {} logger: {}", name, e.what()));
     }
 }
 
@@ -135,22 +57,5 @@ std::shared_ptr<spdlog::logger> getLogger(const std::string& name)
     }
 
     return loggers[name];
-    /*
-    if (logger == "default") {
-        if (defaultLogger == nullptr) {
-            initLogging();
-        }
-        return defaultLogger;
-    } else if (logger == "mpi") {
-        if (mpiLogger == nullptr) {
-            // We need to explicitly initialise the MPI logger with our rank
-            throw std::runtime_error("Use of uninitialized MPI logger");
-        }
-        return mpiLogger;
-    } else {
-        throw std::runtime_error(
-          fmt::format("Unrecognized logger: {}", logger));
-    }
-    */
 }
 }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -1,8 +1,8 @@
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 
-#include "spdlog/sinks/basic_file_sink.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace faabric::util {
 static std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> loggers;
@@ -51,7 +51,6 @@ static void initLogging(const std::string& name)
 std::shared_ptr<spdlog::logger> getLogger(const std::string& name)
 {
     // Lazy-initialize logger
-    // TODO consider using loggers.contains(<key>) when C++20 support
     if (loggers.count(name) == 0) {
         initLogging(name);
     }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -40,7 +40,7 @@ static void initLogging(const std::string& name)
 
         // Add custom pattern. See here the formatting options:
         // https://github.com/gabime/spdlog/wiki/3.-Custom-formatting#pattern-flags
-        // <timestamp> [log-level] [logger-name] [rank] <message>
+        // <timestamp> [logger-name] (log-level) <message>
         loggers[name]->set_pattern("%^%D %T [%n] (%l)%$ %v");
     } catch (const spdlog::spdlog_ex& e) {
         throw std::runtime_error(

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -7,8 +7,6 @@
 
 int main(int argc, char* argv[])
 {
-    //faabric::util::initLogging();
-
     int result = Catch::Session().run(argc, argv);
 
     fflush(stdout);

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -7,7 +7,7 @@
 
 int main(int argc, char* argv[])
 {
-    faabric::util::initLogging();
+    //faabric::util::initLogging();
 
     int result = Catch::Session().run(argc, argv);
 

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -18,6 +18,8 @@ TEST_CASE("Test default system config initialisation", "[util]")
     REQUIRE(conf.functionStorage == "local");
     REQUIRE(conf.fileserverUrl == "");
     REQUIRE(conf.netNsMode == "off");
+    REQUIRE(conf.logLevel == "info");
+    REQUIRE(conf.logFile == "off");
     REQUIRE(conf.pythonPreload == "off");
     REQUIRE(conf.captureStdout == "off");
     REQUIRE(conf.stateMode == "inmemory");
@@ -50,6 +52,8 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     std::string fileserver = setEnvVar("FILESERVER_URL", "www.foo.com");
     std::string cgMode = setEnvVar("CGROUP_MODE", "off");
     std::string nsMode = setEnvVar("NETNS_MODE", "on");
+    std::string logLevel = setEnvVar("LOG_LEVEL", "debug");
+    std::string logFile = setEnvVar("LOG_FILE", "on");
     std::string pythonPre = setEnvVar("PYTHON_PRELOAD", "on");
     std::string captureStdout = setEnvVar("CAPTURE_STDOUT", "on");
     std::string stateMode = setEnvVar("STATE_MODE", "foobar");
@@ -89,6 +93,8 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     REQUIRE(conf.fileserverUrl == "www.foo.com");
     REQUIRE(conf.cgroupMode == "off");
     REQUIRE(conf.netNsMode == "on");
+    REQUIRE(conf.logLevel == "debug");
+    REQUIRE(conf.logFile == "on");
     REQUIRE(conf.pythonPreload == "on");
     REQUIRE(conf.captureStdout == "on");
     REQUIRE(conf.stateMode == "foobar");
@@ -126,6 +132,8 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     setEnvVar("FILESERVER_URL", fileserver);
     setEnvVar("CGROUP_MODE", cgMode);
     setEnvVar("NETNS_MODE", nsMode);
+    setEnvVar("LOG_LEVEL", logLevel);
+    setEnvVar("LOG_FILE", logFile);
     setEnvVar("PYTHON_PRELOAD", pythonPre);
     setEnvVar("CAPTURE_STDOUT", captureStdout);
     setEnvVar("STATE_MODE", stateMode);


### PR DESCRIPTION
In this PR I slightly modify the behaviour of the logging functions in `faabric` to make it more extensible and flexible. The changes are summarized below:

1. Instead of a default logger, there now is a map `<logger_name> -> <logger_shared_ptr>` containing all the different loggers.
2. They are all lazily initialised. I.e. created when first used.
3. To use a specific (or different) logger we just need to call the `faabric::util::getLogger` method with the logger's name as a parameter. Otherwise, it will resort to using the `default` logger.
4. I also introduce a new configuration flag `LOG_FILE` which if set turns on logging to a file at `/var/log/faabric/<logger_name>.log` with the log-level specified in `conf.logLevel`.

Note that there's no control on _how many_ loggers are created, and wrongly typing the logger name could produce unexpected results.

Closes #55 