### PR TITLE
MPI Async Fixes

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -231,15 +231,6 @@ class MpiWorld
 
     void checkRankOnThisHost(int rank);
 
-    int doISendRecv(int sendRank,
-                    int recvRank,
-                    const uint8_t* sendBuffer,
-                    uint8_t* recvBuffer,
-                    faabric_datatype_t* dataType,
-                    int count,
-                    faabric::MPIMessage::MPIMessageType messageType =
-                      faabric::MPIMessage::NORMAL);
-
     void pushToState();
 };
 }

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -222,7 +222,6 @@ class MpiWorld
 
     std::unordered_map<std::string, std::shared_ptr<InMemoryMpiQueue>>
       localQueueMap;
-    std::unordered_map<int, std::thread> asyncThreadMap;
 
     std::vector<int> cartProcsPerDim;
 

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -98,7 +98,7 @@ class MpiWorld
               faabric::MPIMessage::MPIMessageType messageType =
                 faabric::MPIMessage::NORMAL);
 
-    void awaitAsyncRequest(int requestId);
+    void awaitAsyncRequest(int requestId, int myRank);
 
     void sendRecv(uint8_t* sendBuffer,
                   int sendcount,

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -98,7 +98,7 @@ class MpiWorld
               faabric::MPIMessage::MPIMessageType messageType =
                 faabric::MPIMessage::NORMAL);
 
-    void awaitAsyncRequest(int requestId, int myRank);
+    void awaitAsyncRequest(int requestId);
 
     void sendRecv(uint8_t* sendBuffer,
                   int sendcount,

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -346,6 +346,10 @@ int MpiWorld::doISendRecv(int sendRank,
           }
       }));
 
+    if (asyncThreadMap.count(requestId) == 0) {
+        std::cout << "WAT " << requestId << std::endl;
+    }
+
     return requestId;
 }
 
@@ -712,6 +716,29 @@ void MpiWorld::awaitAsyncRequest(int requestId)
 {
     faabric::util::getLogger()->trace("MPI - await {}", requestId);
 
+    /*
+    if (asyncThreadMap.count(requestId) == 0) {
+        auto it = asyncThreadMap.begin();
+        for (; it != asyncThreadMap.end(); it++) {
+            if (it->first == requestId) {
+                std::cout << "Key is indeed here: " << it->first << std::endl;
+                if (asyncThreadMap.find(requestId) == asyncThreadMap.end()) {
+                    std::cout << "Find == end " << std::endl;
+                }
+                if (it->second.joinable()) {
+                    std::cout << "Thread is joinable!" << std::endl;
+                    it->second.join();
+                    break;
+                }
+            }
+        }
+        if (it == asyncThreadMap.end()) {
+            std::cout << "Key really is not there: " << requestId << std::endl;
+            throw std::runtime_error(
+              "Attempting to await unrecognised async request: " +
+              std::to_string(requestId));
+        }
+    }*/
     if (asyncThreadMap.count(requestId) == 0) {
         throw std::runtime_error(
           "Attempting to await unrecognised async request: " +
@@ -722,6 +749,8 @@ void MpiWorld::awaitAsyncRequest(int requestId)
     std::thread& t = asyncThreadMap[requestId];
     if (t.joinable()) {
         t.join();
+    } else {
+        std::cout << "WAT: Not joinable?" << std::endl;
     }
 }
 


### PR DESCRIPTION
This PR solves a bug in the asynchronous API. As always it is a one-liner that ends up making it work, but I've polished some things in the process.

The main problem was that a shared data structure `asyncThreadMap` was concurrently edited by different threads. However, there really was no need to, as each thread R/W to different keys. Making the structure `thread_local` solved the issue.

Further, I've removed the `doISendRecv` method and provided separate implementations for `irecv` and `isend`, plus some small optimizations on the map usage.

Now LAMMPS' execution finishes. It does not scale at all and still sometimes randomly fails, but its quite robust and runs OK most of the times.

Closes faasm/experiment-lammps#8