### PR TITLE
Message factories with shared pointers

### DIFF
--- a/include/faabric/util/func.h
+++ b/include/faabric/util/func.h
@@ -58,8 +58,15 @@ unsigned int setMessageId(faabric::Message& msg);
 
 std::string buildAsyncResponse(const faabric::Message& msg);
 
+std::shared_ptr<faabric::Message> messageFactoryShared(
+  const std::string& user,
+  const std::string& function);
+
 faabric::Message messageFactory(const std::string& user,
                                 const std::string& function);
+
+faabric::BatchExecuteRequest batchExecFactory(
+  std::vector<std::shared_ptr<faabric::Message>>& msgs);
 
 faabric::BatchExecuteRequest batchExecFactory(
   std::vector<faabric::Message>& msgs);

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -345,7 +345,7 @@ std::shared_ptr<faabric::Message> messageFactoryShared(
     auto ptr = std::make_shared<faabric::Message>();
 
     ptr->set_user(user);
-    ptr->set_user(function);
+    ptr->set_function(function);
 
     setMessageId(*ptr);
 

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -309,6 +309,22 @@ std::string buildAsyncResponse(const faabric::Message& msg)
 }
 
 faabric::BatchExecuteRequest batchExecFactory(
+  std::vector<std::shared_ptr<faabric::Message>>& msgs)
+{
+    // TODO - can we avoid this copy?
+    faabric::BatchExecuteRequest req;
+    for (auto p : msgs) {
+        *req.add_messages() = *p.get();
+    }
+
+    // Generate a random ID
+    unsigned int id = faabric::util::generateGid();
+    req.set_id(id);
+
+    return req;
+}
+
+faabric::BatchExecuteRequest batchExecFactory(
   std::vector<faabric::Message>& msgs)
 {
     // TODO - can we avoid this copy?
@@ -320,6 +336,22 @@ faabric::BatchExecuteRequest batchExecFactory(
     req.set_id(id);
 
     return req;
+}
+
+std::shared_ptr<faabric::Message> messageFactoryShared(
+  const std::string& user,
+  const std::string& function)
+{
+    auto ptr = std::make_shared<faabric::Message>();
+
+    ptr->set_user(user);
+    ptr->set_user(function);
+
+    setMessageId(*ptr);
+
+    std::string thisHost = faabric::util::getSystemConfig().endpointHost;
+    ptr->set_masterhost(thisHost);
+    return ptr;
 }
 
 faabric::Message messageFactory(const std::string& user,

--- a/tests/test/util/test_func.cpp
+++ b/tests/test/util/test_func.cpp
@@ -18,6 +18,17 @@ TEST_CASE("Test message factory", "[util]")
     REQUIRE(!msg.resultkey().empty());
 }
 
+TEST_CASE("Test message factory shared", "[util]")
+{
+    std::shared_ptr<faabric::Message> msg =
+      faabric::util::messageFactoryShared("demo", "echo");
+    REQUIRE(msg->user() == "demo");
+    REQUIRE(msg->function() == "echo");
+    REQUIRE(msg->id() > 0);
+    REQUIRE(!msg->statuskey().empty());
+    REQUIRE(!msg->resultkey().empty());
+}
+
 TEST_CASE("Test retrieving function paths", "[util]")
 {
     faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();


### PR DESCRIPTION
We eventually need to avoid all copying of messages, possibly using flatbuffers, but porting all uses of messages to that would take a while. For now we can get away with just having factories that produce shared pointers (we want to avoid calling the message constructors directly as we need to assign IDs and master hosts)
