### PR TITLE
Avoid rebuilding flatbuffers every time

### DIFF
--- a/src/flat/.gitignore
+++ b/src/flat/.gitignore
@@ -1,2 +1,4 @@
-# Flatbuf generated
+# Flatbuffers/ gRPC output
+*.fb.h
 *.fb.cc
+faabric_generated.h

--- a/src/flat/CMakeLists.txt
+++ b/src/flat/CMakeLists.txt
@@ -21,7 +21,7 @@ add_custom_command(
 add_custom_command(
     OUTPUT "${FB_HEADER_COPIED}"
     DEPENDS "${FB_HEADER}"
-    COMMAND ${CMAKE_COMMAND} -E rename
+    COMMAND ${CMAKE_COMMAND} -E copy
     ${FB_HEADER}
     ${FB_HEADER_COPIED}
     )
@@ -29,7 +29,7 @@ add_custom_command(
 add_custom_command(
     OUTPUT "${GRPC_HEADER_COPIED}"
     DEPENDS "${GRPC_HEADER}"
-    COMMAND ${CMAKE_COMMAND} -E rename
+    COMMAND ${CMAKE_COMMAND} -E copy
     ${GRPC_HEADER}
     ${GRPC_HEADER_COPIED}
     )


### PR DESCRIPTION
Because the generated headers are marked as `OUTPUT` for the custom command, but getting moved rather than copied, the build was running every time.

Closes #72 