### PR TITLE
Fix in the `MPI_MIN` operator when running a reduce

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -674,7 +674,9 @@ void MpiWorld::reduce(int sendRank,
         // like the minimum, or product.
         // If we're receiving from ourselves and in-place, our work is
         // already done and the results are written in the recv buffer
-        memcpy(recvBuffer, sendBuffer, bufferSize);
+        if (!isInPlace) {
+            memcpy(recvBuffer, sendBuffer, bufferSize);
+        }
 
         uint8_t* rankData = new uint8_t[bufferSize];
         for (int r = 0; r < size; r++) {

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -666,7 +666,6 @@ void MpiWorld::reduce(int sendRank,
 
         size_t bufferSize = datatype->size * count;
 
-        // Zero the receive buffer if we're not operating in-place
         bool isInPlace = sendBuffer == recvBuffer;
 
         // If not receiving in-place, initialize the receive buffer to the send

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -9,8 +9,6 @@
 #include <faabric/util/macros.h>
 #include <faabric/util/timing.h>
 
-#include <limits>
-
 namespace faabric::scheduler {
 MpiWorld::MpiWorld()
   : id(-1)

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -1087,6 +1087,24 @@ TEST_CASE("Test reduce", "[mpi]")
             doReduceTest<int>(
               world, root, MPI_MAX, MPI_INT, rankData, expected);
         }
+
+        SECTION("Min operator")
+        {
+            // Initialize rankData to non-zero values. This catches faulty
+            // reduce implementations that always return zero
+            for (int r = 0; r < thisWorldSize; r++) {
+                rankData[r][0] = (r + 1);
+                rankData[r][1] = (r + 1) * 10;
+                rankData[r][2] = (r + 1) * 100;
+            }
+
+            expected[0] = 1;
+            expected[1] = 10;
+            expected[2] = 100;
+
+            doReduceTest<int>(
+              world, root, MPI_MIN, MPI_INT, rankData, expected);
+        }
     }
 
     SECTION("Doubles")
@@ -1122,6 +1140,62 @@ TEST_CASE("Test reduce", "[mpi]")
 
             doReduceTest<double>(
               world, root, MPI_MAX, MPI_DOUBLE, rankData, expected);
+        }
+
+        SECTION("Min operator")
+        {
+            expected[0] = 2.5;
+            expected[1] = 25.0;
+            expected[2] = 250.0;
+
+            doReduceTest<double>(
+              world, root, MPI_MIN, MPI_DOUBLE, rankData, expected);
+        }
+    }
+
+    SECTION("Long long")
+    {
+        std::vector<std::vector<long long>> rankData(thisWorldSize,
+                                                     std::vector<long long>(3));
+        std::vector<long long> expected(3, 0);
+
+        // Prepare rank data
+        for (int r = 0; r < thisWorldSize; r++) {
+            rankData[r][0] = (r + 1);
+            rankData[r][1] = (r + 1) * 10;
+            rankData[r][2] = (r + 1) * 100;
+        }
+
+        SECTION("Sum operator")
+        {
+            for (int r = 0; r < thisWorldSize; r++) {
+                expected[0] += rankData[r][0];
+                expected[1] += rankData[r][1];
+                expected[2] += rankData[r][2];
+            }
+
+            doReduceTest<long long>(
+              world, root, MPI_SUM, MPI_DOUBLE, rankData, expected);
+        }
+
+        SECTION("Max operator")
+        {
+            expected[0] = thisWorldSize;
+            expected[1] = thisWorldSize * 10;
+            expected[2] = thisWorldSize * 100;
+
+            doReduceTest<long long>(
+              world, root, MPI_MAX, MPI_DOUBLE, rankData, expected);
+        }
+
+        SECTION("Min operator")
+        {
+            expected[0] = 1;
+            expected[1] = 10;
+            expected[2] = 100;
+
+            doReduceTest<long long>(
+              world, root, MPI_MIN, MPI_DOUBLE, rankData, expected);
         }
     }
 }


### PR DESCRIPTION
When runing a `reduce` with the `MPI_MIN` operator, if `sendRank == recvRank` yet `not isInPlace`, we did (simplified):
```cpp
// rankData  stores the received data, if sendRank != recvRank we'd call recv()
uint8_t* rankData = sendBuffer;
memset(recvBuffer, 0, bufferSize);

op_reduce(FAABRIC_OP_MIN, recvBuffer, rankData);
```

As `recvBuffer` is filled with `0`s, these will override the minimum, obtaining incorrect results. I extend the tests to consider this case as well.

Related to faasm/experiment-lammps#8