### PR TITLE
Allow overriding /usr/local/faasm

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -50,13 +50,12 @@ void SystemConfig::initialise()
       this->getSystemConfIntParam("CHAINED_CALL_TIMEOUT", "300000");
 
     // Filesystem storage
-    functionDir = getEnvVar("FUNC_DIR", "/usr/local/faasm/wasm");
-    objectFileDir = getEnvVar("OBJ_DIR", "/usr/local/faasm/object");
-    runtimeFilesDir =
-      getEnvVar("RUNTIME_FILES_DIR", "/usr/local/faasm/runtime_root");
-    sharedFilesDir = getEnvVar("SHARED_FILES_DIR", "/usr/local/faasm/shared");
-    sharedFilesStorageDir =
-      getEnvVar("SHARED_FILES_STORAGE_DIR", "/usr/local/faasm/shared_store");
+    std::string faasmLocalDir = getEnvVar("FAASM_LOCAL_DIR", "/usr/local/faasm");
+    functionDir = fmt::format("{}/{}", faasmLocalDir, "wasm");
+    objectFileDir = fmt::format("{}/{}", faasmLocalDir, "object");
+    runtimeFilesDir = fmt::format("{}/{}", faasmLocalDir, "runtime_root");
+    sharedFilesDir = fmt::format("{}/{}", faasmLocalDir, "shared");
+    sharedFilesStorageDir = fmt::format("{}/{}", faasmLocalDir, "shared_store");
 
     // MPI
     defaultMpiWorldSize =

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -50,7 +50,8 @@ void SystemConfig::initialise()
       this->getSystemConfIntParam("CHAINED_CALL_TIMEOUT", "300000");
 
     // Filesystem storage
-    std::string faasmLocalDir = getEnvVar("FAASM_LOCAL_DIR", "/usr/local/faasm");
+    std::string faasmLocalDir =
+      getEnvVar("FAASM_LOCAL_DIR", "/usr/local/faasm");
     functionDir = fmt::format("{}/{}", faasmLocalDir, "wasm");
     objectFileDir = fmt::format("{}/{}", faasmLocalDir, "object");
     runtimeFilesDir = fmt::format("{}/{}", faasmLocalDir, "runtime_root");

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -64,12 +64,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     std::string unboundTimeout = setEnvVar("UNBOUND_TIMEOUT", "5555");
     std::string chainedTimeout = setEnvVar("CHAINED_CALL_TIMEOUT", "9999");
 
-    std::string funcDir = setEnvVar("FUNC_DIR", "/tmp/foo");
-    std::string objDir = setEnvVar("OBJ_DIR", "/tmp/bar");
-    std::string runtimeDir = setEnvVar("RUNTIME_FILES_DIR", "/tmp/rara");
-    std::string sharedDir = setEnvVar("SHARED_FILES_DIR", "/tmp/sss");
-    std::string sharedStorageDir =
-      setEnvVar("SHARED_FILES_STORAGE_DIR", "/tmp/sss_store");
+    std::string faasmLocalDir = setEnvVar("FAASM_LOCAL_DIR", "/tmp/blah");
 
     std::string mpiSize = setEnvVar("DEFAULT_MPI_WORLD_SIZE", "2468");
 
@@ -99,11 +94,11 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     REQUIRE(conf.unboundTimeout == 5555);
     REQUIRE(conf.chainedCallTimeout == 9999);
 
-    REQUIRE(conf.functionDir == "/tmp/foo");
-    REQUIRE(conf.objectFileDir == "/tmp/bar");
-    REQUIRE(conf.runtimeFilesDir == "/tmp/rara");
-    REQUIRE(conf.sharedFilesDir == "/tmp/sss");
-    REQUIRE(conf.sharedFilesStorageDir == "/tmp/sss_store");
+    REQUIRE(conf.functionDir == "/tmp/blah/wasm");
+    REQUIRE(conf.objectFileDir == "/tmp/blah/object");
+    REQUIRE(conf.runtimeFilesDir == "/tmp/blah/runtime_root");
+    REQUIRE(conf.sharedFilesDir == "/tmp/blah/shared");
+    REQUIRE(conf.sharedFilesStorageDir == "/tmp/blah/shared_store");
 
     REQUIRE(conf.defaultMpiWorldSize == 2468);
 
@@ -132,11 +127,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     setEnvVar("UNBOUND_TIMEOUT", unboundTimeout);
     setEnvVar("CHAINED_CALL_TIMEOUT", chainedTimeout);
 
-    setEnvVar("FUNC_DIR", funcDir);
-    setEnvVar("OBJ_DIR", objDir);
-    setEnvVar("RUNTIME_FILES_DIR", runtimeDir);
-    setEnvVar("SHARED_FILES_DIR", sharedDir);
-    setEnvVar("SHARED_FILES_STORAGE_DIR", sharedStorageDir);
+    setEnvVar("FAASM_LOCAL_DIR", faasmLocalDir);
 
     setEnvVar("DEFAULT_MPI_WORLD_SIZE", mpiSize);
 }


### PR DESCRIPTION
As with a lot of the Faabric config object, the details are tightly coupled to Faasm, and will be split out once we get round to it.