### PR TITLE
Adding timer totals

### DIFF
--- a/include/faabric/util/timing.h
+++ b/include/faabric/util/timing.h
@@ -4,11 +4,13 @@
 #include <string>
 
 #ifdef TRACE_ALL
+#define PROF_BEGIN faabric::util::startGlobalTimer();
 #define PROF_START(name)                                                       \
     const faabric::util::TimePoint name = faabric::util::startTimer();
 #define PROF_END(name) faabric::util::logEndTimer(#name, name);
 #define PROF_SUMMARY faabric::util::printTimerTotals();
 #else
+#define PROF_BEGIN
 #define PROF_START(name)
 #define PROF_END(name)
 #define PROF_SUMMARY
@@ -25,6 +27,8 @@ double getTimeDiffMillis(const faabric::util::TimePoint& begin);
 
 void logEndTimer(const std::string& label,
                  const faabric::util::TimePoint& begin);
+
+void startGlobalTimer();
 
 void printTimerTotals();
 

--- a/include/faabric/util/timing.h
+++ b/include/faabric/util/timing.h
@@ -7,9 +7,11 @@
 #define PROF_START(name)                                                       \
     const faabric::util::TimePoint name = faabric::util::startTimer();
 #define PROF_END(name) faabric::util::logEndTimer(#name, name);
+#define PROF_SUMMARY faabric::util::printTimerTotals();
 #else
 #define PROF_START(name)
 #define PROF_END(name)
+#define PROF_SUMMARY
 #endif
 
 namespace faabric::util {
@@ -23,6 +25,8 @@ double getTimeDiffMillis(const faabric::util::TimePoint& begin);
 
 void logEndTimer(const std::string& label,
                  const faabric::util::TimePoint& begin);
+
+void printTimerTotals();
 
 uint64_t timespecToNanos(struct timespec* nativeTimespec);
 

--- a/src/util/timing.cpp
+++ b/src/util/timing.cpp
@@ -62,7 +62,7 @@ void printTimerTotals()
         int count = timerCounts[p.second];
         double avg = millis / count;
         printf(
-          "%-11.2f %-10.2f %5i  %s\n", millis, avg, count, p.second.c_str());
+          "%-11.2f %-10.3f %5i  %s\n", millis, avg, count, p.second.c_str());
     }
 }
 

--- a/src/util/timing.cpp
+++ b/src/util/timing.cpp
@@ -1,6 +1,7 @@
 #include <faabric/util/logging.h>
 #include <faabric/util/timing.h>
 
+faabric::util::TimePoint globalStart;
 std::unordered_map<std::string, std::atomic<long>> timerTotals;
 std::unordered_map<std::string, std::atomic<int>> timerCounts;
 
@@ -45,8 +46,17 @@ void logEndTimer(const std::string& label,
     timerCounts[label]++;
 }
 
+void startGlobalTimer()
+{
+    globalStart = startTimer();
+}
+
 void printTimerTotals()
 {
+    // Stop global timer
+    double totalMillis = getTimeDiffMillis(globalStart);
+    double totalSeconds = totalMillis / 1000.0;
+
     // Switch the pairs so we can use std::sort
     std::vector<std::pair<long, std::string>> totals;
     for (auto& p : timerTotals) {
@@ -64,6 +74,8 @@ void printTimerTotals()
         printf(
           "%-11.2f %-10.3f %5i  %s\n", millis, avg, count, p.second.c_str());
     }
+
+    printf("Total running time: %.2fs\n\n", totalSeconds);
 }
 
 uint64_t timespecToNanos(struct timespec* nativeTimespec)


### PR DESCRIPTION
Quick and dirty timer summary.

Numbers clearly have to be taken with a pinch of salt, as the timers may be nested or executed from multiple threads.

Example output:

```
---------- TIMER TOTALS ----------                     
Total (ms)  Avg (ms)   Count  Label                    
0.05        0.026          2  wasmSnapshotRestore      
0.12        0.124          1  wasmContext              
0.71        0.706          1  wasmCopyConstruct        
3.64        0.002       1538  MasterWaitWorker         
6.19        0.002       3777  DeleteSnapshot           
12.44       0.003       3777  BroadcastDeleteSnapshot  
31.06       31.058         1  BaseWasiModule           
33.96       33.961         1  wasmBind                 
48.89       0.013       3778  wasmSnapshot             
144.94      72.472         2  wasmTearDown             
145.30      145.303        1  wasmAssignOp             
154.35      0.100       1538  MasterWaitMaster         
180.87      180.870        1  BaseEnvModule            
549.32      549.321        1  wasmCreateModule         
```