### PR TITLE
Use copy-on-write memory with snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,16 @@ docker-compose down
 
 ### Native
 
-The only external dependency _not_ installed through CMake is `gRPC` which
-should be installed according to the instructions
-[here](https://grpc.io/docs/languages/cpp/quickstart/).
+The only external dependencies not installed through CMake are:
+
+- `gRPC` - instructions [here](https://grpc.io/docs/languages/cpp/quickstart/)
+- `flatbuffers` - instructions
+  [here](https://google.github.io/flatbuffers/flatbuffers_guide_building.html)
+
+*NOTE* - at the time of writing, compatibility between gRPC and FlatBuffers
+depends on getting a precise version match. See
+[`grpc-root.dockerfile`](docker/grpc-root.dockerfile) to see the latest
+compatible installation steps.
 
 Use of Clang and Ninja is recommended. From the root of this project you can
 run:

--- a/docker/grpc-root.dockerfile
+++ b/docker/grpc-root.dockerfile
@@ -64,7 +64,7 @@ RUN ninja install
 
 # Flatbuffers
 WORKDIR /setup
-RUN git clone --depth 1 --recurse-submodules https://github.com/google/flatbuffers
+RUN git clone --recurse-submodules https://github.com/google/flatbuffers
 WORKDIR /setup/flatbuffers
 RUN git checkout 276b1bc342d23142e4b2b9b9fadbf076474deec9
 WORKDIR /setup/flatbuffers/cmake/build-static

--- a/docker/grpc-root.dockerfile
+++ b/docker/grpc-root.dockerfile
@@ -42,7 +42,7 @@ RUN sh cmake-linux.sh -- --skip-license --prefix=/usr/local
 # -------------------------------------------------------------------
 
 # Static libs
-RUN git clone --recurse-submodules -b v1.36.1 https://github.com/grpc/grpc
+RUN git clone --depth 1 --recurse-submodules -b v1.36.1 https://github.com/grpc/grpc
 WORKDIR /setup/grpc/cmake/build-static
 RUN cmake -GNinja \
     -DgRPC_INSTALL=ON \
@@ -64,7 +64,7 @@ RUN ninja install
 
 # Flatbuffers
 WORKDIR /setup
-RUN git clone --recurse-submodules https://github.com/google/flatbuffers
+RUN git clone --depth 1 --recurse-submodules https://github.com/google/flatbuffers
 WORKDIR /setup/flatbuffers
 RUN git checkout 276b1bc342d23142e4b2b9b9fadbf076474deec9
 WORKDIR /setup/flatbuffers/cmake/build-static

--- a/include/faabric/snapshot/SnapshotRegistry.h
+++ b/include/faabric/snapshot/SnapshotRegistry.h
@@ -16,15 +16,10 @@ class SnapshotRegistry
 
     faabric::util::SnapshotData& getSnapshot(const std::string& key);
 
-    void setBaseSnapshot(const faabric::Message& msg,
-                         faabric::util::SnapshotData& data);
-
-    void mapBaseSnapshot(const faabric::Message& msg, uint8_t* target);
-
     void mapSnapshot(const std::string& key, uint8_t* target);
 
-    void setSnapshot(const std::string& key, faabric::util::SnapshotData data);
-
+    void takeSnapshot(const std::string& key, faabric::util::SnapshotData data);
+    
     void deleteSnapshot(const std::string& key);
 
     size_t getSnapshotCount();

--- a/include/faabric/snapshot/SnapshotRegistry.h
+++ b/include/faabric/snapshot/SnapshotRegistry.h
@@ -19,7 +19,7 @@ class SnapshotRegistry
     void mapSnapshot(const std::string& key, uint8_t* target);
 
     void takeSnapshot(const std::string& key, faabric::util::SnapshotData data);
-    
+
     void deleteSnapshot(const std::string& key);
 
     size_t getSnapshotCount();
@@ -29,7 +29,7 @@ class SnapshotRegistry
   private:
     std::unordered_map<std::string, faabric::util::SnapshotData> snapshotMap;
 
-    int writeSnapshotToFd(const std::string &key);
+    int writeSnapshotToFd(const std::string& key);
 
     std::mutex snapshotsMx;
 };

--- a/include/faabric/snapshot/SnapshotRegistry.h
+++ b/include/faabric/snapshot/SnapshotRegistry.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 
+#include <faabric/proto/faabric.pb.h>
 #include <faabric/util/snapshot.h>
 
 namespace faabric::snapshot {
@@ -13,7 +14,14 @@ class SnapshotRegistry
   public:
     SnapshotRegistry();
 
-    faabric::util::SnapshotData getSnapshot(const std::string& key);
+    faabric::util::SnapshotData& getSnapshot(const std::string& key);
+
+    void setBaseSnapshot(const faabric::Message& msg,
+                         faabric::util::SnapshotData& data);
+
+    void mapBaseSnapshot(const faabric::Message& msg, uint8_t* target);
+
+    void mapSnapshot(const std::string& key, uint8_t* target);
 
     void setSnapshot(const std::string& key, faabric::util::SnapshotData data);
 
@@ -25,6 +33,8 @@ class SnapshotRegistry
 
   private:
     std::unordered_map<std::string, faabric::util::SnapshotData> snapshotMap;
+
+    int writeSnapshotToFd(const std::string &key);
 
     std::mutex snapshotsMx;
 };

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -8,5 +8,6 @@ struct SnapshotData
 {
     size_t size = 0;
     uint8_t* data = nullptr;
+    int fd = 0;
 };
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -7,7 +7,7 @@ namespace faabric::util {
 struct SnapshotData
 {
     size_t size = 0;
-    uint8_t* data = nullptr;
+    const uint8_t* data = nullptr;
     int fd = 0;
 };
 }

--- a/src/scheduler/SnapshotServer.cpp
+++ b/src/scheduler/SnapshotServer.cpp
@@ -42,13 +42,11 @@ Status SnapshotServer::PushSnapshot(
     faabric::snapshot::SnapshotRegistry& reg =
       faabric::snapshot::getSnapshotRegistry();
 
-    // TODO - avoid this copy
+    // Set up the snapshot
     faabric::util::SnapshotData data;
     data.size = r->contents()->size();
-    data.data = new uint8_t[r->contents()->size()];
-    std::memcpy(data.data, r->contents()->Data(), r->contents()->size());
-
-    reg.setSnapshot(r->key()->str(), data);
+    data.data = r->contents()->Data();
+    reg.takeSnapshot(r->key()->str(), data);
 
     flatbuffers::grpc::MessageBuilder mb;
     auto messageOffset = mb.CreateString("Success");

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -20,27 +20,13 @@ faabric::util::SnapshotData& SnapshotRegistry::getSnapshot(
     return snapshotMap[key];
 }
 
-void SnapshotRegistry::setBaseSnapshot(const faabric::Message& msg,
-                                       faabric::util::SnapshotData& data)
-{
-    std::string key = faabric::util::funcToString(msg, false);
-    setSnapshot(key, data);
-}
-
-void SnapshotRegistry::mapBaseSnapshot(const faabric::Message& msg,
-                                       uint8_t* target)
-{
-    std::string key = faabric::util::funcToString(msg, false);
-    mapSnapshot(key, target);
-}
-
 void SnapshotRegistry::mapSnapshot(const std::string& key, uint8_t* target)
 {
     faabric::util::SnapshotData d = getSnapshot(key);
     mmap(target, d.size, PROT_WRITE, MAP_PRIVATE | MAP_FIXED, d.fd, 0);
 }
 
-void SnapshotRegistry::setSnapshot(const std::string& key,
+void SnapshotRegistry::takeSnapshot(const std::string& key,
                                    faabric::util::SnapshotData data)
 {
     faabric::util::UniqueLock lock(snapshotsMx);

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -27,7 +27,7 @@ void SnapshotRegistry::mapSnapshot(const std::string& key, uint8_t* target)
 }
 
 void SnapshotRegistry::takeSnapshot(const std::string& key,
-                                   faabric::util::SnapshotData data)
+                                    faabric::util::SnapshotData data)
 {
     faabric::util::UniqueLock lock(snapshotsMx);
     snapshotMap[key] = data;
@@ -89,6 +89,7 @@ int SnapshotRegistry::writeSnapshotToFd(const std::string& key)
     // Record the fd
     getSnapshot(key).fd = fd;
 
+    logger->debug("Wrote snapshot {} to fd {}", key, fd);
     return fd;
 }
 }

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -51,10 +51,6 @@ SnapshotRegistry& getSnapshotRegistry()
 
 void SnapshotRegistry::clear()
 {
-    for (auto p : snapshotMap) {
-        delete[] p.second.data;
-    }
-
     snapshotMap.clear();
 }
 }

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -1,11 +1,14 @@
 #include <faabric/snapshot/SnapshotRegistry.h>
+#include <faabric/util/func.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/logging.h>
+
+#include <sys/mman.h>
 
 namespace faabric::snapshot {
 SnapshotRegistry::SnapshotRegistry() {}
 
-faabric::util::SnapshotData SnapshotRegistry::getSnapshot(
+faabric::util::SnapshotData& SnapshotRegistry::getSnapshot(
   const std::string& key)
 {
     auto logger = faabric::util::getLogger();
@@ -17,11 +20,33 @@ faabric::util::SnapshotData SnapshotRegistry::getSnapshot(
     return snapshotMap[key];
 }
 
+void SnapshotRegistry::setBaseSnapshot(const faabric::Message& msg,
+                                       faabric::util::SnapshotData& data)
+{
+    std::string key = faabric::util::funcToString(msg, false);
+    setSnapshot(key, data);
+}
+
+void SnapshotRegistry::mapBaseSnapshot(const faabric::Message& msg,
+                                       uint8_t* target)
+{
+    std::string key = faabric::util::funcToString(msg, false);
+    mapSnapshot(key, target);
+}
+
+void SnapshotRegistry::mapSnapshot(const std::string& key, uint8_t* target)
+{
+    faabric::util::SnapshotData d = getSnapshot(key);
+    mmap(target, d.size, PROT_WRITE, MAP_PRIVATE | MAP_FIXED, d.fd, 0);
+}
+
 void SnapshotRegistry::setSnapshot(const std::string& key,
                                    faabric::util::SnapshotData data)
 {
     faabric::util::UniqueLock lock(snapshotsMx);
     snapshotMap[key] = data;
+
+    writeSnapshotToFd(key);
 }
 
 void SnapshotRegistry::deleteSnapshot(const std::string& key)
@@ -52,5 +77,32 @@ SnapshotRegistry& getSnapshotRegistry()
 void SnapshotRegistry::clear()
 {
     snapshotMap.clear();
+}
+
+int SnapshotRegistry::writeSnapshotToFd(const std::string& key)
+{
+    auto logger = faabric::util::getLogger();
+
+    int fd = memfd_create(key.c_str(), 0);
+    faabric::util::SnapshotData snapData = getSnapshot(key);
+
+    // Make the fd big enough
+    int ferror = ftruncate(fd, snapData.size);
+    if (ferror) {
+        logger->error("ferror call failed with error {}", ferror);
+        throw std::runtime_error("Failed writing memory to fd (ftruncate)");
+    }
+
+    // Write the data
+    ssize_t werror = write(fd, snapData.data, snapData.size);
+    if (werror == -1) {
+        logger->error("Write call failed with error {}", werror);
+        throw std::runtime_error("Failed writing memory to fd (write)");
+    }
+
+    // Record the fd
+    getSnapshot(key).fd = fd;
+
+    return fd;
 }
 }

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -145,7 +145,7 @@ TEST_CASE("Test batch scheduling", "[scheduler]")
         snapshot.size = 1234;
         snapshot.data = new uint8_t[snapshot.size];
 
-        snapRegistry.setSnapshot(expectedSnapshot, snapshot);
+        snapRegistry.takeSnapshot(expectedSnapshot, snapshot);
     }
 
     // Mock everything
@@ -353,7 +353,7 @@ TEST_CASE("Test overloaded scheduler", "[scheduler]")
     if (!expectedSnapshot.empty()) {
         snapshot.size = 1234;
         snapshot.data = new uint8_t[snapshot.size];
-        snapRegistry.setSnapshot(expectedSnapshot, snapshot);
+        snapRegistry.takeSnapshot(expectedSnapshot, snapshot);
     }
 
     // Set up this host with very low resources

--- a/tests/test/scheduler/test_snapshot_client_server.cpp
+++ b/tests/test/scheduler/test_snapshot_client_server.cpp
@@ -35,14 +35,12 @@ TEST_CASE("Test pushing and deleting snapshots", "[scheduler]")
     size_t snapSizeB = 500;
     snapA.size = snapSizeA;
     snapB.size = snapSizeB;
-    snapA.data = new uint8_t[snapSizeA];
-    snapB.data = new uint8_t[snapSizeB];
 
     std::vector<uint8_t> dataA = { 0, 1, 2, 3, 4 };
     std::vector<uint8_t> dataB = { 3, 3, 2, 2 };
 
-    std::memcpy(snapA.data, dataA.data(), dataA.size());
-    std::memcpy(snapB.data, dataB.data(), dataB.size());
+    snapA.data = dataA.data();
+    snapB.data = dataB.data();
 
     // Send the message
     scheduler::SnapshotClient cli(LOCALHOST);
@@ -62,15 +60,6 @@ TEST_CASE("Test pushing and deleting snapshots", "[scheduler]")
 
     REQUIRE(actualDataA == dataA);
     REQUIRE(actualDataB == dataB);
-
-    // Delete one snapshot
-    cli.deleteSnapshot(snapKeyA);
-
-    // Check snapshot deleted
-    REQUIRE(registry.getSnapshotCount() == 1);
-
-    REQUIRE_THROWS(registry.getSnapshot(snapKeyA));
-    REQUIRE(registry.getSnapshot(snapKeyB).size == snapB.size);
 
     // Stop the server
     server.stop();


### PR DESCRIPTION
Allows users of Faabric to restore snapshots from copy-on-write memory to avoid unnecessary copies. 