### PR TITLE
Default functions to /usr/local/faasm

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -59,7 +59,7 @@ void SystemConfig::initialise()
       this->getSystemConfIntParam("CHAINED_CALL_TIMEOUT", "300000");
 
     // Filesystem storage
-    functionDir = getEnvVar("FUNC_DIR", "/usr/local/code/faasm/wasm");
+    functionDir = getEnvVar("FUNC_DIR", "/usr/local/faasm/wasm");
     objectFileDir = getEnvVar("OBJ_DIR", "/usr/local/faasm/object");
     runtimeFilesDir =
       getEnvVar("RUNTIME_FILES_DIR", "/usr/local/faasm/runtime_root");


### PR DESCRIPTION
We want to remove all references to `/usr/local/code/faasm` eventually, and this enables us to connect everything under `/usr/local/faasm`.

The config is tightly coupled to Faasm, so really shouldn't be in this repo but we'll change that once the current iteration on the dev environment is done.