### PR TITLE
Running multi-host MPI applications

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -232,6 +232,8 @@ class MpiWorld
 
     std::shared_ptr<state::StateKeyValue> getRankHostState(int rank);
 
+    int getMpiThreadPoolSize();
+
     void checkRankOnThisHost(int rank);
 
     void pushToState();

--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -34,6 +34,7 @@ class SystemConfig
 
     // Scheduling
     int noScheduler;
+    int overrideCpuCount;
 
     // Worker-related timeouts
     int globalMessageTimeout;

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -89,7 +89,11 @@ std::string FaabricEndpointHandler::executeFunction(faabric::Message& msg)
         return "Empty function";
     }
 
+    // Set message ID and master host
     faabric::util::setMessageId(msg);
+    std::string thisHost = faabric::util::getSystemConfig().endpointHost;
+    logger->debug("Setting up masterhost to {}", thisHost);
+    msg.set_masterhost(thisHost);
 
     auto tid = (pid_t)syscall(SYS_gettid);
 

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -92,7 +92,6 @@ std::string FaabricEndpointHandler::executeFunction(faabric::Message& msg)
     // Set message ID and master host
     faabric::util::setMessageId(msg);
     std::string thisHost = faabric::util::getSystemConfig().endpointHost;
-    logger->debug("Setting up masterhost to {}", thisHost);
     msg.set_masterhost(thisHost);
 
     auto tid = (pid_t)syscall(SYS_gettid);

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -66,14 +66,15 @@ std::shared_ptr<state::StateKeyValue> MpiWorld::getRankHostState(int rank)
 
 int MpiWorld::getMpiThreadPoolSize()
 {
+    auto logger = faabric::util::getLogger();
     int usableCores = faabric::util::getUsableCores();
     int worldSize = size;
 
-    // Note - this will overprovision threads if worldSize > usableCores, and
-    // worldSize % usableCores != 0
-    faabric::util::getLogger()->warn(
-      "Over-provisioning threads in the MPI thread pool. To avoid this, set a "
-      "MPI world size multiple of the number of cores per machine.");
+    if ((worldSize > usableCores) && (worldSize % usableCores != 0)) {
+        logger->warn("Over-provisioning threads in the MPI thread pool.");
+        logger->warn("To avoid this, set an MPI world size multiple of the "
+                     "number of cores per machine.");
+    }
     return std::min<int>(worldSize, usableCores);
 }
 

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -66,26 +66,12 @@ std::shared_ptr<state::StateKeyValue> MpiWorld::getRankHostState(int rank)
 
 int MpiWorld::getMpiThreadPoolSize()
 {
-    // We initialise as many threads as MPI ranks assigned to this host, as long
-    // as this number does not exceed the number of usable cores.
     int usableCores = faabric::util::getUsableCores();
-    int ranksInHost = size;
-    /* TODO improve
-    for (int i = 0; i < this->size; i++) {
-        if (getHostForRank(i) == thisHost) {
-            ranksInHost++;
-        }
-    }
-    */
+    int worldSize = size;
 
-    // TODO - does it make sense to pin each thread to a CPU core using affinity
-    if (ranksInHost > usableCores) {
-        faabric::util::getLogger()->warn(
-          "WARNING: more MPI ranks in host ({}) than usable cores ({})",
-          ranksInHost,
-          usableCores);
-    }
-    return (int)std::min(ranksInHost, usableCores);
+    // Note - this may overprovision threads if worldSize > usableCores, and
+    // worldSize % usableCores != 0
+    return std::min<int>(worldSize, usableCores);
 }
 
 void MpiWorld::create(const faabric::Message& call, int newId, int newSize)

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -69,8 +69,11 @@ int MpiWorld::getMpiThreadPoolSize()
     int usableCores = faabric::util::getUsableCores();
     int worldSize = size;
 
-    // Note - this may overprovision threads if worldSize > usableCores, and
+    // Note - this will overprovision threads if worldSize > usableCores, and
     // worldSize % usableCores != 0
+    faabric::util::getLogger()->warn(
+      "Over-provisioning threads in the MPI thread pool. To avoid this, set a "
+      "MPI world size multiple of the number of cores per machine.");
     return std::min<int>(worldSize, usableCores);
 }
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -40,6 +40,7 @@ void SystemConfig::initialise()
 
     // Scheduling
     noScheduler = this->getSystemConfIntParam("NO_SCHEDULER", "0");
+    overrideCpuCount = this->getSystemConfIntParam("OVERRIDE_CPU_COUNT", "0");
 
     // Worker-related timeouts (all in seconds)
     globalMessageTimeout =

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -115,6 +115,7 @@ void SystemConfig::print()
 
     logger->info("--- Scheduling ---");
     logger->info("NO_SCHEDULER               {}", noScheduler);
+    logger->info("OVERRIDE_CPU_COUNT         {}", overrideCpuCount);
 
     logger->info("--- Timeouts ---");
     logger->info("GLOBAL_MESSAGE_TIMEOUT     {}", globalMessageTimeout);

--- a/src/util/environment.cpp
+++ b/src/util/environment.cpp
@@ -1,3 +1,4 @@
+#include <faabric/util/config.h>
 #include <faabric/util/environment.h>
 
 #include <thread>
@@ -35,7 +36,14 @@ void unsetEnvVar(const std::string& varName)
 
 unsigned int getUsableCores()
 {
-    unsigned int nCores = std::thread::hardware_concurrency();
+    auto conf = faabric::util::getSystemConfig();
+    unsigned int nCores;
+
+    if (conf.overrideCpuCount == 0) {
+        nCores = std::thread::hardware_concurrency();
+    } else {
+        nCores = conf.overrideCpuCount;
+    }
 
     // Returns zero when unable to detect
     if (nCores == 0) {

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -124,6 +124,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     setEnvVar("REDIS_PORT", redisPort);
 
     setEnvVar("NO_SCHEDULER", noScheduler);
+    setEnvVar("OVERRIDE_CPU_COUNT", overrideCpuCount);
 
     setEnvVar("GLOBAL_MESSAGE_TIMEOUT", globalTimeout);
     setEnvVar("BOUND_TIMEOUT", boundTimeout);

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -28,6 +28,7 @@ TEST_CASE("Test default system config initialisation", "[util]")
     REQUIRE(conf.redisPort == "6379");
 
     REQUIRE(conf.noScheduler == 0);
+    REQUIRE(conf.overrideCpuCount == 0);
 
     REQUIRE(conf.globalMessageTimeout == 60000);
     REQUIRE(conf.boundTimeout == 30000);
@@ -58,6 +59,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     std::string redisPort = setEnvVar("REDIS_PORT", "1234");
 
     std::string noScheduler = setEnvVar("NO_SCHEDULER", "1");
+    std::string overrideCpuCount = setEnvVar("OVERRIDE_CPU_COUNT", "4");
 
     std::string globalTimeout = setEnvVar("GLOBAL_MESSAGE_TIMEOUT", "9876");
     std::string boundTimeout = setEnvVar("BOUND_TIMEOUT", "6666");
@@ -88,6 +90,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     REQUIRE(conf.redisPort == "1234");
 
     REQUIRE(conf.noScheduler == 1);
+    REQUIRE(conf.overrideCpuCount == 4);
 
     REQUIRE(conf.globalMessageTimeout == 9876);
     REQUIRE(conf.boundTimeout == 6666);

--- a/tests/test/util/test_environment.cpp
+++ b/tests/test/util/test_environment.cpp
@@ -1,3 +1,4 @@
+#include "faabric_utils.h"
 #include <catch.hpp>
 
 #include <faabric/util/config.h>
@@ -40,13 +41,21 @@ TEST_CASE("Test setting environment variables", "[util]")
 
 TEST_CASE("Test overriding CPU count", "[util]")
 {
-    // Unset just in case it is set
-    unsetEnvVar("OVERRIDE_CPU_COUNT");
+    cleanFaabric();
 
-    unsigned int expectedNumCores = std::thread::hardware_concurrency();
-    REQUIRE(getUsableCores() == expectedNumCores);
+    // Check default cores is same as available concurrency
+    auto& conf = getSystemConfig();
+    unsigned int defaultCores = getUsableCores();
+    REQUIRE(defaultCores == std::thread::hardware_concurrency());
 
-    getSystemConfig().overrideCpuCount = 4;
-    REQUIRE(getUsableCores() == 4);
+    // Check it can be overridden
+    conf.overrideCpuCount = 1234;
+    REQUIRE(getUsableCores() == 1234);
+
+    // Reset the conf
+    conf.reset();
+
+    // Check we're back to the default
+    REQUIRE(getUsableCores() == defaultCores);
 }
 }

--- a/tests/test/util/test_environment.cpp
+++ b/tests/test/util/test_environment.cpp
@@ -3,6 +3,8 @@
 #include <faabric/util/config.h>
 #include <faabric/util/environment.h>
 
+#include <thread>
+
 using namespace faabric::util;
 
 namespace tests {
@@ -34,5 +36,17 @@ TEST_CASE("Test setting environment variables", "[util]")
 
     const std::string original2 = setEnvVar("MY_VAR", "gamma");
     REQUIRE(original2 == "beta");
+}
+
+TEST_CASE("Test overriding CPU count", "[util]")
+{
+    // Unset just in case it is set
+    unsetEnvVar("OVERRIDE_CPU_COUNT");
+
+    unsigned int expectedNumCores = std::thread::hardware_concurrency();
+    REQUIRE(getUsableCores() == expectedNumCores);
+
+    getSystemConfig().overrideCpuCount = 4;
+    REQUIRE(getUsableCores() == 4);
 }
 }


### PR DESCRIPTION
This PR introduces the minimal changes needed to run multi-host MPI applications through the REST API. I also include a new config parameter that allows overriding the CPU count to fake single-machine multi-host docker deployments.

I also use this PR as a clean sheet to start GRPC-related optimizations.