### PR TITLE
Introduce delta snapshot utilities and zstd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.0)
+cmake_minimum_required(VERSION 3.14.0)
 project(faabric)
 
 option(FAABRIC_WASM_BUILD "Build Faabric wasm library" OFF)
@@ -28,7 +28,7 @@ include(cmake/ExternalProjects.cmake)
 function(faabric_lib lib_name lib_deps)
     # "Normal" library used for linking internally
     add_library(${lib_name} ${lib_deps})
-    target_include_directories(${lib_name} 
+    target_include_directories(${lib_name}
         PUBLIC ${FAABRIC_INCLUDE_DIR}
         PUBLIC ${PISTACHE_INCLUDE_DIR}
         PUBLIC ${SPDLOG_INCLUDE_DIR}
@@ -39,7 +39,7 @@ function(faabric_lib lib_name lib_deps)
     # Object library for bundling everything together (should have the same
     # include dirs and dependencies as the normal library)
     add_library(${lib_name}_obj OBJECT ${lib_deps})
-    target_include_directories(${lib_name}_obj 
+    target_include_directories(${lib_name}_obj
         PUBLIC ${FAABRIC_INCLUDE_DIR}
         PUBLIC ${PISTACHE_INCLUDE_DIR}
         PUBLIC ${SPDLOG_INCLUDE_DIR}
@@ -52,7 +52,7 @@ function(faabric_lib lib_name lib_deps)
     if(BUILD_SHARED_LIBS)
         target_compile_options(${lib_name} PRIVATE "-fPIC")
         target_compile_options(${lib_name}_obj PRIVATE "-fPIC")
-    endif()    
+    endif()
 endfunction()
 
 add_subdirectory(src/endpoint)
@@ -68,15 +68,15 @@ add_subdirectory(src/snapshot)
 add_subdirectory(src/state)
 add_subdirectory(src/util)
 
-# Wrapper library - note we want to include all the _object_ targets in this 
+# Wrapper library - note we want to include all the _object_ targets in this
 # library to ensure it's all bundled in together
-if(BUILD_SHARED_LIBS) 
+if(BUILD_SHARED_LIBS)
     set(FAABRIC_LIB_TYPE SHARED)
 else()
     set(FAABRIC_LIB_TYPE STATIC)
 endif()
 
-add_library(faabric 
+add_library(faabric
     ${FAABRIC_LIB_TYPE}
     faabric.cpp
     $<TARGET_OBJECTS:endpoint_obj>
@@ -93,7 +93,7 @@ add_library(faabric
 
 add_dependencies(faabric pistache spdlog_ext)
 
-target_link_libraries(faabric
+target_link_libraries(faabric PUBLIC
     ${Protobuf_LIBRARIES}
     faabricmpi
     gRPC::grpc++
@@ -102,9 +102,10 @@ target_link_libraries(faabric
     pistache
     boost_system
     boost_filesystem
+    zstd::libzstd_static
     )
 
-target_include_directories(faabric PUBLIC 
+target_include_directories(faabric PUBLIC
     ${FAABRIC_INCLUDE_DIR}
     ${CMAKE_INSTALL_PREFIX}/include
 )

--- a/include/faabric/util/bytes.h
+++ b/include/faabric/util/bytes.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -18,4 +20,26 @@ int safeCopyToBuffer(const uint8_t* dataIn,
                      int dataLen,
                      uint8_t* buffer,
                      int bufferLen);
+
+template<class T>
+void appendBytesOf(std::vector<uint8_t>& container, T value)
+{
+    uint8_t* start = reinterpret_cast<uint8_t*>(&value);
+    uint8_t* end = reinterpret_cast<uint8_t*>(&value) + sizeof(T);
+    container.insert(container.end(), start, end);
+}
+
+template<class T>
+size_t readBytesOf(const std::vector<uint8_t>& container,
+                   size_t offset,
+                   T* outValue)
+{
+    if (offset >= container.size() || offset + sizeof(T) > container.size()) {
+        throw std::range_error("Trying to read bytes out of container range");
+    }
+    // use byte pointers to make sure there are no alignment issues
+    uint8_t* outStart = reinterpret_cast<uint8_t*>(outValue);
+    std::copy_n(container.data() + offset, sizeof(T), outStart);
+    return offset + sizeof(T);
+}
 }

--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -26,6 +26,7 @@ class SystemConfig
     std::string captureStdout;
     std::string stateMode;
     std::string wasmVm;
+    std::string deltaSnapshotEncoding;
 
     // Redis
     std::string redisStateHost;

--- a/include/faabric/util/delta.h
+++ b/include/faabric/util/delta.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace faabric::util {
+
+struct DeltaSettings
+{
+    // pages=SIZE;
+    bool usePages = true;
+    size_t pageSize = 4096;
+    // xor;
+    bool xorWithOld = true;
+    // zstd=LEVEL;
+    bool useZstd = true;
+    int zstdLevel = 1;
+
+    explicit DeltaSettings(const std::string& definition);
+    std::string toString() const;
+};
+
+inline constexpr uint8_t DELTA_PROTOCOL_VERSION = 1;
+inline constexpr int DELTA_ZSTD_COMPRESS_LEVEL = 1;
+
+enum DeltaCommand : uint8_t
+{
+    // followed by u32(total size)
+    DELTACMD_TOTAL_SIZE = 0x00,
+    // followed by u64(compressed length), u64(decompressed length),
+    // bytes(compressed commands)
+    DELTACMD_ZSTD_COMPRESSED_COMMANDS = 0x01,
+    // followed by u32(offset), u32(length), bytes(data)
+    DELTACMD_DELTA_OVERWRITE = 0x02,
+    // followed by u32(offset), u32(length), bytes(data)
+    DELTACMD_DELTA_XOR = 0x03,
+    // final command
+    DELTACMD_END = 0xFE,
+};
+
+std::vector<uint8_t> serializeDelta(const DeltaSettings& cfg,
+                                    const uint8_t* oldDataStart,
+                                    size_t oldDataLen,
+                                    const uint8_t* newDataStart,
+                                    size_t newDataLen);
+
+void applyDelta(const std::vector<uint8_t>& delta,
+                std::function<void(uint32_t)> setDataSize,
+                std::function<uint8_t*()> getDataPointer);
+
+}

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIB_FILES
         bytes.cpp
         config.cpp
         clock.cpp
+        delta.cpp
         environment.cpp
         files.cpp
         func.cpp
@@ -33,8 +34,9 @@ add_dependencies(util rapidjson_ext)
 add_dependencies(util cppcodec_ext)
 
 target_link_libraries(
-        util
+        util PUBLIC
         proto
         boost_system
         boost_filesystem
+        zstd::libzstd_static
 )

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -32,6 +32,8 @@ void SystemConfig::initialise()
     captureStdout = getEnvVar("CAPTURE_STDOUT", "off");
     stateMode = getEnvVar("STATE_MODE", "inmemory");
     wasmVm = getEnvVar("WASM_VM", "wavm");
+    deltaSnapshotEncoding =
+      getEnvVar("DELTA_SNAPSHOT_ENCODING", "pages=4096;xor;zstd=1");
 
     // Redis
     redisStateHost = getEnvVar("REDIS_STATE_HOST", "localhost");
@@ -107,6 +109,7 @@ void SystemConfig::print()
     logger->info("CAPTURE_STDOUT             {}", captureStdout);
     logger->info("STATE_MODE                 {}", stateMode);
     logger->info("WASM_VM                    {}", wasmVm);
+    logger->info("DELTA_SNAPSHOT_ENCODING    {}", deltaSnapshotEncoding);
 
     logger->info("--- Redis ---");
     logger->info("REDIS_STATE_HOST           {}", redisStateHost);

--- a/src/util/delta.cpp
+++ b/src/util/delta.cpp
@@ -1,0 +1,272 @@
+#include <faabric/util/bytes.h>
+#include <faabric/util/delta.h>
+
+#include <zstd.h>
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+
+namespace faabric::util {
+
+DeltaSettings::DeltaSettings(const std::string& definition)
+  : usePages(false)
+  , pageSize(4096)
+  , xorWithOld(false)
+  , useZstd(false)
+  , zstdLevel(1)
+{
+    std::stringstream ss(definition);
+    std::string part;
+    while (std::getline(ss, part, ';')) {
+        if (part.size() < 1) {
+            continue;
+        }
+        if (std::string_view pfx = "pages="; part.find(pfx.data(), 0) == 0) {
+            this->usePages = true;
+            this->pageSize = std::stoul(part.substr(pfx.size()));
+        } else if (part == "xor") {
+            this->xorWithOld = true;
+        } else if (std::string_view pfx = "zstd=";
+                   part.find(pfx.data(), 0) == 0) {
+            this->useZstd = true;
+            this->zstdLevel = std::stoi(part.substr(pfx.size()));
+        } else {
+            throw std::invalid_argument(
+              std::string("Invalid DeltaSettings configuration argument: ") +
+              part);
+        }
+    }
+}
+
+std::string DeltaSettings::toString() const
+{
+    std::stringstream ss;
+    if (this->usePages) {
+        ss << "pages=" << this->pageSize << ';';
+    }
+    if (this->xorWithOld) {
+        ss << "xor;";
+    }
+    if (this->useZstd) {
+        ss << "zstd=" << this->zstdLevel << ';';
+    }
+    return ss.str();
+}
+
+std::vector<uint8_t> serializeDelta(const DeltaSettings& cfg,
+                                    const uint8_t* oldDataStart,
+                                    size_t oldDataLen,
+                                    const uint8_t* newDataStart,
+                                    size_t newDataLen)
+{
+    std::vector<uint8_t> outb;
+    outb.reserve(16384);
+    outb.push_back(DELTA_PROTOCOL_VERSION);
+    outb.push_back(DELTACMD_TOTAL_SIZE);
+    appendBytesOf(outb, uint32_t(newDataLen));
+    auto encodeChangedRegion = [&](size_t startByte, size_t newLength) {
+        if (newLength == 0) {
+            return;
+        }
+        assert(startByte <= newDataLen);
+        size_t endByte = startByte + newLength;
+        assert(endByte <= newDataLen);
+        assert(startByte <= oldDataLen);
+        assert(endByte <= oldDataLen);
+        if (cfg.xorWithOld) {
+            outb.push_back(DELTACMD_DELTA_XOR);
+            appendBytesOf(outb, uint32_t(startByte));
+            appendBytesOf(outb, uint32_t(newLength));
+            size_t xorStart = outb.size();
+            outb.insert(
+              outb.end(), newDataStart + startByte, newDataStart + endByte);
+            auto xorBegin = outb.begin() + xorStart;
+            std::transform(oldDataStart + startByte,
+                           oldDataStart + endByte,
+                           xorBegin,
+                           xorBegin,
+                           std::bit_xor<uint8_t>());
+        } else {
+            outb.push_back(DELTACMD_DELTA_OVERWRITE);
+            appendBytesOf(outb, uint32_t(startByte));
+            appendBytesOf(outb, uint32_t(newLength));
+            outb.insert(
+              outb.end(), newDataStart + startByte, newDataStart + endByte);
+        }
+    };
+    auto encodeNewRegion = [&](size_t newStart, size_t newLength) {
+        if (newLength == 0) {
+            return;
+        }
+        assert(newStart <= newDataLen);
+        size_t newEnd = newStart + newLength;
+        assert(newEnd <= newDataLen);
+        outb.push_back(DELTACMD_DELTA_OVERWRITE);
+        appendBytesOf(outb, uint32_t(newStart));
+        appendBytesOf(outb, uint32_t(newLength));
+        outb.insert(outb.end(), newDataStart + newStart, newDataStart + newEnd);
+    };
+    if (cfg.usePages) {
+        for (size_t pageStart = 0; pageStart < newDataLen;
+             pageStart += cfg.pageSize) {
+            size_t pageEnd = pageStart + cfg.pageSize;
+            bool startInBoth = (pageStart < oldDataLen);
+            bool endInBoth = (pageEnd <= newDataLen) && (pageEnd <= oldDataLen);
+            if (startInBoth && endInBoth) {
+                bool anyChanges = !std::equal(newDataStart + pageStart,
+                                              newDataStart + pageEnd,
+                                              oldDataStart);
+                if (anyChanges) {
+                    encodeChangedRegion(pageStart, cfg.pageSize);
+                }
+            } else if (!startInBoth) {
+                using namespace std::placeholders;
+                if (std::any_of(
+                      newDataStart + pageStart,
+                      newDataStart + pageEnd,
+                      std::bind(std::not_equal_to<uint8_t>(), 0, _1))) {
+                    encodeNewRegion(pageStart,
+                                    std::min(pageEnd, newDataLen) - pageStart);
+                }
+            } else {
+                encodeNewRegion(pageStart,
+                                std::min(pageEnd, newDataLen) - pageStart);
+            }
+        }
+    } else {
+        if (newDataLen >= oldDataLen) {
+            encodeChangedRegion(0, oldDataLen);
+            encodeNewRegion(oldDataLen, newDataLen - oldDataLen);
+        } else {
+            encodeChangedRegion(0, newDataLen);
+            // discard longer old data
+        }
+    }
+    outb.push_back(DELTACMD_END);
+    outb.shrink_to_fit();
+    if (!cfg.useZstd) {
+        return outb;
+    } else {
+        std::vector<uint8_t> compressBuffer;
+        size_t compressBound = ZSTD_compressBound(outb.size());
+        compressBuffer.reserve(compressBound + 19);
+        compressBuffer.push_back(DELTA_PROTOCOL_VERSION);
+        compressBuffer.push_back(DELTACMD_ZSTD_COMPRESSED_COMMANDS);
+        size_t idxComprLen = compressBuffer.size();
+        appendBytesOf(compressBuffer, uint64_t(0xDEAD)); // to be filled in
+        appendBytesOf(compressBuffer, uint64_t(outb.size()));
+        size_t idxCDataStart = compressBuffer.size();
+        compressBuffer.insert(compressBuffer.end(), compressBound, uint8_t(0));
+        auto zstdResult = ZSTD_compress(compressBuffer.data() + idxCDataStart,
+                                        compressBuffer.size() - idxCDataStart,
+                                        outb.data(),
+                                        outb.size(),
+                                        cfg.zstdLevel);
+        if (ZSTD_isError(zstdResult)) {
+            auto error = ZSTD_getErrorName(zstdResult);
+            throw std::runtime_error(std::string("ZSTD compression error: ") +
+                                     error);
+        } else {
+            compressBuffer.resize(idxCDataStart + zstdResult);
+        }
+        {
+            uint64_t comprLen = zstdResult;
+            std::copy_n(reinterpret_cast<uint8_t*>(&comprLen),
+                        sizeof(uint64_t),
+                        compressBuffer.data() + idxComprLen);
+        }
+        compressBuffer.push_back(DELTACMD_END);
+        compressBuffer.shrink_to_fit();
+        return compressBuffer;
+    }
+}
+
+void applyDelta(const std::vector<uint8_t>& delta,
+                std::function<void(uint32_t)> setDataSize,
+                std::function<uint8_t*()> getDataPointer)
+{
+    size_t deltaLen = delta.size();
+    if (deltaLen < 2) {
+        throw std::runtime_error("Delta too short to be valid");
+    }
+    if (delta.at(0) != DELTA_PROTOCOL_VERSION) {
+        throw std::runtime_error("Unsupported delta version");
+    }
+    size_t readIdx = 1;
+    while (readIdx < deltaLen) {
+        uint8_t cmd = delta.at(readIdx);
+        readIdx++;
+        switch (cmd) {
+            case DELTACMD_TOTAL_SIZE: {
+                uint32_t totalSize{};
+                readIdx = readBytesOf(delta, readIdx, &totalSize);
+                setDataSize(totalSize);
+                break;
+            }
+            case DELTACMD_ZSTD_COMPRESSED_COMMANDS: {
+                uint64_t compressedSize{}, decompressedSize{};
+                readIdx = readBytesOf(delta, readIdx, &compressedSize);
+                readIdx = readBytesOf(delta, readIdx, &decompressedSize);
+                if (readIdx + compressedSize > deltaLen) {
+                    throw std::range_error(
+                      "Delta compressed commands block goes out of range:");
+                }
+                std::vector<uint8_t> decompressedCmds(decompressedSize, 0);
+                auto zstdResult = ZSTD_decompress(decompressedCmds.data(),
+                                                  decompressedCmds.size(),
+                                                  delta.data() + readIdx,
+                                                  compressedSize);
+                if (ZSTD_isError(zstdResult)) {
+                    auto error = ZSTD_getErrorName(zstdResult);
+                    throw std::runtime_error(
+                      std::string("ZSTD compression error: ") + error);
+                } else if (zstdResult != decompressedCmds.size()) {
+                    throw std::runtime_error(
+                      "Mismatched decompression sizes in the NDP delta");
+                }
+                applyDelta(decompressedCmds, setDataSize, getDataPointer);
+                readIdx += compressedSize;
+                break;
+            }
+            case DELTACMD_DELTA_OVERWRITE: {
+                uint32_t offset{}, length{};
+                readIdx = readBytesOf(delta, readIdx, &offset);
+                readIdx = readBytesOf(delta, readIdx, &length);
+                if (readIdx + length > deltaLen) {
+                    throw std::range_error(
+                      "Delta overwrite block goes out of range");
+                }
+                uint8_t* data = getDataPointer();
+                std::copy_n(delta.data() + readIdx, length, data + offset);
+                readIdx += length;
+                break;
+            }
+            case DELTACMD_DELTA_XOR: {
+                uint32_t offset{}, length{};
+                readIdx = readBytesOf(delta, readIdx, &offset);
+                readIdx = readBytesOf(delta, readIdx, &length);
+                if (readIdx + length > deltaLen) {
+                    throw std::range_error("Delta XOR block goes out of range");
+                }
+                uint8_t* data = getDataPointer();
+                std::transform(delta.data() + readIdx,
+                               delta.data() + readIdx + length,
+                               data + offset,
+                               data + offset,
+                               std::bit_xor<uint8_t>());
+                readIdx += length;
+                break;
+            }
+            case DELTACMD_END: {
+                readIdx = deltaLen;
+                break;
+            }
+        }
+    }
+}
+
+}

--- a/tests/test/util/test_bytes.cpp
+++ b/tests/test/util/test_bytes.cpp
@@ -103,4 +103,38 @@ TEST_CASE("Test safe copy with long buffer and other chars", "[util]")
     REQUIRE(input == actualStr);
 }
 
+TEST_CASE("Test integer encoding to/from bytes", "[util]")
+{
+    std::vector<uint8_t> buffer;
+
+    uint8_t v1 = 2, r1;
+    uint16_t v2 = 0xABCD, r2;
+    uint32_t v4 = 0xBEEF1337, r4;
+    uint64_t v8 = 0xABEE2929BEE51234, r8;
+
+    appendBytesOf(buffer, v1);
+    REQUIRE(buffer.size() == 1);
+    appendBytesOf(buffer, v2);
+    REQUIRE(buffer.size() == (1 + 2));
+    appendBytesOf(buffer, v4);
+    REQUIRE(buffer.size() == (1 + 2 + 4));
+    appendBytesOf(buffer, v8);
+    REQUIRE(buffer.size() == (1 + 2 + 4 + 8));
+
+    size_t offset = 0;
+    offset = readBytesOf(buffer, offset, &r1);
+    REQUIRE(r1 == v1);
+    REQUIRE(offset == 1);
+    offset = readBytesOf(buffer, offset, &r2);
+    REQUIRE(r2 == v2);
+    REQUIRE(offset == (1 + 2));
+    offset = readBytesOf(buffer, offset, &r4);
+    REQUIRE(r4 == v4);
+    REQUIRE(offset == (1 + 2 + 4));
+    offset = readBytesOf(buffer, offset, &r8);
+    REQUIRE(r8 == v8);
+    REQUIRE(offset == (1 + 2 + 4 + 8));
+    REQUIRE_THROWS_AS(readBytesOf(buffer, offset, &r1), std::range_error);
+}
+
 }

--- a/tests/test/util/test_delta.cpp
+++ b/tests/test/util/test_delta.cpp
@@ -1,0 +1,142 @@
+#include <catch.hpp>
+
+#include <algorithm>
+#include <faabric/util/delta.h>
+
+using namespace faabric::util;
+
+namespace tests {
+
+TEST_CASE("Test parsing DeltaSettings from configuration strings",
+          "[util][delta]")
+{
+    SECTION("Empty")
+    {
+        DeltaSettings empty("");
+        REQUIRE(empty.usePages == false);
+        REQUIRE(empty.xorWithOld == false);
+        REQUIRE(empty.useZstd == false);
+    }
+
+    SECTION("Just pages")
+    {
+        DeltaSettings justPages("pages=64;");
+        REQUIRE(justPages.usePages == true);
+        REQUIRE(justPages.pageSize == 64);
+        REQUIRE(justPages.xorWithOld == false);
+        REQUIRE(justPages.useZstd == false);
+    }
+
+    SECTION("Just pages 2")
+    {
+        DeltaSettings justPages2("pages=64");
+        REQUIRE(justPages2.usePages == true);
+        REQUIRE(justPages2.pageSize == 64);
+        REQUIRE(justPages2.xorWithOld == false);
+        REQUIRE(justPages2.useZstd == false);
+    }
+
+    SECTION("Just xor")
+    {
+        DeltaSettings justXor("xor;");
+        REQUIRE(justXor.usePages == false);
+        REQUIRE(justXor.xorWithOld == true);
+        REQUIRE(justXor.useZstd == false);
+    }
+
+    SECTION("Just xor 2")
+    {
+        DeltaSettings justXor2("xor");
+        REQUIRE(justXor2.usePages == false);
+        REQUIRE(justXor2.xorWithOld == true);
+        REQUIRE(justXor2.useZstd == false);
+    }
+
+    SECTION("Just zstd")
+    {
+        DeltaSettings justZstd("zstd=-3;");
+        REQUIRE(justZstd.usePages == false);
+        REQUIRE(justZstd.xorWithOld == false);
+        REQUIRE(justZstd.useZstd == true);
+        REQUIRE(justZstd.zstdLevel == -3);
+    }
+
+    SECTION("Just zstd 2")
+    {
+        DeltaSettings justZstd2("zstd=7");
+        REQUIRE(justZstd2.usePages == false);
+        REQUIRE(justZstd2.xorWithOld == false);
+        REQUIRE(justZstd2.useZstd == true);
+        REQUIRE(justZstd2.zstdLevel == 7);
+    }
+
+    SECTION("All options")
+    {
+        DeltaSettings allOptions("pages=128;xor;zstd=7;");
+        REQUIRE(allOptions.usePages == true);
+        REQUIRE(allOptions.pageSize == 128);
+        REQUIRE(allOptions.xorWithOld == true);
+        REQUIRE(allOptions.useZstd == true);
+        REQUIRE(allOptions.zstdLevel == 7);
+    }
+
+    SECTION("All options 2")
+    {
+        DeltaSettings allOptions2("pages=128;xor;zstd=7");
+        REQUIRE(allOptions2.usePages == true);
+        REQUIRE(allOptions2.pageSize == 128);
+        REQUIRE(allOptions2.xorWithOld == true);
+        REQUIRE(allOptions2.useZstd == true);
+        REQUIRE(allOptions2.zstdLevel == 7);
+    }
+}
+
+TEST_CASE("Test delta calculate and apply", "[util][delta]")
+{
+    std::array<DeltaSettings, 13> settingsVariants{ {
+      DeltaSettings(""),
+      DeltaSettings("pages=4096"),
+      DeltaSettings("xor"),
+      DeltaSettings("zstd=3"),
+      DeltaSettings("zstd=-7"),
+      DeltaSettings("pages=4096;xor"),
+      DeltaSettings("xor;zstd=3"),
+      DeltaSettings("xor;zstd=-7"),
+      DeltaSettings("pages=4096;zstd=3"),
+      DeltaSettings("pages=4096;zstd=3"),
+      DeltaSettings("pages=4096;xor;zstd=3"),
+      DeltaSettings("pages=4096;xor;zstd=1"),
+      DeltaSettings("pages=4096;xor;zstd=-7"),
+    } };
+    std::vector<uint8_t> oldMem(65536, 0);
+    std::fill(oldMem.begin() + 10000, oldMem.begin() + 20000, 17);
+    std::fill(oldMem.begin() + 20000, oldMem.begin() + 30000, 37);
+    std::vector<uint8_t> newMem(oldMem);
+    newMem.resize(131072);
+    std::fill(newMem.begin() + 15000, newMem.begin() + 19000, 12);
+    std::fill(newMem.begin() + 29000, newMem.begin() + 32000, 99);
+    std::fill(newMem.begin() + 100000, newMem.begin() + 129000, 127);
+    for (const auto& cfg : settingsVariants) {
+        SECTION(cfg.toString())
+        {
+            auto delta = serializeDelta(
+              cfg, oldMem.data(), oldMem.size(), newMem.data(), newMem.size());
+            REQUIRE(delta.size() > 2);
+            std::vector<uint8_t> appliedMem(oldMem);
+            REQUIRE(std::equal(oldMem.cbegin(),
+                               oldMem.cend(),
+                               appliedMem.cbegin(),
+                               appliedMem.cend()));
+            applyDelta(
+              delta,
+              [&appliedMem](uint32_t newSize) { appliedMem.resize(newSize); },
+              [&appliedMem]() { return appliedMem.data(); });
+            REQUIRE(std::equal(newMem.cbegin(),
+                               newMem.cend(),
+                               appliedMem.cbegin(),
+                               appliedMem.cend()));
+        }
+    }
+}
+
+}


### PR DESCRIPTION
This introduces a zstd dependency and adds configurable delta snapshots with multiple encodings.

The different encoding formats (with/without pages, compressed/uncompressed, xor/overwrite mode) are tested to work, but I have not determined their individual overheads and benefits so far.