### PR TITLE
Configurable build types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches: [master]
-  pull_request: 
+  pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -29,15 +29,16 @@ jobs:
         run: git fetch origin ${GITHUB_REF}:ci-branch
       - name: "Check out branch"
         run: git checkout --force ci-branch
+      # Note - here we build a release build to be the same as the container
       - name: "Run cmake"
-        run: inv dev.cmake
+        run: inv dev.cmake --build=Release
       - name: "Rerun build to ensure code is up to date"
-        run: inv dev.cc faabric_tests 
+        run: inv dev.cc faabric_tests
       # --- Formatting checks ---
       - name: "Python formatting check"
         run: ./bin/check_python.sh
       - name: "Run C/C++ formatting"
-        run: ./bin/run_clang_format.sh 
+        run: ./bin/run_clang_format.sh
       - name: "Check C/C++ formatting changes"
         run: git diff --exit-code
       - name: "Run C/C++ linter"
@@ -67,9 +68,9 @@ jobs:
       # --- Set-up ---
       - name: "Ping redis"
         run: redis-cli -h redis ping
-      # --- Tests build ---
-      - name: "Run cmake static"
-        run: inv dev.cmake
+      # --- Tests build - need a debug build for actually running tests ---
+      - name: "Run cmake for tests"
+        run: inv dev.cmake --build=Debug
       - name: "Build tests"
         run: inv dev.cc faabric_tests
       # --- Tests ---
@@ -100,7 +101,7 @@ jobs:
         run: git checkout --force ci-branch
       # --- Examples ---
       - name: "Run cmake shared"
-        run: inv dev.cmake --shared
+        run: inv dev.cmake --shared --build=Release
       - name: "Build Faabric shared library"
         run: inv dev.cc faabric --shared
       - name: "Install Faabric shared library"

--- a/docker/faabric.dockerfile
+++ b/docker/faabric.dockerfile
@@ -25,12 +25,12 @@ WORKDIR /code/faabric
 RUN pip3 install -r requirements.txt
 
 # Static build
-RUN inv dev.cmake
+RUN inv dev.cmake --build=Release
 RUN inv dev.cc faabric
 RUN inv dev.cc faabric_tests
 
 # Shared build
-RUN inv dev.cmake --shared
+RUN inv dev.cmake --shared --build=Release
 RUN inv dev.cc faabric --shared
 RUN inv dev.install faabric --shared
 

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -14,7 +14,7 @@ from invoke import task
 
 
 @task
-def cmake(ctx, clean=False, shared=False):
+def cmake(ctx, clean=False, shared=False, build="Debug"):
     """
     Configures the build
     """
@@ -28,11 +28,15 @@ def cmake(ctx, clean=False, shared=False):
     if not exists(build_dir):
         makedirs(build_dir)
 
+    build_types = ["Release", "Debug"]
+    if build not in build_types:
+        raise RuntimeError("Expected build to be in {}".format(build_types))
+
     cmd = [
         "cmake",
         "-GNinja",
         "-DCMAKE_INSTALL_PREFIX={}".format(FAABRIC_INSTALL_PREFIX),
-        "-DCMAKE_BUILD_TYPE=Debug",
+        "-DCMAKE_BUILD_TYPE={}".format(build),
         "-DBUILD_SHARED_LIBS={}".format("ON" if shared else "OFF"),
         "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-10",
         "-DCMAKE_C_COMPILER=/usr/bin/clang-10",

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -9,6 +9,7 @@
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
+#include <faabric/util/macros.h>
 #include <faabric/util/testing.h>
 
 using namespace faabric::scheduler;
@@ -90,6 +91,7 @@ class TestExecutor final : public Executor
             for (int i = 0; i < chainedReq->messages_size(); i++) {
                 uint32_t mid = chainedReq->messages().at(i).id();
                 int threadRes = sch.awaitThreadResult(mid);
+                UNUSED(threadRes);
                 assert(threadRes == mid / 100);
             }
 


### PR DESCRIPTION
The default build type for Faabric has always been `Debug`, including in the container builds. This makes it configurable and does `Release` builds in the container builds (but a `Debug` build for tests).