### PR TITLE
Fix cartesian topology implementation

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -52,6 +52,12 @@ class MpiWorld
 
     void getRankFromCoords(int* rank, int* coords);
 
+    void shiftCartesianCoords(int rank,
+                              int direction,
+                              int disp,
+                              int* source,
+                              int* destination);
+
     void send(int sendRank,
               int recvRank,
               const uint8_t* buffer,

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -44,7 +44,11 @@ class MpiWorld
 
     void enqueueMessage(faabric::MPIMessage& msg);
 
-    void getCartesianRank(int rank, int* dims, int* periods, int* coords);
+    void getCartesianRank(int rank,
+                          int maxDims,
+                          const int* dims,
+                          int* periods,
+                          int* coords);
 
     void getRankFromCoords(int* rank, int* coords);
 
@@ -213,6 +217,8 @@ class MpiWorld
     std::unordered_map<std::string, std::shared_ptr<InMemoryMpiQueue>>
       localQueueMap;
     std::unordered_map<int, std::thread> asyncThreadMap;
+
+    std::vector<int> cartProcsPerDim;
 
     void setUpStateKV();
 

--- a/src/mpi_native/mpi_native.cpp
+++ b/src/mpi_native/mpi_native.cpp
@@ -465,7 +465,7 @@ int MPI_Cart_get(MPI_Comm comm,
 {
     getMpiLogger()->debug("MPI_Cart_get");
     getExecutingWorld().getCartesianRank(
-      executingContext.getRank(), dims, periods, coords);
+      executingContext.getRank(), maxdims, dims, periods, coords);
 
     return MPI_SUCCESS;
 }

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -216,7 +216,7 @@ void MpiWorld::getCartesianRank(int rank,
     periods[0] = 1;
     periods[1] = 1;
 
-    // The remaining dimensions should be 1, and so the coordinate of our rank
+    // The remaining dimensions should be 1, and the coordinate of our rank 0
     for (int i = 2; i < maxDims; i++) {
         if (dims[i] != 1) {
             throw std::runtime_error(

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -202,21 +202,19 @@ void MpiWorld::getCartesianRank(int rank,
     // vector.
     // Note that we could only store one of the two, and derive the other
     // from the world size.
-    cartProcsPerDim[0] = dims[0];
-    cartProcsPerDim[1] = dims[1];
+    this->cartProcsPerDim[0] = dims[0];
+    this->cartProcsPerDim[1] = dims[1];
 
     // Compute the coordinates in a 2-dim grid of the original process rank.
     // As input we have a vector containing the number of processes per
     // dimension (dims).
     // We have dims[0] x dims[1] = N slots, thus:
-    // - The row is rank % dim
-    // - The column is rank / dim
-    coords[0] = rank % dims[0];
-    coords[1] = rank / dims[0];
+    coords[0] = rank / dims[1];
+    coords[1] = rank % dims[1];
 
-    // We don't support periodic grids, so we set periods to 0
-    periods[0] = 0;
-    periods[1] = 0;
+    // LAMMPS always uses periodic grids. So do we.
+    periods[0] = 1;
+    periods[1] = 1;
 
     // The remaining dimensions should be 1, and so the coordinate of our rank
     for (int i = 2; i < maxDims; i++) {
@@ -228,26 +226,10 @@ void MpiWorld::getCartesianRank(int rank,
                           dims[i]));
         }
         coords[i] = 0;
-        periods[i] = 0;
+        periods[i] = 1;
     }
-    /*
-    int sideLength = static_cast<int>(std::floor(std::sqrt(this->size)));
-    int nprocs = sideLength * sideLength;
-    if (rank >= nprocs) {
-        for (int i = 0; i < MPI_CART_MAX_DIMENSIONS; i++) {
-            dims[i] = sideLength;
-            periods[i] = 0;
-            coords[i] = MPI_UNDEFINED;
-        }
-    } else {
-        for (int i = 0; i < MPI_CART_MAX_DIMENSIONS; i++) {
-            nprocs /= sideLength;
-            dims[i] = sideLength;
-            periods[i] = 0;
-            coords[i] = rank / nprocs;
-            rank %= nprocs;
-        }
-    }*/
+
+    // Sanity check before returning. Check that no rank exceeds the dimensions
 }
 
 void MpiWorld::getRankFromCoords(int* rank, int* coords)
@@ -256,31 +238,66 @@ void MpiWorld::getRankFromCoords(int* rank, int* coords)
     // cartProcsPerDim[0] and cartProcsPerDim[1] processes respectively.
 
     // Pre-requisite: cartProcsPerDim[0] * cartProcsPerDim[1] == nprocs
-    if ((cartProcsPerDim[0] * cartProcsPerDim[1]) != this->size) {
+    if ((this->cartProcsPerDim[0] * this->cartProcsPerDim[1]) != this->size) {
         throw std::runtime_error(fmt::format(
           "Processors per dimension don't match world size: {} x {} != {}",
-          cartProcsPerDim[0],
-          cartProcsPerDim[1],
+          this->cartProcsPerDim[0],
+          this->cartProcsPerDim[1],
           this->size));
     }
 
     // This is the inverse of finding the coordinates for a rank
-    *rank = coords[0] + coords[1] * cartProcsPerDim[0];
-    /*
-    int sideLength = static_cast<int>(std::floor(std::sqrt(this->size)));
-    int prank = 0;
-    int factor = 1;
+    *rank = coords[1] + coords[0] * cartProcsPerDim[1];
+}
 
-    for (int i = MPI_CART_MAX_DIMENSIONS - 1; i >= 0; --i) {
-        if (coords[i] == MPI_UNDEFINED) {
-            throw std::runtime_error(
-              "Cartesian rank with undefined coordinates.");
-        }
-        prank += factor * (coords[i] % sideLength);
-        factor *= sideLength;
+void MpiWorld::shiftCartesianCoords(int rank,
+                                    int direction,
+                                    int disp,
+                                    int* source,
+                                    int* destination)
+{
+    // rank: is the process the method is being called from (i.e. me)
+    // source: the rank that reaches me moving <disp> units in <direction>
+    // destination: is the rank I reach moving <disp> units in <direction>
+
+    // Get the coordinates for my rank
+    std::vector<int> coords = { rank / cartProcsPerDim[1],
+                                rank % cartProcsPerDim[1] };
+
+    // Move <disp> units in <direction> forward with periodicity
+    // Note: we always use periodicity and 2 dimensions because LAMMMPS does.
+    std::vector<int> dispCoordsFwd;
+    if (direction == 0) {
+        dispCoordsFwd = { (coords[0] + disp) % cartProcsPerDim[0], coords[1] };
+    } else if (direction == 1) {
+        dispCoordsFwd = { coords[0], (coords[1] + disp) % cartProcsPerDim[1] };
+    } else {
+        dispCoordsFwd = { coords[0], coords[1] };
     }
-    *rank = prank;
-    */
+    // If direction >=2 we are in a dimension we don't use, hence we are the
+    // only process, and we always land in our coordinates (due to periodicity)
+
+    // Fill the destination variable
+    getRankFromCoords(destination, dispCoordsFwd.data());
+
+    // Move <disp> units in <direction> backwards with periodicity
+    // Note: as subtracting may yield a negative result, we add a full loop
+    // to prevent taking the modulo of a negative value.
+    std::vector<int> dispCoordsBwd;
+    if (direction == 0) {
+        dispCoordsBwd = { (coords[0] - disp + cartProcsPerDim[0]) %
+                            cartProcsPerDim[0],
+                          coords[1] };
+    } else if (direction == 1) {
+        dispCoordsBwd = { coords[0],
+                          (coords[1] - disp + cartProcsPerDim[1]) %
+                            cartProcsPerDim[1] };
+    } else {
+        dispCoordsBwd = { coords[0], coords[1] };
+    }
+
+    // Fill the source variable
+    getRankFromCoords(source, dispCoordsBwd.data());
 }
 
 int MpiWorld::isend(int sendRank,

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -228,8 +228,6 @@ void MpiWorld::getCartesianRank(int rank,
         coords[i] = 0;
         periods[i] = 1;
     }
-
-    // Sanity check before returning. Check that no rank exceeds the dimensions
 }
 
 void MpiWorld::getRankFromCoords(int* rank, int* coords)

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -227,7 +227,7 @@ void MpiWorld::getCartesianRank(int rank,
                           i,
                           dims[i]));
         }
-        coords[i] = 1;
+        coords[i] = 0;
         periods[i] = 0;
     }
     /*

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -112,48 +112,94 @@ TEST_CASE("Test cartesian communicator", "[mpi]")
     cleanFaabric();
 
     faabric::Message msg = faabric::util::messageFactory(user, func);
-    // 5 processes create a 2x2 grid with one left MPI_UNDEFINED
-    msg.set_mpiworldsize(5);
+
+    int worldSize;
+    int maxDims = 3;
+    std::vector<int> dims(maxDims);
+    std::vector<int> periods(2, 1);
+    std::vector<std::vector<int>> expectedShift;
+    std::vector<std::vector<int>> expectedCoords;
+
+    // Different grid sizes
+    SECTION("5 x 1 grid")
+    {
+        // 5 processes create a 5x1 grid
+        worldSize = 5;
+        msg.set_mpiworldsize(worldSize);
+        dims = { 5, 1, 1 };
+        expectedCoords = {
+            { 0, 0, 0 }, { 1, 0, 0 }, { 2, 0, 0 }, { 3, 0, 0 }, { 4, 0, 0 },
+        };
+        // We only test for the first three dimensions
+        expectedShift = {
+            { 4, 1, 0, 0, 0, 0 }, { 0, 2, 1, 1, 1, 1 }, { 1, 3, 2, 2, 2, 2 },
+            { 2, 4, 3, 3, 3, 3 }, { 3, 0, 4, 4, 4, 4 },
+        };
+    }
+    SECTION("2 x 2 grid")
+    {
+        // 4 processes create a 2x2 grid
+        worldSize = 4;
+        msg.set_mpiworldsize(worldSize);
+        dims = { 2, 2, 1 };
+        expectedCoords = {
+            { 0, 0, 0 },
+            { 0, 1, 0 },
+            { 1, 0, 0 },
+            { 1, 1, 0 },
+        };
+        // We only test for the first three dimensions
+        expectedShift = {
+            { 2, 2, 1, 1, 0, 0 },
+            { 3, 3, 0, 0, 1, 1 },
+            { 0, 0, 3, 3, 2, 2 },
+            { 1, 1, 2, 2, 3, 3 },
+        };
+    }
+
     MpiWorld& world =
       getMpiWorldRegistry().createWorld(msg, worldId, LOCALHOST);
 
-    std::vector<int> dims(2, -1);
-    std::vector<int> periods(2, 0);
-    std::vector<int> coords(2, -1);
-
-    SECTION("Create cartesian coordinates")
-    {
-        // Check it works well for a rank within the grid
-        for (int i = 0; i < 4; i++) {
-            std::vector<int> required = { i / 2, i % 2 };
-            world.getCartesianRank(
-              i, dims.data(), periods.data(), coords.data());
-            REQUIRE(required == coords);
-        }
-
-        // Or MPI_UNDEFINED otherwise
-        std::vector<int> required = { MPI_UNDEFINED, MPI_UNDEFINED };
-        world.getCartesianRank(4, dims.data(), periods.data(), coords.data());
-        REQUIRE(required == coords);
+    // Get coordinates from rank
+    for (int i = 0; i < worldSize; i++) {
+        std::vector<int> coords(3, -1);
+        world.getCartesianRank(
+          i, maxDims, dims.data(), periods.data(), coords.data());
+        REQUIRE(expectedCoords[i] == coords);
     }
 
-    SECTION("Get rank from cartesian coordinates")
-    {
-        // Check it works for defined processes
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                std::vector<int> coords = { i, j };
-                int rank;
-                int expected = i * 2 + j;
-                world.getRankFromCoords(&rank, coords.data());
-                REQUIRE(rank == expected);
-            }
+    // Get rank from coordinates
+    for (int i = 0; i < dims[0]; i++) {
+        for (int j = 0; j < dims[1]; j++) {
+            int rank;
+            std::vector<int> coords = { i, j, 0 };
+            int expected =
+              std::find(expectedCoords.begin(), expectedCoords.end(), coords) -
+              expectedCoords.begin();
+            world.getRankFromCoords(&rank, coords.data());
+            REQUIRE(rank == expected);
         }
+    }
 
-        // Check it throws exception if MPI_UNDEFINED
-        std::vector<int> coords = { MPI_UNDEFINED, MPI_UNDEFINED };
-        int rank;
-        REQUIRE_THROWS(world.getRankFromCoords(&rank, coords.data()));
+    // Shift coordinates one unit along each axis
+    for (int i = 0; i < dims[0]; i++) {
+        for (int j = 0; j < dims[1]; j++) {
+            std::vector<int> coords = { i, j, 0 };
+            int rank, src, dst;
+            world.getRankFromCoords(&rank, coords.data());
+            // Test first dimension
+            world.shiftCartesianCoords(rank, 0, 1, &src, &dst);
+            REQUIRE(src == expectedShift[rank][0]);
+            REQUIRE(dst == expectedShift[rank][1]);
+            // Test second dimension
+            world.shiftCartesianCoords(rank, 1, 1, &src, &dst);
+            REQUIRE(src == expectedShift[rank][2]);
+            REQUIRE(dst == expectedShift[rank][3]);
+            // Test third dimension
+            world.shiftCartesianCoords(rank, 2, 1, &src, &dst);
+            REQUIRE(src == expectedShift[rank][4]);
+            REQUIRE(dst == expectedShift[rank][5]);
+        }
     }
 }
 

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -737,8 +737,9 @@ TEST_CASE("Test collective messaging locally and across hosts", "[mpi]")
 
         // Check the host that the root is on
         for (int rank : remoteWorldRanks) {
-            if (rank == remoteRankB)
+            if (rank == remoteRankB) {
                 continue;
+            }
 
             std::vector<int> actual(3, -1);
             remoteWorld.recv(
@@ -870,8 +871,9 @@ TEST_CASE("Test collective messaging locally and across hosts", "[mpi]")
             }
 
             for (int rank : localWorldRanks) {
-                if (rank == root)
+                if (rank == root) {
                     continue;
+                }
                 localWorld.gather(rank,
                                   root,
                                   BYTES(rankData[rank].data()),
@@ -1000,8 +1002,9 @@ void doReduceTest(scheduler::MpiWorld& world,
     // ---- Reduce ----
     // Call on all but the root first
     for (int r = 0; r < thisWorldSize; r++) {
-        if (r == root)
+        if (r == root) {
             continue;
+        }
         world.reduce(
           r, root, BYTES(rankData[r].data()), nullptr, datatype, 3, op);
     }


### PR DESCRIPTION
In this PR I correct some erroneous behaviour I introduced when implementing the cartesian topology methods in MPI. In particular I correct (and clarify) the implementation of `MPI_Cart_get` and provide an implementation for `MPI_Cart_shift`. Note that in this PR there's only the `faabric`-related changes. A companion one for `faasm` will be ready once LAMMPS execution is flushed out. I also improve the tests for this functionality.

`MPI_Cart_get` calls `MpiWorld::getCartesianRank` which, given a triple of dimensions `i x j x 1` (3D-grid), returns the coordinates in said grid of the caller rank. The grid is filled left to right, top to bottom (in this order).

`MPI_Cart_shift` calls `MpiWorld::shiftCartesianCoords` and returns, for the caller rank:
* The rank it would land if moving `disp` units along a `direction`.
* The rank that would land on it by moving `disp` units along a `direction`.

It's a bit of a tong-twister, but hopefuly the comments help understanding the code. It's easy to make mistakes with symbols, so I've taken care to add a couple of test cases, and have it be easily extensible (to include more test cases were it to be necessary).

Related to faasm/experiment-lammps#8