### PR TITLE
Local and cross-host snapshot deletion

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -26,6 +26,9 @@ class Scheduler
     std::vector<std::string> callFunctions(faabric::BatchExecuteRequest& req,
                                            bool forceLocal = false);
 
+    void broadcastSnapshotDelete(const faabric::Message& msg,
+                                 const std::string& snapshotKey);
+
     void reset();
 
     void shutdown();

--- a/include/faabric/snapshot/SnapshotRegistry.h
+++ b/include/faabric/snapshot/SnapshotRegistry.h
@@ -18,7 +18,9 @@ class SnapshotRegistry
 
     void mapSnapshot(const std::string& key, uint8_t* target);
 
-    void takeSnapshot(const std::string& key, faabric::util::SnapshotData data);
+    void takeSnapshot(const std::string& key,
+                      faabric::util::SnapshotData data,
+                      bool locallyRestorable = true);
 
     void deleteSnapshot(const std::string& key);
 
@@ -29,9 +31,9 @@ class SnapshotRegistry
   private:
     std::unordered_map<std::string, faabric::util::SnapshotData> snapshotMap;
 
-    int writeSnapshotToFd(const std::string& key);
-
     std::mutex snapshotsMx;
+
+    int writeSnapshotToFd(const std::string& key);
 };
 
 SnapshotRegistry& getSnapshotRegistry();

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -430,6 +430,20 @@ std::vector<std::string> Scheduler::callFunctions(
     return executed;
 }
 
+void Scheduler::broadcastSnapshotDelete(const faabric::Message& msg,
+                                        const std::string& snapshotKey)
+{
+
+    std::string funcStr = faabric::util::funcToString(msg, false);
+    std::unordered_set<std::string>& thisRegisteredHosts =
+      registeredHosts[funcStr];
+
+    for (auto host : thisRegisteredHosts) {
+        SnapshotClient c(host);
+        c.deleteSnapshot(snapshotKey);
+    }
+}
+
 int Scheduler::scheduleFunctionsOnHost(const std::string& host,
                                        faabric::BatchExecuteRequest& req,
                                        std::vector<std::string>& records,

--- a/src/scheduler/SnapshotClient.cpp
+++ b/src/scheduler/SnapshotClient.cpp
@@ -82,7 +82,7 @@ void SnapshotClient::deleteSnapshot(const std::string& key)
     if (faabric::util::isMockMode()) {
         snapshotDeletes.emplace_back(host, key);
     } else {
-        logger->debug("Deleting snapshot {}", key);
+        logger->debug("Deleting snapshot {} from {}", key, host);
 
         ClientContext context;
 

--- a/src/scheduler/SnapshotServer.cpp
+++ b/src/scheduler/SnapshotServer.cpp
@@ -46,7 +46,7 @@ Status SnapshotServer::PushSnapshot(
     faabric::util::SnapshotData data;
     data.size = r->contents()->size();
     data.data = r->contents()->Data();
-    reg.takeSnapshot(r->key()->str(), data);
+    reg.takeSnapshot(r->key()->str(), data, true);
 
     flatbuffers::grpc::MessageBuilder mb;
     auto messageOffset = mb.CreateString("Success");

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -96,6 +96,12 @@ SnapshotRegistry& getSnapshotRegistry()
 
 void SnapshotRegistry::clear()
 {
+    for (auto p : snapshotMap) {
+        if (p.second.fd > 0) {
+            ::close(p.second.fd);
+        }
+    }
+
     snapshotMap.clear();
 }
 

--- a/tests/test/snapshot/test_snapshot_registry.cpp
+++ b/tests/test/snapshot/test_snapshot_registry.cpp
@@ -115,5 +115,4 @@ TEST_CASE("Test set and get snapshots", "[snapshot]")
     deallocatePages(dataC, 3);
     deallocatePages(actualDataC, 3);
 }
-:x
-:
+}

--- a/tests/test/snapshot/test_snapshot_registry.cpp
+++ b/tests/test/snapshot/test_snapshot_registry.cpp
@@ -1,0 +1,119 @@
+#include "faabric_utils.h"
+#include <catch.hpp>
+
+#include <sys/mman.h>
+
+#include <faabric/snapshot/SnapshotRegistry.h>
+#include <faabric/util/memory.h>
+
+using namespace faabric::snapshot;
+using namespace faabric::util;
+
+namespace tests {
+
+uint8_t* allocatePages(int nPages)
+{
+    return (uint8_t*)mmap(nullptr,
+                          nPages * HOST_PAGE_SIZE,
+                          PROT_WRITE,
+                          MAP_SHARED | MAP_ANONYMOUS,
+                          -1,
+                          0);
+}
+void deallocatePages(uint8_t* base, int nPages)
+{
+    munmap(base, nPages * HOST_PAGE_SIZE);
+}
+
+TEST_CASE("Test set and get snapshots", "[snapshot]")
+{
+    cleanFaabric();
+
+    SnapshotRegistry& reg = getSnapshotRegistry();
+
+    REQUIRE(reg.getSnapshotCount() == 0);
+
+    SnapshotData snapA;
+    SnapshotData snapB;
+    SnapshotData snapC;
+
+    // Snapshot have to be page-aligned
+    uint8_t* dataA = allocatePages(1);
+    uint8_t* dataB = allocatePages(2);
+    uint8_t* dataC = allocatePages(3);
+
+    // Add some random bits of data to the vectors
+    for (int i = 0; i < HOST_PAGE_SIZE - 10; i += 50) {
+        dataA[i] = i;
+        dataB[i + 1] = i;
+        dataC[i + 2] = i;
+    }
+
+    snapA.size = HOST_PAGE_SIZE;
+    snapA.data = dataA;
+
+    snapB.size = HOST_PAGE_SIZE;
+    snapB.data = dataB;
+
+    snapC.size = HOST_PAGE_SIZE;
+    snapC.data = dataC;
+
+    std::string keyA = "snapA";
+    std::string keyB = "snapB";
+    std::string keyC = "snapC";
+
+    reg.takeSnapshot(keyA, snapA);
+    reg.takeSnapshot(keyB, snapB, false);
+    reg.takeSnapshot(keyC, snapC);
+
+    REQUIRE(reg.getSnapshotCount() == 3);
+
+    SnapshotData actualA = reg.getSnapshot(keyA);
+    SnapshotData actualB = reg.getSnapshot(keyB);
+    SnapshotData actualC = reg.getSnapshot(keyC);
+
+    REQUIRE(actualA.size == snapA.size);
+    REQUIRE(actualB.size == snapB.size);
+    REQUIRE(actualC.size == snapC.size);
+
+    // Pointer equality here is good enough
+    REQUIRE(actualA.data == snapA.data);
+    REQUIRE(actualB.data == snapB.data);
+    REQUIRE(actualC.data == snapC.data);
+
+    REQUIRE(actualA.fd > 0);
+    REQUIRE(actualB.fd == 0);
+    REQUIRE(actualC.fd > 0);
+
+    // Create regions onto which we will map the snapshots
+    uint8_t* actualDataA = allocatePages(1);
+    uint8_t* actualDataB = allocatePages(2);
+    uint8_t* actualDataC = allocatePages(3);
+
+    // Check those that are mappable are mapped
+    reg.mapSnapshot(keyA, actualDataA);
+    reg.mapSnapshot(keyC, actualDataC);
+
+    // Check error when mapping an unmappable snapshot
+    REQUIRE_THROWS(reg.mapSnapshot(keyB, actualDataB));
+
+    // Here we need to check the actual data after mapping
+    std::vector<uint8_t> vecDataA(dataA, dataA + HOST_PAGE_SIZE);
+    std::vector<uint8_t> vecActualDataA(actualDataA,
+                                        actualDataA + HOST_PAGE_SIZE);
+    std::vector<uint8_t> vecDataC(dataC, dataC + (3 * HOST_PAGE_SIZE));
+    std::vector<uint8_t> vecActualDataC(actualDataC,
+                                        actualDataC + (3 * HOST_PAGE_SIZE));
+
+    REQUIRE(vecActualDataA == vecDataA);
+    REQUIRE(vecActualDataC == vecDataC);
+
+    deallocatePages(dataA, 1);
+    deallocatePages(actualDataA, 1);
+    deallocatePages(dataB, 2);
+    deallocatePages(actualDataB, 2);
+    deallocatePages(dataC, 3);
+    deallocatePages(actualDataC, 3);
+}
+:x
+:


### PR DESCRIPTION
This supports deleting snapshots locally and across hosts once they're done with.

It also adds the concept of a snapshot that's not `locallyRestorable`, i.e. it's only used for transmitting snapshots across hosts. This is used when doing cross-host thread/ process spawning.