### PR TITLE
Avoid potential race condition

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -176,10 +176,10 @@ void MpiWorld::registerRank(int rank)
 std::string MpiWorld::getHostForRank(int rank)
 {
     // Pull from state if not present
-    if (rankHostMap.count(rank) == 0) {
+    if (rankHostMap.find(rank) == rankHostMap.end()) {
         faabric::util::FullLock lock(worldMutex);
 
-        if (rankHostMap.count(rank) == 0) {
+        if (rankHostMap.find(rank) == rankHostMap.end()) {
             auto buffer = new uint8_t[MPI_HOST_STATE_LEN];
             const std::shared_ptr<state::StateKeyValue>& kv =
               getRankHostState(rank);
@@ -200,7 +200,10 @@ std::string MpiWorld::getHostForRank(int rank)
         }
     }
 
-    return rankHostMap[rank];
+    {
+        faabric::util::SharedLock lock(worldMutex);
+        return rankHostMap[rank];
+    }
 }
 
 void MpiWorld::getCartesianRank(int rank,
@@ -1120,17 +1123,20 @@ std::shared_ptr<InMemoryMpiQueue> MpiWorld::getLocalQueue(int sendRank,
     checkRankOnThisHost(recvRank);
 
     std::string key = std::to_string(sendRank) + "_" + std::to_string(recvRank);
-    if (localQueueMap.count(key) == 0) {
+    if (localQueueMap.find(key) == localQueueMap.end()) {
         faabric::util::FullLock lock(worldMutex);
 
-        if (localQueueMap.count(key) == 0) {
+        if (localQueueMap.find(key) == localQueueMap.end()) {
             auto mq = new InMemoryMpiQueue();
             localQueueMap.emplace(
               std::pair<std::string, InMemoryMpiQueue*>(key, mq));
         }
     }
 
-    return localQueueMap[key];
+    {
+        faabric::util::SharedLock lock(worldMutex);
+        return localQueueMap[key];
+    }
 }
 
 void MpiWorld::rmaGet(int sendRank,

--- a/src/scheduler/MpiWorldRegistry.cpp
+++ b/src/scheduler/MpiWorldRegistry.cpp
@@ -42,15 +42,18 @@ MpiWorld& MpiWorldRegistry::getOrInitialiseWorld(const faabric::Message& msg,
                                                  int worldId)
 {
     // Create world locally if not exists
-    if (worldMap.count(worldId) == 0) {
+    if (worldMap.find(worldId) == worldMap.end()) {
         faabric::util::FullLock lock(registryMutex);
-        if (worldMap.count(worldId) == 0) {
+        if (worldMap.find(worldId) == worldMap.end()) {
             MpiWorld& world = worldMap[worldId];
             world.initialiseFromState(msg, worldId);
         }
     }
 
-    return worldMap[worldId];
+    {
+        faabric::util::SharedLock lock(registryMutex);
+        return worldMap[worldId];
+    }
 }
 
 MpiWorld& MpiWorldRegistry::getWorld(int worldId)


### PR DESCRIPTION
The MPI code does the following to access shared objects: (i) check if it's in a map; (ii) if not in map, add to map _then_ initialise; (iii) return value from the map. Once a thread has entered part (ii), another thread can come along and access the object while it's still initialising, hence seeing a partially/ un-initialised object