### PR TITLE
Executor fixes

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -70,6 +70,8 @@ class Executor
       std::pair<int, std::shared_ptr<faabric::BatchExecuteRequest>>>>
       threadQueues;
 
+    void threadPoolThread(int threadPoolIdx);
+
     void shutdownThreadPoolThread(int threadPoolIdx);
 };
 

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -120,8 +120,6 @@ class Scheduler
 
     void vacateSlot();
 
-    void notifyExecutorFinished(Executor* exec, const faabric::Message& msg);
-
     void notifyExecutorShutdown(Executor* exec, const faabric::Message& msg);
 
     std::string getThisHost();

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -36,7 +36,7 @@ class Executor
 
     virtual void flush();
 
-    virtual void reset();
+    virtual void reset(const faabric::Message& msg);
 
     virtual int32_t executeTask(
       int threadPoolIdx,

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -46,9 +46,9 @@ class Executor
 
     virtual void postFinish();
 
-  private:
     faabric::Message boundMessage;
 
+  private:
     std::string lastSnapshot;
 
     std::atomic<int> executingTaskCount = 0;

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -23,6 +23,8 @@ Scheduler& getScheduler();
 class Executor
 {
   public:
+    std::string id;
+
     explicit Executor(const faabric::Message& msg);
 
     virtual ~Executor();
@@ -34,7 +36,7 @@ class Executor
 
     virtual void flush();
 
-    std::string id;
+    virtual void reset();
 
     virtual int32_t executeTask(
       int threadPoolIdx,

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -36,12 +36,12 @@ class Executor
 
     std::string id;
 
-  protected:
     virtual int32_t executeTask(
       int threadPoolIdx,
       int msgIdx,
       std::shared_ptr<faabric::BatchExecuteRequest> req);
 
+  protected:
     virtual void restore(const faabric::Message& msg);
 
     virtual void postFinish();

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -56,6 +56,8 @@ class Executor
 
     faabric::Message boundMessage;
 
+    uint32_t threadPoolSize = 0;
+
   private:
     std::string lastSnapshot;
 
@@ -64,7 +66,6 @@ class Executor
     std::atomic<int> executingTaskCount = 0;
 
     std::mutex threadsMutex;
-    uint32_t threadPoolSize = 0;
     std::vector<std::shared_ptr<std::thread>> threadPoolThreads;
     std::vector<faabric::util::Queue<
       std::pair<int, std::shared_ptr<faabric::BatchExecuteRequest>>>>

--- a/include/faabric/util/macros.h
+++ b/include/faabric/util/macros.h
@@ -2,3 +2,5 @@
 
 #define BYTES(arr) reinterpret_cast<uint8_t*>(arr)
 #define BYTES_CONST(arr) reinterpret_cast<const uint8_t*>(arr)
+
+#define UNUSED(x) (void)(x)

--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -14,14 +14,6 @@ class QueueTimeoutException : public faabric::util::FaabricException
     {}
 };
 
-class ExecutorFinishedException : public faabric::util::FaabricException
-{
-  public:
-    explicit ExecutorFinishedException(std::string message)
-      : FaabricException(std::move(message))
-    {}
-};
-
 template<typename T>
 class Queue
 {

--- a/src/mpi_native/MpiExecutor.cpp
+++ b/src/mpi_native/MpiExecutor.cpp
@@ -22,7 +22,7 @@ int32_t MpiExecutor::executeTask(
         logger->error("There was an error running the MPI function");
     }
 
-    throw faabric::util::ExecutorFinishedException("Finished MPI Execution!");
+    return 0;
 }
 
 int mpiNativeMain(int argc, char** argv)

--- a/src/runner/FaabricMain.cpp
+++ b/src/runner/FaabricMain.cpp
@@ -42,9 +42,6 @@ void FaabricMain::startRunner()
     auto& sch = faabric::scheduler::getScheduler();
     sch.addHostToGlobalSet();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-    conf.print();
-
 #if (FAASM_SGX)
     // Check for SGX capability and create shared enclave
     sgx::checkSgxSetup();

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -9,6 +9,8 @@
 #include <faabric/util/queue.h>
 #include <faabric/util/timing.h>
 
+#define POOL_SHUTDOWN -1
+
 namespace faabric::scheduler {
 
 // TODO - avoid the copy of the message here?
@@ -43,7 +45,7 @@ void Executor::finish()
 
         // Send a kill message
         logger->trace("Executor {} killing thread pool {}", id, i);
-        threadQueues.at(i).enqueue(std::make_pair(-1, nullptr));
+        threadQueues.at(i).enqueue(std::make_pair(POOL_SHUTDOWN, nullptr));
 
         // Await the thread
         if (threadPoolThreads.at(i)->joinable()) {
@@ -168,7 +170,7 @@ void Executor::threadPoolThread(int threadPoolIdx)
 
         // If the thread is being killed, the executor itself
         // will handle the clean-up
-        if (msgIdx == -1) {
+        if (msgIdx == POOL_SHUTDOWN) {
             logger->debug(
               "Killing thread pool thread {}:{}", id, threadPoolIdx);
             break;

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -216,7 +216,9 @@ void Executor::threadPoolThread(int threadPoolIdx)
 
         // Notify the scheduler
         if (oldTaskCount == 1) {
-            sch.notifyExecutorFinished(this, msg);
+            // Reset this executor ready for next invocation
+            releaseClaim();
+            reset(msg);
         }
     }
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -63,10 +63,10 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
 
     const std::string funcStr = faabric::util::funcToString(req);
     logger->trace("{} executing {}/{} tasks of {}",
-                 id,
-                 nMessages,
-                 req->messages_size(),
-                 funcStr);
+                  id,
+                  nMessages,
+                  req->messages_size(),
+                  funcStr);
 
     // Restore if necessary. If we're executing threads on the master host we
     // assume we don't need to restore, but for everything else we do. If we've

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -57,6 +57,14 @@ void Executor::finish()
     // Hook
     this->postFinish();
 
+    // Reset variables
+    boundMessage.Clear();
+    executingTaskCount = 0;
+
+    lastSnapshot = "";
+
+    claimed = false;
+
     threadPoolThreads.clear();
     threadQueues.clear();
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -205,5 +205,7 @@ void Executor::postFinish() {}
 
 void Executor::flush() {}
 
+void Executor::reset() {}
+
 void Executor::restore(const faabric::Message& msg) {}
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -58,8 +58,10 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
     int nMessages = msgIdxs.size();
 
     const std::string funcStr = faabric::util::funcToString(req);
-    logger->info(
-      "Executing {}/{} tasks of {}", nMessages, req->messages_size(), funcStr);
+    logger->info("{} executing {} tasks of {}",
+                 id,
+                 nMessages,
+                 funcStr);
 
     // Restore if necessary. If we're executing threads on the master host we
     // assume we don't need to restore, but for everything else we do. If we've

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -128,7 +128,8 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
                 threadPoolThreads.emplace(
                   std::make_pair(threadPoolIdx, [this, threadPoolIdx] {
                       auto logger = faabric::util::getLogger();
-                      logger->debug("Thread pool thread {} starting up",
+                      logger->debug("Thread pool thread {}:{} starting up",
+                                    id,
                                     threadPoolIdx);
 
                       auto& sch = faabric::scheduler::getScheduler();
@@ -168,7 +169,8 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
                               break;
                           }
 
-                          logger->trace("Thread {} executing task {} ({})",
+                          logger->trace("Thread {}:{} executing task {} ({})",
+                                        id,
                                         threadPoolIdx,
                                         msgIdx,
                                         msg.id());

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -214,11 +214,11 @@ void Executor::threadPoolThread(int threadPoolIdx)
             sch.setFunctionResult(msg);
         }
 
-        // Notify the scheduler
+        // Notify the scheduler, note that we have to release the claim _after_
+        // resetting, once the executor is ready to be reused
         if (oldTaskCount == 1) {
-            // Reset this executor ready for next invocation
-            releaseClaim();
             reset(msg);
+            releaseClaim();
         }
     }
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -10,6 +10,8 @@
 #include <faabric/util/timing.h>
 
 namespace faabric::scheduler {
+
+// TODO - avoid the copy of the message here?
 Executor::Executor(const faabric::Message& msg)
   : boundMessage(msg)
 {
@@ -58,10 +60,7 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
     int nMessages = msgIdxs.size();
 
     const std::string funcStr = faabric::util::funcToString(req);
-    logger->info("{} executing {} tasks of {}",
-                 id,
-                 nMessages,
-                 funcStr);
+    logger->info("{} executing {} tasks of {}", id, nMessages, funcStr);
 
     // Restore if necessary. If we're executing threads on the master host we
     // assume we don't need to restore, but for everything else we do. If we've
@@ -79,10 +78,8 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
         if ((!isMaster && isThreads) || !isThreads) {
             faabric::util::UniqueLock lock(threadsMutex);
 
-            if (snapshotKey != lastSnapshot) {
-                lastSnapshot = snapshotKey;
-                restore(firstMsg);
-            }
+            lastSnapshot = snapshotKey;
+            restore(firstMsg);
         }
     }
 

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -205,7 +205,7 @@ void Executor::postFinish() {}
 
 void Executor::flush() {}
 
-void Executor::reset() {}
+void Executor::reset(const faabric::Message& msg) {}
 
 void Executor::restore(const faabric::Message& msg) {}
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -28,10 +28,7 @@ Executor::Executor(const faabric::Message& msg)
     faabric::util::getLogger()->debug("Starting executor {}", id);
 }
 
-Executor::~Executor()
-{
-    finish();
-}
+Executor::~Executor() {}
 
 void Executor::finish()
 {

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -139,7 +139,7 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
 {
     faabric::util::FullLock lock(mx);
     const std::string funcStr = faabric::util::funcToString(msg, false);
-        const auto& logger = faabric::util::getLogger();
+    const auto& logger = faabric::util::getLogger();
 
     logger->debug("{} finished message {}", exec->id, msg.id());
 
@@ -344,8 +344,11 @@ std::vector<std::string> Scheduler::callFunctions(
         // At this point there's no more capacity in the system, so we
         // just need to execute locally
         if (offset < nMessages) {
-            logger->debug(
-              "Overloading {}/{} {} locally", nLocally, nMessages, funcStr);
+            int overloadCount = nMessages - offset;
+            logger->debug("Overloading {}/{} {} locally",
+                          overloadCount,
+                          nMessages,
+                          funcStr);
 
             for (; offset < nMessages; offset++) {
                 localMessageIdxs.emplace_back(offset);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -164,7 +164,7 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
     warmExecutors[funcStr].emplace_back(execPtr);
 
     // Reset the executor
-    execPtr->reset();
+    execPtr->reset(msg);
 }
 
 void Scheduler::notifyExecutorShutdown(Executor* exec,

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -139,6 +139,9 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
 {
     faabric::util::FullLock lock(mx);
     const std::string funcStr = faabric::util::funcToString(msg, false);
+        const auto& logger = faabric::util::getLogger();
+
+    logger->debug("{} finished message {}", exec->id, msg.id());
 
     std::vector<std::shared_ptr<Executor>>& executing =
       executingExecutors[funcStr];
@@ -155,7 +158,6 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
 
     // Check if not found
     if (execPtr == nullptr) {
-        const auto& logger = faabric::util::getLogger();
         logger->error("Unable to find record of executor {}", exec->id);
         throw std::runtime_error("Unable to find record of executor");
     }

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -63,12 +63,6 @@ void Scheduler::addHostToGlobalSet()
 void Scheduler::reset()
 {
     // Shut down all Executors
-    for (auto p : executors) {
-        for (auto e : p.second) {
-            e->finish();
-        }
-    }
-
     executors.clear();
 
     // Ensure host is set correctly
@@ -144,6 +138,8 @@ void Scheduler::notifyExecutorShutdown(Executor* exec,
                                        const faabric::Message& msg)
 {
     faabric::util::FullLock lock(mx);
+
+    faabric::util::getLogger()->trace("Shutting down executor {}", exec->id);
 
     std::string funcStr = faabric::util::funcToString(msg, false);
 
@@ -356,6 +352,8 @@ std::vector<std::string> Scheduler::callFunctions(
                   "Expected only one executor for threaded function");
             }
 
+            assert(e != nullptr);
+
             // Execute the tasks
             e->executeTasks(localMessageIdxs, req);
         } else {
@@ -552,6 +550,7 @@ std::shared_ptr<Executor> Scheduler::claimExecutor(const faabric::Message& msg)
         assert(claimed->tryClaim());
     }
 
+    assert(claimed != nullptr);
     return claimed;
 }
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -128,19 +128,6 @@ void Scheduler::vacateSlot()
     thisHostResources.set_usedslots(thisHostResources.usedslots() - 1);
 }
 
-void Scheduler::notifyExecutorFinished(Executor* exec,
-                                       const faabric::Message& msg)
-{
-    faabric::util::FullLock lock(mx);
-
-    const auto& logger = faabric::util::getLogger();
-    logger->debug("{} finished message {}", exec->id, msg.id());
-
-    // Reset this executor ready for next invocation
-    exec->releaseClaim();
-    exec->reset(msg);
-}
-
 void Scheduler::notifyExecutorShutdown(Executor* exec,
                                        const faabric::Message& msg)
 {

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -541,7 +541,7 @@ std::shared_ptr<Executor> Scheduler::claimExecutor(const faabric::Message& msg)
         claimed = thisExecutors.back();
 
         // Claim it
-        assert(claimed->tryClaim());
+        claimed->tryClaim();
     }
 
     assert(claimed != nullptr);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -62,23 +62,14 @@ void Scheduler::addHostToGlobalSet()
 
 void Scheduler::reset()
 {
-    faabric::util::FullLock lock(mx);
-
     // Shut down all Executors
-    for (auto p : warmExecutors) {
+    for (auto p : executors) {
         for (auto e : p.second) {
             e->finish();
         }
     }
 
-    for (auto p : executingExecutors) {
-        for (auto e : p.second) {
-            e->finish();
-        }
-    }
-
-    warmExecutors.clear();
-    executingExecutors.clear();
+    executors.clear();
 
     // Ensure host is set correctly
     thisHost = faabric::util::getSystemConfig().endpointHost;
@@ -107,7 +98,7 @@ void Scheduler::shutdown()
 long Scheduler::getFunctionExecutorCount(const faabric::Message& msg)
 {
     const std::string funcStr = faabric::util::funcToString(msg, false);
-    return warmExecutors[funcStr].size() + executingExecutors[funcStr].size();
+    return executors[funcStr].size();
 }
 
 int Scheduler::getFunctionRegisteredHostCount(const faabric::Message& msg)
@@ -140,34 +131,12 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
                                        const faabric::Message& msg)
 {
     faabric::util::FullLock lock(mx);
-    const std::string funcStr = faabric::util::funcToString(msg, false);
-    const auto& logger = faabric::util::getLogger();
 
+    const auto& logger = faabric::util::getLogger();
     logger->debug("{} finished message {}", exec->id, msg.id());
 
-    std::vector<std::shared_ptr<Executor>>& executing =
-      executingExecutors[funcStr];
-
-    // Find and remove from executing executors
-    std::shared_ptr<Executor> execPtr = nullptr;
-    for (int i = 0; i < executing.size(); i++) {
-        if (executing.at(i)->id == exec->id) {
-            execPtr = executing.at(i);
-            executing.erase(executing.begin() + i);
-            break;
-        }
-    }
-
-    // Check if not found
-    if (execPtr == nullptr) {
-        logger->error("Unable to find record of executor {}", exec->id);
-        throw std::runtime_error("Unable to find record of executor");
-    }
-
-    // Add back to pool of warm executors
-    warmExecutors[funcStr].emplace_back(execPtr);
-
-    // Rest this executor ready for next invocation
+    // Reset this executor ready for next invocation
+    exec->releaseClaim();
     exec->reset(msg);
 }
 
@@ -178,24 +147,14 @@ void Scheduler::notifyExecutorShutdown(Executor* exec,
 
     std::string funcStr = faabric::util::funcToString(msg, false);
 
-    std::vector<std::shared_ptr<Executor>>& warm = warmExecutors[funcStr];
-    std::vector<std::shared_ptr<Executor>>& executing =
-      executingExecutors[funcStr];
-
-    std::string execId = exec->id;
-
     // Remove from warm executors
-    std::remove_if(warm.begin(), warm.end(), [&execId](const auto& p) {
-        return p->id == execId;
-    });
-
-    // Remove from executing executors
-    std::remove_if(executing.begin(),
-                   executing.end(),
+    std::string execId = exec->id;
+    std::vector<std::shared_ptr<Executor>>& thisExecutors = executors[funcStr];
+    std::remove_if(thisExecutors.begin(),
+                   thisExecutors.end(),
                    [&execId](const auto& p) { return p->id == execId; });
 
-    int count = getFunctionExecutorCount(msg);
-    if (count == 0) {
+    if (thisExecutors.empty()) {
         // Unregister if this was the last executor for that function
         bool isMaster = thisHost == msg.masterhost();
         if (!isMaster) {
@@ -286,7 +245,7 @@ std::vector<std::string> Scheduler::callFunctions(
             nLocally = std::min<int>(available, nMessages);
         }
 
-        // Handle those that can be executed locally
+        // Add those that can be executed locally
         if (nLocally > 0) {
             logger->debug(
               "Executing {}/{} {} locally", nLocally, nMessages, funcStr);
@@ -357,29 +316,50 @@ std::vector<std::string> Scheduler::callFunctions(
                 executed.at(offset) = thisHost;
             }
         }
+
+        // Sanity check
+        assert(offset == nMessages);
     }
 
-    // Register thread results if need be
+    // Register thread results if necessary
     if (isThreads) {
         for (auto& m : req->messages()) {
             registerThread(m.id());
         }
     }
 
-    // Schedule messages locally if need be. For threads we only need one
+    // Schedule messages locally if necessary. For threads we only need one
     // executor, for anything else we want one Executor per function in flight
     if (!localMessageIdxs.empty()) {
         // Update slots
         thisHostResources.set_usedslots(thisHostResources.usedslots() +
                                         localMessageIdxs.size());
 
-        if (isThreads && !executingExecutors.empty()) {
-            std::shared_ptr<Executor> e = executingExecutors[funcStr].back();
-            e->executeTasks(localMessageIdxs, req);
-        } else if (isThreads) {
-            std::shared_ptr<Executor> e = claimExecutor(firstMsg);
+        if (isThreads) {
+            // Threads use the existing executor. We assume there's only one
+            // running at a time.
+            std::vector<std::shared_ptr<Executor>>& thisExecutors =
+              executors[funcStr];
+
+            std::shared_ptr<Executor> e = nullptr;
+            if (thisExecutors.empty()) {
+                // Create executor if not exists
+                e = claimExecutor(firstMsg);
+            } else if (thisExecutors.size() == 1) {
+                // Use existing executor if exists
+                e = thisExecutors.back();
+            } else {
+                logger->error("Found {} executors for threaded function {}",
+                              thisExecutors.size(),
+                              funcStr);
+                throw std::runtime_error(
+                  "Expected only one executor for threaded function");
+            }
+
+            // Execute the tasks
             e->executeTasks(localMessageIdxs, req);
         } else {
+            // Non-threads require one executor per task
             for (auto i : localMessageIdxs) {
                 std::shared_ptr<Executor> e = claimExecutor(firstMsg);
                 e->executeTasks({ i }, req);
@@ -544,31 +524,35 @@ std::shared_ptr<Executor> Scheduler::claimExecutor(const faabric::Message& msg)
     const auto& logger = faabric::util::getLogger();
     std::string funcStr = faabric::util::funcToString(msg, false);
 
-    int nWarmExecutors = warmExecutors[funcStr].size();
-    int nExecutingExecutors = executingExecutors[funcStr].size();
-    int nTotal = nWarmExecutors + nExecutingExecutors;
+    std::vector<std::shared_ptr<Executor>>& thisExecutors = executors[funcStr];
+    int nExecutors = thisExecutors.size();
 
     std::shared_ptr<faabric::scheduler::ExecutorFactory> factory =
       getExecutorFactory();
 
-    if (nWarmExecutors > 0) {
-        // Here we have warm executors that we can reuse
-        logger->debug("Reusing warm executor for {}", funcStr);
-
-        // Take the warm one
-        std::shared_ptr<Executor> exec = warmExecutors[funcStr].back();
-        warmExecutors[funcStr].pop_back();
-
-        // Add it to the list of executing
-        executingExecutors[funcStr].emplace_back(exec);
-    } else {
-        // We have no warm executors available, so scale up
-        logger->debug("Scaling {} from {} -> {}", funcStr, nTotal, nTotal + 1);
-
-        executingExecutors[funcStr].emplace_back(factory->createExecutor(msg));
+    std::shared_ptr<Executor> claimed = nullptr;
+    for (auto& e : thisExecutors) {
+        if (e->tryClaim()) {
+            claimed = e;
+            logger->debug(
+              "Reusing warm executor {} for {}", claimed->id, funcStr);
+            break;
+        }
     }
 
-    return executingExecutors[funcStr].back();
+    // We have no warm executors available, so scale up
+    if (claimed == nullptr) {
+        logger->debug(
+          "Scaling {} from {} -> {}", funcStr, nExecutors, nExecutors + 1);
+
+        thisExecutors.emplace_back(factory->createExecutor(msg));
+        claimed = thisExecutors.back();
+
+        // Claim it
+        assert(claimed->tryClaim());
+    }
+
+    return claimed;
 }
 
 std::string Scheduler::getThisHost()
@@ -600,8 +584,8 @@ void Scheduler::flushLocally()
     logger->info("Flushing host {}",
                  faabric::util::getSystemConfig().endpointHost);
 
-    // Flush each warm executor
-    for (auto& p : warmExecutors) {
+    // Flush each executor
+    for (auto& p : executors) {
         for (auto& f : p.second) {
             f->flush();
         }

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -75,6 +75,7 @@ void Scheduler::reset()
     // Reset scheduler state
     availableHostsCache.clear();
     registeredHosts.clear();
+    threadResults.clear();
 
     // Records
     recordedMessagesAll.clear();

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -479,8 +479,8 @@ int Scheduler::scheduleFunctionsOnHost(
     }
 
     // Push the snapshot if necessary
-    if (req->type() == req->THREADS || req->type() == req->PROCESSES) {
-        std::string snapshotKey = firstMsg.snapshotkey();
+    std::string snapshotKey = firstMsg.snapshotkey();
+    if (!snapshotKey.empty()) {
         SnapshotClient c(host);
         const SnapshotData& d =
           snapshot::getSnapshotRegistry().getSnapshot(snapshotKey);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -162,6 +162,9 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
 
     // Add back to pool of warm executors
     warmExecutors[funcStr].emplace_back(execPtr);
+
+    // Reset the executor
+    execPtr->reset();
 }
 
 void Scheduler::notifyExecutorShutdown(Executor* exec,

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -62,6 +62,8 @@ void Scheduler::addHostToGlobalSet()
 
 void Scheduler::reset()
 {
+    faabric::util::FullLock lock(mx);
+
     // Shut down all Executors
     for (auto p : warmExecutors) {
         for (auto e : p.second) {
@@ -165,8 +167,8 @@ void Scheduler::notifyExecutorFinished(Executor* exec,
     // Add back to pool of warm executors
     warmExecutors[funcStr].emplace_back(execPtr);
 
-    // Reset the executor
-    execPtr->reset(msg);
+    // Rest this executor ready for next invocation
+    exec->reset(msg);
 }
 
 void Scheduler::notifyExecutorShutdown(Executor* exec,

--- a/src/scheduler/SnapshotClient.cpp
+++ b/src/scheduler/SnapshotClient.cpp
@@ -51,12 +51,11 @@ void SnapshotClient::pushSnapshot(const std::string& key,
                                   const faabric::util::SnapshotData& req)
 {
     auto logger = faabric::util::getLogger();
+    logger->debug("Pushing snapshot {} to {}", key, host);
 
     if (faabric::util::isMockMode()) {
         snapshotPushes.emplace_back(host, req);
     } else {
-        logger->debug("Pushing snapshot {} to {}", key, host);
-
         ClientContext context;
 
         // TODO - avoid copying data here

--- a/src/state/DummyStateServer.cpp
+++ b/src/state/DummyStateServer.cpp
@@ -83,7 +83,7 @@ void DummyStateServer::start()
     });
 
     // Give it time to start
-    usleep(500 * 1000);
+    usleep(1000 * 1000);
 }
 
 void DummyStateServer::stop()

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -13,9 +13,9 @@ struct LogListener : Catch::TestEventListenerBase
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
         auto logger = faabric::util::getLogger();
-        logger->debug("---------------------------------------------");
-        logger->debug("TEST: {}", testInfo.name);
-        logger->debug("---------------------------------------------");
+        logger->info("---------------------------------------------");
+        logger->info("TEST: {}", testInfo.name);
+        logger->info("---------------------------------------------");
     }
 };
 

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -204,7 +204,7 @@ TEST_CASE("Test executing threads indirectly", "[executor]")
     cleanFaabric();
     restoreCount = 0;
 
-    int nThreads;
+    int nThreads = 100;
     SECTION("Underloaded") { nThreads = 8; }
 
     SECTION("Overloaded") { nThreads = 100; }

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -89,7 +89,8 @@ class TestExecutor final : public Executor
 
             for (int i = 0; i < chainedReq->messages_size(); i++) {
                 uint32_t mid = chainedReq->messages().at(i).id();
-                sch.awaitThreadResult(mid);
+                int threadRes = sch.awaitThreadResult(mid);
+                assert(threadRes == mid / 100);
             }
 
             logger->trace("TestExecutor got {} thread results",
@@ -136,8 +137,6 @@ class TestExecutor final : public Executor
         } else if (msg.function() == "error") {
             throw std::runtime_error("This is a test error");
         } else if (reqOrig->type() == faabric::BatchExecuteRequest::THREADS) {
-            logger->debug("TestExecutor executing thread {}", msg.id());
-
             return msg.id() / 100;
         } else {
             msg.set_outputdata(

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -84,9 +84,14 @@ class TestExecutor final : public Executor
             Scheduler& sch = getScheduler();
             sch.callFunctions(chainedReq);
 
-            for (auto& m : chainedReq->messages()) {
-                sch.awaitThreadResult(m.id());
+            for (int i = 0; i < chainedReq->messages_size(); i++) {
+                uint32_t mid = chainedReq->messages().at(i).id();
+                sch.awaitThreadResult(mid);
             }
+
+            logger->trace("TestExecutor got {} thread results",
+                          chainedReq->messages_size());
+            return 0;
         } else if (msg.function() == "chain-check-a") {
             if (msg.inputdata() == "chained") {
                 // Set up output data for the chained call
@@ -128,7 +133,6 @@ class TestExecutor final : public Executor
         } else if (msg.function() == "error") {
             throw std::runtime_error("This is a test error");
         } else if (reqOrig->type() == faabric::BatchExecuteRequest::THREADS) {
-            auto logger = faabric::util::getLogger();
             logger->debug("TestExecutor executing thread {}", msg.id());
 
             return msg.id() / 100;

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -584,4 +584,35 @@ TEST_CASE("Test executing different functions", "[executor]")
     sch.shutdown();
 }
 
+TEST_CASE("Test claiming and releasing executor", "[executor]")
+{
+    cleanFaabric();
+
+    faabric::Message msgA = faabric::util::messageFactory("foo", "bar");
+    faabric::Message msgB = faabric::util::messageFactory("foo", "bar");
+
+    std::shared_ptr<faabric::scheduler::ExecutorFactory> fac =
+      faabric::scheduler::getExecutorFactory();
+    std::shared_ptr<faabric::scheduler::Executor> execA =
+      fac->createExecutor(msgA);
+    std::shared_ptr<faabric::scheduler::Executor> execB =
+      fac->createExecutor(msgB);
+
+    // Claim one
+    REQUIRE(execA->tryClaim());
+
+    // Check can't claim again
+    REQUIRE(!execA->tryClaim());
+
+    // Same for the other
+    REQUIRE(execB->tryClaim());
+    REQUIRE(!execB->tryClaim());
+
+    // Release one and check can claim again
+    execA->releaseClaim();
+
+    REQUIRE(execA->tryClaim());
+    REQUIRE(!execB->tryClaim());
+}
+
 }

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -169,6 +169,10 @@ TEST_CASE("Test executing threads directly", "[executor]")
     restoreCount = 0;
 
     int nThreads = 10;
+    SECTION("Underloaded") { nThreads = 10; }
+
+    SECTION("Overloaded") { nThreads = 200; }
+
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "blah", nThreads);
     req->set_type(faabric::BatchExecuteRequest::THREADS);
@@ -200,7 +204,11 @@ TEST_CASE("Test executing threads indirectly", "[executor]")
     cleanFaabric();
     restoreCount = 0;
 
-    int nThreads = 8;
+    int nThreads;
+    SECTION("Underloaded") { nThreads = 8; }
+
+    SECTION("Overloaded") { nThreads = 100; }
+
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "thread-check", 1);
     faabric::Message& msg = req->mutable_messages()->at(0);

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -372,7 +372,7 @@ TEST_CASE("Test executing remote threads indirectly", "[executor]")
         sch.callFunctions(req, false);
 
         faabric::Message res = sch.getFunctionResult(msg.id(), 2000);
-        REQUIRE(res.returnvalue() == 0);
+        assert(res.returnvalue() == 0);
     });
 
     // Give it time to have made the request

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -35,6 +35,10 @@ class TestExecutor final : public Executor
         faabric::Message& msg = req->mutable_messages()->at(msgIdx);
         bool isThread = req->type() == faabric::BatchExecuteRequest::THREADS;
 
+        // Check we're being asked to execute the message we've bound to
+        REQUIRE(msg.user() == boundMessage.user());
+        REQUIRE(msg.function() == boundMessage.function());
+
         // Custom thread-check function
         if (msg.function() == "thread-check" && !isThread) {
             msg.set_outputdata(fmt::format(
@@ -77,8 +81,8 @@ class TestExecutor final : public Executor
 
             return msg.id() / 100;
         } else {
-            msg.set_outputdata(fmt::format(
-              "Simple function {} executed", msg.id()));
+            msg.set_outputdata(
+              fmt::format("Simple function {} executed", msg.id()));
         }
 
         return 0;
@@ -147,8 +151,7 @@ TEST_CASE("Test executing simple function", "[executor]")
     auto& sch = faabric::scheduler::getScheduler();
     faabric::Message result =
       sch.getFunctionResult(msgId, SHORT_TEST_TIMEOUT_MS);
-    std::string expected =
-      fmt::format("Simple function {} executed", msgId);
+    std::string expected = fmt::format("Simple function {} executed", msgId);
     REQUIRE(result.outputdata() == expected);
 
     // Check that restore has not been called


### PR DESCRIPTION
After testing out the new Executor set-up in anger, added the following changes:

- Give Faabric responsibility for calling `restore` and `reset` as part of the `Executor` lifecycle (`restore` gets called to restore a snapshot, and `reset` when a function has finished).
- In the scheduler, avoid use of maps with an integer index where we know the keys will just be a range 0 to N (instead use an array).
- Have the scheduler "claim" `Executor`s when they're executing, rather than switching them between lists of `warm` and `executing` executors.
- Add more logging to the `Executor` lifecycle (mostly `trace`-level to avoid bloat in normal circumstances).
- Add more detailed tests to check overloading, chaining, executing different functions and restore counts.
- Avoid the use of `REQUIRE` in more than one thread in Catch2 tests (as it's [not safe](https://github.com/catchorg/Catch2/blob/devel/docs/limitations.md#thread-safe-assertions)).
- Fix small bug thread pool index allocation, where threads must be executed by the thread pool index `>= 1`, leaving `0` free to execute the spawning function (thus avoiding deadlocks).

I've also sprinkled a few `assert`s around the place. I've tried to stick to the rule of checking inputs to "external" interfaces, or to sense-check a bit of thorny logic (e.g. in the scheduler). Hopefully these should catch slip ups in the future.