### PR TITLE
Shutdown issue fix

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -67,13 +67,13 @@ class Executor
 
     std::mutex threadsMutex;
     std::vector<std::shared_ptr<std::thread>> threadPoolThreads;
+    std::vector<std::shared_ptr<std::thread>> deadThreads;
+
     std::vector<faabric::util::Queue<
       std::pair<int, std::shared_ptr<faabric::BatchExecuteRequest>>>>
       threadQueues;
 
     void threadPoolThread(int threadPoolIdx);
-
-    void shutdownThreadPoolThread(int threadPoolIdx);
 };
 
 class Scheduler
@@ -166,6 +166,8 @@ class Scheduler
     std::string thisHost;
 
     faabric::util::SystemConfig& conf;
+
+    std::vector<std::shared_ptr<Executor>> deadExecutors;
 
     std::unordered_map<std::string, std::vector<std::shared_ptr<Executor>>>
       executors;

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -629,7 +629,7 @@ TEST_CASE("Test executor timing out waiting", "[executor]")
 
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory("foo", "bar", 1);
-    faabric::Message &msg = req->mutable_messages()->at(0);
+    faabric::Message& msg = req->mutable_messages()->at(0);
 
     // Set a very short bound timeout so we can check it works
     auto& conf = faabric::util::getSystemConfig();

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -623,4 +623,29 @@ TEST_CASE("Test claiming and releasing executor", "[executor]")
     REQUIRE(!execB->tryClaim());
 }
 
+TEST_CASE("Test executor timing out waiting", "[executor]")
+{
+    cleanFaabric();
+
+    std::shared_ptr<faabric::BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("foo", "bar", 1);
+    faabric::Message &msg = req->mutable_messages()->at(0);
+
+    // Set a very short bound timeout so we can check it works
+    auto& conf = faabric::util::getSystemConfig();
+    conf.boundTimeout = 300;
+
+    auto& sch = faabric::scheduler::getScheduler();
+    sch.callFunctions(req);
+
+    REQUIRE(sch.getFunctionExecutorCount(msg) == 1);
+
+    usleep((conf.boundTimeout + 500) * 1000);
+
+    REQUIRE(sch.getFunctionExecutorCount(msg) == 0);
+
+    conf.reset();
+
+    sch.shutdown();
+}
 }


### PR DESCRIPTION
Three problems fixed in here:

- When thread pool thread `0` finished in the executor, the reference to it was being removed, so it couldn't be joined, and hence when running quickly, would cause `terminate caused without an active exception`-like errors.
- When an executor was removed from the scheduler, the same thing was happening; the executor thread pool would finish, the reference would be removed, then the scheduler couldn't clear it up.
- The executor removal code wasn't actually working, calling `remove_if` but not calling `erase`.

Because all of this shutdown happens _inside_ one of the worker threads of the executor, we can't fully kill the executor without a deadlock (as it must also await the worker thread itself). As a result, I've added a bit of a hack which is to have a list of `deadExecutors` and `deadThreads` which will also get tidied up at the end.