### PR TITLE
Compose problems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,8 @@ jobs:
       redis:
         image: redis
     steps:
+      - name: "Compose version"
+        run: docker-compose --version
       # --- Code update ---
       - name: "Fetch ref"
         uses: actions/checkout@v2

--- a/mpi-native/mpi-native.env
+++ b/mpi-native/mpi-native.env
@@ -3,7 +3,7 @@ FAABRIC_MPI_NATIVE_IMAGE=faasm/faabric-mpi-native:0.0.18
 COMPOSE_PROJECT_NAME=faabric-mpi
 
 COMPOSE_FILE="./mpi-native/mpi-native-docker-compose.yml"
-ENV_FILE="mpi-native.env"
+ENV_FILE="./mpi-native/mpi-native.env"
 
 # Deployment-specific (MPI_EXAMPLE _must_ be the last line)
 MPI_WORLD_SIZE=5

--- a/mpi-native/run_all.sh
+++ b/mpi-native/run_all.sh
@@ -13,8 +13,8 @@ for w in $(ls ./mpi-native/examples/*.cpp);
 do
     example=$(basename $w ".cpp")
     if [[ $example == mpi_* ]]; then
-        sed -i '$ d' ./mpi-native/${ENV_FILE}
-        echo "MPI_EXAMPLE=${example}" >> ./mpi-native/${ENV_FILE}
+        sed -i '$ d' ${ENV_FILE}
+        echo "MPI_EXAMPLE=${example}" >> ${ENV_FILE}
         echo "----------------------------------------"
         echo "Running MPI native test:"
         echo "    - MPI_EXAMPLE ${example}"


### PR DESCRIPTION
The order is clearly specified [here](https://docs.docker.com/compose/env-file/):

> The project directory is specified by the order of precedence:
> * --project-directory flag
> * Folder of the first --file flag
> * Current directory

But has apparently been reverted [here](https://docs.docker.com/compose/release-notes/#1286), dated 23/3. Now:

> Bug fixes
> * Made --env-file relative to the current working directory. Environment file paths set with --env-file are now relative to the current working directory and override the default .env file located in the project directory.

This means, that it does not take into account the directory of the `--file` flag (so we must revert #58).

I add a check of the `docker-compose` version for future reference.