### PR TITLE
Dirty page checking and snapshot diffs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      # --- Tidy up ---
+      - name: "Remove existing containers"
+        run: "docker ps -aq | xargs docker stop | xargs docker rm"
       # --- Code update ---
       - name: "Check out code"
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,7 @@ jobs:
       # --- Tidy up ---
       - name: "Remove existing containers"
         run: "docker ps -aq | xargs docker stop | xargs docker rm"
+        continue-on-error: true
       # --- Code update ---
       - name: "Check out code"
         uses: actions/checkout@v2

--- a/dist-test/run.sh
+++ b/dist-test/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 export PROJ_ROOT=$(dirname $(dirname $(readlink -f $0)))
 pushd ${PROJ_ROOT}/dist-test >> /dev/null
 
@@ -10,6 +8,8 @@ if [[ -z "${FAABRIC_CLI_IMAGE}" ]]; then
     VERSION=$(cat ../VERSION)
     export FAABRIC_CLI_IMAGE=faasm/faabric:${VERSION}
 fi
+
+RETURN_VAL=0
 
 if [ "$1" == "local" ]; then
     INNER_SHELL=${SHELL:-"/bin/bash"}
@@ -32,9 +32,16 @@ else
         run \
         master \
         /build/faabric/static/bin/faabric_dist_tests
+    RETURN_VAL=$?
 
-    docker-compose \
-        stop
+    echo "-------------------------------------------"
+    echo "                WORKER LOGS                "
+    echo "-------------------------------------------"
+    docker-compose logs worker
+
+    docker-compose stop
 fi
 
 popd >> /dev/null
+
+exit $RETURN_VAL

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -27,9 +27,6 @@ getResourceRequests();
 std::vector<std::pair<std::string, faabric::UnregisterRequest>>
 getUnregisterRequests();
 
-std::vector<std::pair<std::string, faabric::ThreadResultRequest>>
-getThreadResults();
-
 void queueResourceResponse(const std::string& host,
                            faabric::HostResources& res);
 
@@ -55,8 +52,6 @@ class FunctionCallClient : public faabric::transport::MessageEndpointClient
       const std::shared_ptr<faabric::BatchExecuteRequest> req);
 
     void unregister(const faabric::UnregisterRequest& req);
-
-    void setThreadResult(const faabric::ThreadResultRequest& req);
 
   private:
     void sendHeader(faabric::scheduler::FunctionCalls call);

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -15,10 +15,6 @@ class FunctionCallServer final
   public:
     FunctionCallServer();
 
-    /* Stop the function call server
-     *
-     * Override the base stop method to do some implementation-specific cleanup.
-     */
     void stop() override;
 
   private:

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -196,6 +196,7 @@ class Scheduler
     faabric::scheduler::FunctionCallClient& getFunctionCallClient(
       const std::string& otherHost);
 
+    std::mutex snapshotClientsMutex;
     std::unordered_map<std::string, faabric::scheduler::SnapshotClient>
       snapshotClients;
     faabric::scheduler::SnapshotClient& getSnapshotClient(

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -52,9 +52,9 @@ class Executor
 
     void releaseClaim();
 
-  protected:
     virtual faabric::util::SnapshotData snapshot();
 
+  protected:
     virtual void restore(const faabric::Message& msg);
 
     virtual void postFinish();
@@ -122,7 +122,7 @@ class Scheduler
                          int32_t returnValue,
                          const std::vector<faabric::util::SnapshotDiff>& diffs);
 
-    void setThreadResult(uint32_t msgId, int32_t returnValue);
+    void setThreadResultLocally(uint32_t msgId, int32_t returnValue);
 
     int32_t awaitThreadResult(uint32_t messageId);
 

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -191,12 +191,13 @@ class Scheduler
 
     std::unordered_map<uint32_t, std::promise<int32_t>> threadResults;
 
+    std::shared_mutex functionCallClientsMx;
     std::unordered_map<std::string, faabric::scheduler::FunctionCallClient>
       functionCallClients;
     faabric::scheduler::FunctionCallClient& getFunctionCallClient(
       const std::string& otherHost);
 
-    std::mutex snapshotClientsMutex;
+    std::shared_mutex snapshotClientsMx;
     std::unordered_map<std::string, faabric::scheduler::SnapshotClient>
       snapshotClients;
     faabric::scheduler::SnapshotClient& getSnapshotClient(

--- a/include/faabric/scheduler/SnapshotApi.h
+++ b/include/faabric/scheduler/SnapshotApi.h
@@ -5,6 +5,8 @@ enum SnapshotCalls
 {
     NoSnapshotCall = 0,
     PushSnapshot = 1,
-    DeleteSnapshot = 2,
+    PushSnapshotDiffs = 2,
+    DeleteSnapshot = 3,
+    ThreadResult = 4,
 };
 }

--- a/include/faabric/scheduler/SnapshotClient.h
+++ b/include/faabric/scheduler/SnapshotClient.h
@@ -14,7 +14,17 @@ namespace faabric::scheduler {
 std::vector<std::pair<std::string, faabric::util::SnapshotData>>
 getSnapshotPushes();
 
+std::vector<std::pair<std::string, std::vector<faabric::util::SnapshotDiff>>>
+getSnapshotDiffPushes();
+
 std::vector<std::pair<std::string, std::string>> getSnapshotDeletes();
+
+std::vector<std::pair<std::string,
+                      std::tuple<uint32_t,
+                                 int,
+                                 std::string,
+                                 std::vector<faabric::util::SnapshotDiff>>>>
+getThreadResults();
 
 void clearMockSnapshotRequests();
 
@@ -32,7 +42,18 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
     void pushSnapshot(const std::string& key,
                       const faabric::util::SnapshotData& data);
 
+    void pushSnapshotDiffs(std::string snapshotKey,
+                           std::vector<faabric::util::SnapshotDiff> diffs);
+
     void deleteSnapshot(const std::string& key);
+
+    void pushThreadResult(uint32_t messageId, int returnValue);
+
+    void pushThreadResult(
+      uint32_t messageId,
+      int returnValue,
+      const std::string& snapshotKey,
+      const std::vector<faabric::util::SnapshotDiff>& diffs);
 
   private:
     void sendHeader(faabric::scheduler::SnapshotCalls call);

--- a/include/faabric/scheduler/SnapshotClient.h
+++ b/include/faabric/scheduler/SnapshotClient.h
@@ -56,7 +56,7 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
       const std::vector<faabric::util::SnapshotDiff>& diffs);
 
   private:
-    std::shared_ptr<spdlog::logger> logger;
+    const std::shared_ptr<spdlog::logger> logger;
     void sendHeader(faabric::scheduler::SnapshotCalls call);
 };
 }

--- a/include/faabric/scheduler/SnapshotClient.h
+++ b/include/faabric/scheduler/SnapshotClient.h
@@ -56,6 +56,7 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
       const std::vector<faabric::util::SnapshotDiff>& diffs);
 
   private:
+    std::shared_ptr<spdlog::logger> logger;
     void sendHeader(faabric::scheduler::SnapshotCalls call);
 };
 }

--- a/include/faabric/scheduler/SnapshotServer.h
+++ b/include/faabric/scheduler/SnapshotServer.h
@@ -11,6 +11,8 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
   public:
     SnapshotServer();
 
+    void stop() override;
+
   protected:
     void doRecv(faabric::transport::Message& header,
                 faabric::transport::Message& body) override;
@@ -20,5 +22,14 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     void recvPushSnapshot(faabric::transport::Message& msg);
 
     void recvDeleteSnapshot(faabric::transport::Message& msg);
+
+    void recvPushSnapshotDiffs(faabric::transport::Message& msg);
+
+    void recvThreadResult(faabric::transport::Message& msg);
+
+  private:
+    void applyDiffsToSnapshot(
+      const std::string& snapshotKey,
+      const flatbuffers::Vector<flatbuffers::Offset<SnapshotDiffChunk>>* diffs);
 };
 }

--- a/include/faabric/snapshot/SnapshotRegistry.h
+++ b/include/faabric/snapshot/SnapshotRegistry.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/util/logging.h>
 #include <faabric/util/snapshot.h>
 
 namespace faabric::snapshot {
@@ -29,6 +30,8 @@ class SnapshotRegistry
     void clear();
 
   private:
+    std::shared_ptr<spdlog::logger> logger;
+
     std::unordered_map<std::string, faabric::util::SnapshotData> snapshotMap;
 
     std::mutex snapshotsMx;

--- a/include/faabric/snapshot/SnapshotRegistry.h
+++ b/include/faabric/snapshot/SnapshotRegistry.h
@@ -30,7 +30,7 @@ class SnapshotRegistry
     void clear();
 
   private:
-    std::shared_ptr<spdlog::logger> logger;
+    const std::shared_ptr<spdlog::logger> logger;
 
     std::unordered_map<std::string, faabric::util::SnapshotData> snapshotMap;
 

--- a/include/faabric/transport/MessageContext.h
+++ b/include/faabric/transport/MessageContext.h
@@ -29,7 +29,7 @@ class MessageContext
     /* Close the message context
      *
      * In 0MQ terms, this method calls close() on the context, which in turn
-     * first shutdowns (i.e. stop blocking operations) and then closes.
+     * first shuts down (i.e. stop blocking operations) and then closes.
      */
     void close();
 

--- a/include/faabric/util/memory.h
+++ b/include/faabric/util/memory.h
@@ -1,8 +1,14 @@
 #pragma once
 
+#include <cstdint>
 #include <unistd.h>
+#include <vector>
 
 namespace faabric::util {
+
+// -------------------------
+// Alignment
+// -------------------------
 struct AlignedChunk
 {
     long originalOffset = 0;
@@ -25,4 +31,11 @@ size_t getRequiredHostPagesRoundDown(size_t nBytes);
 size_t alignOffsetDown(size_t offset);
 
 AlignedChunk getPageAlignedChunk(long offset, long length);
+
+// -------------------------
+// Dirty pages
+// -------------------------
+void resetDirtyTracking();
+
+std::vector<bool> getDirtyPages(const uint8_t* ptr, int nPages);
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -1,13 +1,32 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace faabric::util {
 
-struct SnapshotData
+struct SnapshotDiff
 {
+    uint32_t offset = 0;
     size_t size = 0;
     const uint8_t* data = nullptr;
-    int fd = 0;
+
+    SnapshotDiff(uint32_t offsetIn, const uint8_t* dataIn, size_t sizeIn)
+    {
+        offset = offsetIn;
+        data = dataIn;
+        size = sizeIn;
+    }
 };
+
+class SnapshotData
+{
+  public:
+    size_t size = 0;
+    uint8_t* data = nullptr;
+    int fd = 0;
+
+    std::vector<SnapshotDiff> getDirtyPages();
+};
+
 }

--- a/src/flat/CMakeLists.txt
+++ b/src/flat/CMakeLists.txt
@@ -5,12 +5,13 @@
 set(FB_HEADER "${CMAKE_CURRENT_LIST_DIR}/faabric_generated.h")
 set(FB_HEADER_COPIED "${FAABRIC_INCLUDE_DIR}/faabric/flat/faabric_generated.h")
 
+# flatc command to generate flatbuffers files
 add_custom_command(
     OUTPUT "${FB_HEADER}"
     DEPENDS faabric.fbs
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     COMMAND ${FLATBUFFERS_FLATC_EXECUTABLE}
-    ARGS --cpp --raw-binary faabric.fbs
+    ARGS --cpp --gen-mutable --raw-binary faabric.fbs
 )
 
 # Copy the generated headers into place

--- a/src/flat/faabric.fbs
+++ b/src/flat/faabric.fbs
@@ -1,4 +1,5 @@
 table SnapshotPushRequest {
+  return_host:string;
   key:string;
   contents:[ubyte];
 }
@@ -13,6 +14,7 @@ table SnapshotDiffChunk {
 }
 
 table SnapshotDiffPushRequest {
+  return_host:string;
   key:string;
   chunks:[SnapshotDiffChunk];
 }

--- a/src/flat/faabric.fbs
+++ b/src/flat/faabric.fbs
@@ -3,15 +3,23 @@ table SnapshotPushRequest {
   contents:[ubyte];
 }
 
-table SnapshotPushResponse {
-  message:string;
-}
-
 table SnapshotDeleteRequest {
   key:string;
 }
 
-table SnapshotDeleteResponse {
-  message:string;
+table SnapshotDiffChunk {
+  offset:int;
+  data:[ubyte];
 }
 
+table SnapshotDiffPushRequest {
+  key:string;
+  chunks:[SnapshotDiffChunk];
+}
+
+table ThreadResultRequest {
+  message_id:int;
+  return_value:int;
+  key:string;
+  chunks:[SnapshotDiffChunk];
+}

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -50,11 +50,6 @@ message UnregisterRequest {
     Message function = 2;
 }
 
-message ThreadResultRequest {
-    int32 messageId = 1;
-    int32 returnValue = 2;
-}
-
 message FunctionStatusResponse {
     enum FunctionStatus {
         OK = 0;

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -27,7 +27,6 @@ message BatchExecuteRequest {
 
     // Shared snapshot used for threads
     string snapshotKey = 3;
-    int32 snapshotSize = 4;
 
     repeated Message messages = 5;
 
@@ -109,7 +108,6 @@ message Message {
     int32 returnValue = 11;
 
     string snapshotKey = 12;
-    int32 snapshotSize = 13;
 
     int64 timestamp = 14;
     string resultKey = 15;

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -6,6 +6,7 @@
 #include <faabric/util/environment.h>
 #include <faabric/util/func.h>
 #include <faabric/util/gids.h>
+#include <faabric/util/memory.h>
 #include <faabric/util/queue.h>
 #include <faabric/util/timing.h>
 
@@ -122,6 +123,12 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
           "Skipping already restored snapshot {} [{}]", funcStr, snapshotKey);
     }
 
+    // Reset dirty page tracking if we're executing threads.
+    // Note this must be done after the restore has happened
+    if (isThreads && isSnapshot) {
+        faabric::util::resetDirtyTracking();
+    }
+
     // Set executing task count
     executingTaskCount += msgIdxs.size();
 
@@ -216,6 +223,7 @@ void Executor::threadPoolThread(int threadPoolIdx)
         // Decrement the task count
         int oldTaskCount = executingTaskCount.fetch_sub(1);
         assert(oldTaskCount >= 0);
+        bool isLastTask = oldTaskCount == 1;
 
         logger->trace("Task {} finished by thread {}:{} ({} left)",
                       msg.id(),
@@ -223,15 +231,30 @@ void Executor::threadPoolThread(int threadPoolIdx)
                       threadPoolIdx,
                       executingTaskCount);
 
-        // Set function result
-        if (req->type() == faabric::BatchExecuteRequest::THREADS) {
+        bool isThreads = req->type() == faabric::BatchExecuteRequest::THREADS;
+        if (isLastTask && isThreads) {
+            logger->debug("Task {} finished, returning snapshot diffs",
+                          msg.id());
+
+            // Get diffs
+            faabric::util::SnapshotData d = snapshot();
+            std::vector<faabric::util::SnapshotDiff> diffs = d.getDirtyPages();
+
+            // Send diffs along with thread result
+            sch.setThreadResult(msg, returnValue, diffs);
+
+            // Reset dirty page tracking
+            faabric::util::resetDirtyTracking();
+        } else if (isThreads) {
+            // Set non-final thread result
             sch.setThreadResult(msg, returnValue);
         } else {
+            // Set normal function result
             sch.setFunctionResult(msg);
         }
 
-        // Notify the scheduler, note that we have to release the claim _after_
-        // resetting, once the executor is ready to be reused
+        // Reset and release claim. Note that we have to release the claim
+        // _after_ resetting, once the executor is ready to be reused
         if (oldTaskCount == 1) {
             reset(msg);
             releaseClaim();
@@ -296,5 +319,17 @@ void Executor::flush() {}
 
 void Executor::reset(const faabric::Message& msg) {}
 
-void Executor::restore(const faabric::Message& msg) {}
+faabric::util::SnapshotData Executor::snapshot()
+{
+    faabric::util::getLogger()->warn(
+      "Executor has not implemented snapshot method");
+    faabric::util::SnapshotData d;
+    return d;
+}
+
+void Executor::restore(const faabric::Message& msg)
+{
+    faabric::util::getLogger()->warn(
+      "Executor has not implemented restore method");
+}
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -233,18 +233,19 @@ void Executor::threadPoolThread(int threadPoolIdx)
 
         bool isThreads = req->type() == faabric::BatchExecuteRequest::THREADS;
         if (isLastTask && isThreads) {
-            logger->debug("Task {} finished, returning snapshot diffs",
-                          msg.id());
-
             // Get diffs
             faabric::util::SnapshotData d = snapshot();
             std::vector<faabric::util::SnapshotDiff> diffs = d.getDirtyPages();
 
+            logger->debug("Task {} finished, returning {} snapshot diffs",
+                          msg.id(),
+                          diffs.size());
+
+            // Reset dirty page tracking now that we've got the diffs
+            faabric::util::resetDirtyTracking();
+
             // Send diffs along with thread result
             sch.setThreadResult(msg, returnValue, diffs);
-
-            // Reset dirty page tracking
-            faabric::util::resetDirtyTracking();
         } else if (isThreads) {
             // Set non-final thread result
             sch.setThreadResult(msg, returnValue);

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -42,9 +42,6 @@ void FunctionCallServer::doRecv(faabric::transport::Message& header,
         case faabric::scheduler::FunctionCalls::GetResources:
             this->recvGetResources(body);
             break;
-        case faabric::scheduler::FunctionCalls::SetThreadResult:
-            this->recvSetThreadResult(body);
-            break;
         default:
             throw std::runtime_error(
               fmt::format("Unrecognized call header: {}", call));
@@ -102,15 +99,5 @@ void FunctionCallServer::recvGetResources(faabric::transport::Message& body)
     // Send the response body
     faabric::HostResources response = scheduler.getThisHostResources();
     SEND_SERVER_RESPONSE(response, msg.returnhost(), FUNCTION_CALL_PORT)
-}
-
-void FunctionCallServer::recvSetThreadResult(faabric::transport::Message& body)
-{
-    PARSE_MSG(faabric::ThreadResultRequest, body.data(), body.size())
-
-    faabric::util::getLogger()->info(
-      "Setting thread {} result to {}", msg.messageid(), msg.returnvalue());
-
-    scheduler.setThreadResult(msg.messageid(), msg.returnvalue());
 }
 }

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -588,15 +588,22 @@ SnapshotClient& Scheduler::getSnapshotClient(const std::string& otherHost)
     auto it = snapshotClients.find(key);
     if (it == snapshotClients.end()) {
         faabric::util::UniqueLock lock(snapshotClientsMutex);
-        auto _it = snapshotClients.try_emplace(key, otherHost);
-        if (!_it.second) {
-            logger->error("Could not add snapshot client key {} for host {}",
-                          key,
-                          otherHost);
-            throw std::runtime_error("Error inserting snapshot client");
+
+        auto it = snapshotClients.find(key);
+        if (it == snapshotClients.end()) {
+
+            auto _it = snapshotClients.try_emplace(key, otherHost);
+            if (!_it.second) {
+                logger->error(
+                  "Could not add snapshot client key {} for host {}",
+                  key,
+                  otherHost);
+                throw std::runtime_error("Error inserting snapshot client");
+            }
+            it = _it.first;
         }
-        it = _it.first;
     }
+
     return it->second;
 }
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -579,7 +579,7 @@ FunctionCallClient& Scheduler::getFunctionCallClient(
 SnapshotClient& Scheduler::getSnapshotClient(const std::string& otherHost)
 {
     // Note, our keys here have to include the tid as the clients can only be
-    // used within the same thread
+    // used within the same thread.
     std::thread::id tid = std::this_thread::get_id();
     std::stringstream ss;
     ss << otherHost << "_" << tid;
@@ -587,6 +587,7 @@ SnapshotClient& Scheduler::getSnapshotClient(const std::string& otherHost)
 
     auto it = snapshotClients.find(key);
     if (it == snapshotClients.end()) {
+        faabric::util::UniqueLock lock(snapshotClientsMutex);
         auto _it = snapshotClients.try_emplace(key, otherHost);
         if (!_it.second) {
             logger->error("Could not add snapshot client key {} for host {}",

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1,4 +1,3 @@
-#include "faabric/util/memory.h"
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/ExecutorFactory.h>
@@ -9,6 +8,7 @@
 #include <faabric/util/environment.h>
 #include <faabric/util/func.h>
 #include <faabric/util/logging.h>
+#include <faabric/util/memory.h>
 #include <faabric/util/random.h>
 #include <faabric/util/snapshot.h>
 #include <faabric/util/testing.h>
@@ -113,12 +113,6 @@ void Scheduler::reset()
 
     closeFunctionCallClients();
     closeSnapshotClients();
-
-    // Close snapshot clients
-    for (auto& iter : snapshotClients) {
-        iter.second.close();
-    }
-    snapshotClients.clear();
 }
 
 void Scheduler::shutdown()

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -507,7 +507,6 @@ int Scheduler::scheduleFunctionsOnHost(
     std::shared_ptr<faabric::BatchExecuteRequest> hostRequest =
       faabric::util::batchExecFactory();
     hostRequest->set_snapshotkey(req->snapshotkey());
-    hostRequest->set_snapshotsize(req->snapshotsize());
     hostRequest->set_type(req->type());
 
     // Add messages

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1,3 +1,4 @@
+#include "faabric/util/memory.h"
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/ExecutorFactory.h>
@@ -30,6 +31,7 @@ Scheduler& getScheduler()
 Scheduler::Scheduler()
   : thisHost(faabric::util::getSystemConfig().endpointHost)
   , conf(faabric::util::getSystemConfig())
+  , logger(faabric::util::getLogger())
 {
     // Set up the initial resources
     int cores = faabric::util::getUsableCores();
@@ -62,11 +64,18 @@ void Scheduler::addHostToGlobalSet()
 
 void Scheduler::closeFunctionCallClients()
 {
-    // Close function call clients
     for (auto& iter : functionCallClients) {
         iter.second.close();
     }
     functionCallClients.clear();
+}
+
+void Scheduler::closeSnapshotClients()
+{
+    for (auto& iter : snapshotClients) {
+        iter.second.close();
+    }
+    snapshotClients.clear();
 }
 
 void Scheduler::reset()
@@ -103,6 +112,13 @@ void Scheduler::reset()
     recordedMessagesShared.clear();
 
     closeFunctionCallClients();
+    closeSnapshotClients();
+
+    // Close snapshot clients
+    for (auto& iter : snapshotClients) {
+        iter.second.close();
+    }
+    snapshotClients.clear();
 }
 
 void Scheduler::shutdown()
@@ -149,7 +165,7 @@ void Scheduler::notifyExecutorShutdown(Executor* exec,
 {
     faabric::util::FullLock lock(mx);
 
-    faabric::util::getLogger()->trace("Shutting down executor {}", exec->id);
+    logger->trace("Shutting down executor {}", exec->id);
 
     std::string funcStr = faabric::util::funcToString(msg, false);
 
@@ -173,8 +189,7 @@ void Scheduler::notifyExecutorShutdown(Executor* exec,
     thisExecutors.erase(thisExecutors.begin() + execIdx);
 
     if (thisExecutors.empty()) {
-        faabric::util::getLogger()->trace("No remaining executors for {}",
-                                          funcStr);
+        logger->trace("No remaining executors for {}", funcStr);
 
         // Unregister if this was the last executor for that function
         bool isMaster = thisHost == msg.masterhost();
@@ -192,14 +207,13 @@ std::vector<std::string> Scheduler::callFunctions(
   std::shared_ptr<faabric::BatchExecuteRequest> req,
   bool forceLocal)
 {
-    const auto& logger = faabric::util::getLogger();
-
     // Extract properties of the request
     int nMessages = req->messages_size();
     bool isThreads = req->type() == faabric::BatchExecuteRequest::THREADS;
     std::vector<std::string> executed(nMessages);
 
-    // Note, we assume all the messages are for the same function and master
+    // Note, we assume all the messages are for the same function and have the
+    // same master host
     const faabric::Message& firstMsg = req->messages().at(0);
     std::string funcStr = faabric::util::funcToString(firstMsg, false);
     std::string masterHost = firstMsg.masterhost();
@@ -212,20 +226,18 @@ std::vector<std::string> Scheduler::callFunctions(
     // TODO - more granular locking, this is incredibly conservative
     faabric::util::FullLock lock(mx);
 
-    // We want to dispatch remote calls here, and record what's left to be done
-    // locally
+    // If we're not the master host, we need to forward the request back to the
+    // master host. This will only happen if a nested batch execution happens.
     std::vector<int> localMessageIdxs;
     if (!forceLocal && masterHost != thisHost) {
-        // If we're not the master host, we need to forward the request back to
-        // the master host. This will only happen if a nested batch execution
-        // happens.
         logger->debug(
           "Forwarding {} {} back to master {}", nMessages, funcStr, masterHost);
 
         getFunctionCallClient(masterHost).executeFunctions(req);
         return executed;
+    }
 
-    } else if (forceLocal) {
+    if (forceLocal) {
         // We're forced to execute locally here so we do all the messages
         for (int i = 0; i < nMessages; i++) {
             localMessageIdxs.emplace_back(i);
@@ -235,9 +247,17 @@ std::vector<std::string> Scheduler::callFunctions(
         // At this point we know we're the master host, and we've not been
         // asked to force full local execution.
 
+        // Get a list of other registered hosts
+        std::set<std::string>& thisRegisteredHosts = registeredHosts[funcStr];
+
         // For threads/ processes we need to have a snapshot key and be
-        // ready to push the snapshot to other hosts
+        // ready to push the snapshot to other hosts.
+        // We also have to broadcast the latest snapshots to all registered
+        // hosts, regardless of whether they're going to execute a function.
+        // This ensures everything is up to date, and we don't have to
+        // maintain different records of which hosts hold which updates.
         faabric::util::SnapshotData snapshotData;
+        std::vector<faabric::util::SnapshotDiff> snapshotDiffs;
         std::string snapshotKey = firstMsg.snapshotkey();
         bool snapshotNeeded =
           req->type() == req->THREADS || req->type() == req->PROCESSES;
@@ -246,9 +266,25 @@ std::vector<std::string> Scheduler::callFunctions(
             logger->error("No snapshot provided for {}", funcStr);
             throw std::runtime_error(
               "Empty snapshot for distributed threads/ processes");
-        } else if (snapshotNeeded) {
+        }
+
+        if (snapshotNeeded) {
             snapshotData =
               faabric::snapshot::getSnapshotRegistry().getSnapshot(snapshotKey);
+            snapshotDiffs = snapshotData.getDirtyPages();
+
+            // Do the snapshot diff pushing
+            if (!snapshotDiffs.empty()) {
+                for (const auto& h : thisRegisteredHosts) {
+                    SnapshotClient& c = getSnapshotClient(h);
+                    c.pushSnapshotDiffs(snapshotKey, snapshotDiffs);
+                }
+            }
+
+            // Now reset the dirty page tracking, as we want the next batch of
+            // diffs to contain everything from now on (including the updates
+            // sent back from all the threads)
+            faabric::util::resetDirtyTracking();
         }
 
         // Work out how many we can handle locally
@@ -277,15 +313,10 @@ std::vector<std::string> Scheduler::callFunctions(
         // If some are left, we need to distribute
         int offset = nLocally;
         if (offset < nMessages) {
-            // At this point we have a remainder, so we need to distribute
-            // the rest over the registered hosts for this function
-            std::set<std::string>& thisRegisteredHosts =
-              registeredHosts[funcStr];
-
-            // Schedule the remainder on these other hosts
-            for (auto& h : thisRegisteredHosts) {
+            // Schedule first to already registered hosts
+            for (const auto& h : thisRegisteredHosts) {
                 int nOnThisHost =
-                  scheduleFunctionsOnHost(h, req, executed, offset);
+                  scheduleFunctionsOnHost(h, req, executed, offset, nullptr);
 
                 offset += nOnThisHost;
                 if (offset >= nMessages) {
@@ -294,6 +325,7 @@ std::vector<std::string> Scheduler::callFunctions(
             }
         }
 
+        // Now schedule to unregistered hosts if there are some left
         if (offset < nMessages) {
             std::vector<std::string> unregisteredHosts =
               getUnregisteredHosts(funcStr);
@@ -305,8 +337,8 @@ std::vector<std::string> Scheduler::callFunctions(
                 }
 
                 // Schedule functions on the host
-                int nOnThisHost =
-                  scheduleFunctionsOnHost(h, req, executed, offset);
+                int nOnThisHost = scheduleFunctionsOnHost(
+                  h, req, executed, offset, &snapshotData);
 
                 // Register the host if it's exected a function
                 if (nOnThisHost > 0) {
@@ -342,7 +374,7 @@ std::vector<std::string> Scheduler::callFunctions(
 
     // Register thread results if necessary
     if (isThreads) {
-        for (auto& m : req->messages()) {
+        for (const auto& m : req->messages()) {
             registerThread(m.id());
         }
     }
@@ -408,7 +440,7 @@ std::vector<std::string> Scheduler::callFunctions(
 }
 
 std::vector<std::string> Scheduler::getUnregisteredHosts(
-  const std::string funcStr,
+  const std::string& funcStr,
   bool noCache)
 {
     // Load the list of available hosts
@@ -439,14 +471,12 @@ std::vector<std::string> Scheduler::getUnregisteredHosts(
 void Scheduler::broadcastSnapshotDelete(const faabric::Message& msg,
                                         const std::string& snapshotKey)
 {
-
     std::string funcStr = faabric::util::funcToString(msg, false);
     std::set<std::string>& thisRegisteredHosts = registeredHosts[funcStr];
 
     for (auto host : thisRegisteredHosts) {
-        SnapshotClient c(host);
+        SnapshotClient& c = getSnapshotClient(host);
         c.deleteSnapshot(snapshotKey);
-        c.close();
     }
 }
 
@@ -454,16 +484,16 @@ int Scheduler::scheduleFunctionsOnHost(
   const std::string& host,
   std::shared_ptr<faabric::BatchExecuteRequest> req,
   std::vector<std::string>& records,
-  int offset)
+  int offset,
+  faabric::util::SnapshotData* snapshot)
 {
-    auto logger = faabric::util::getLogger();
     const faabric::Message& firstMsg = req->messages().at(0);
     std::string funcStr = faabric::util::funcToString(firstMsg, false);
 
     int nMessages = req->messages_size();
     int remainder = nMessages - offset;
 
-    // Execute as many as possible to this host
+    // Work out how many we can put on the host
     faabric::HostResources r = getHostResources(host);
     int available = r.slots() - r.usedslots();
 
@@ -487,18 +517,15 @@ int Scheduler::scheduleFunctionsOnHost(
         records.at(i) = host;
     }
 
-    // Push the snapshot if necessary
+    // Handle snapshots
     std::string snapshotKey = firstMsg.snapshotkey();
-    if (!snapshotKey.empty()) {
-        SnapshotClient c(host);
-        const SnapshotData& d =
-          snapshot::getSnapshotRegistry().getSnapshot(snapshotKey);
-        c.pushSnapshot(snapshotKey, d);
-        c.close();
+    if (snapshot != nullptr && !snapshotKey.empty()) {
+        SnapshotClient& c = getSnapshotClient(host);
+        c.pushSnapshot(snapshotKey, *snapshot);
     }
 
     logger->debug(
-      "Sending {}/{} {} to {}", nOnThisHost, nMessages, funcStr, host);
+      "Sending {}/{} {} to {}", available, nMessages, funcStr, host);
 
     getFunctionCallClient(host).executeFunctions(hostRequest);
 
@@ -549,6 +576,19 @@ FunctionCallClient& Scheduler::getFunctionCallClient(
     return it->second;
 }
 
+SnapshotClient& Scheduler::getSnapshotClient(const std::string& otherHost)
+{
+    auto it = snapshotClients.find(otherHost);
+    if (it == snapshotClients.end()) {
+        auto _it = snapshotClients.try_emplace(otherHost, otherHost);
+        if (!_it.second) {
+            throw std::runtime_error("Error inserting function call client");
+        }
+        it = _it.first;
+    }
+    return it->second;
+}
+
 std::vector<std::pair<std::string, faabric::Message>>
 Scheduler::getRecordedMessagesShared()
 {
@@ -557,7 +597,6 @@ Scheduler::getRecordedMessagesShared()
 
 std::shared_ptr<Executor> Scheduler::claimExecutor(const faabric::Message& msg)
 {
-    const auto& logger = faabric::util::getLogger();
     std::string funcStr = faabric::util::funcToString(msg, false);
 
     std::vector<std::shared_ptr<Executor>>& thisExecutors = executors[funcStr];
@@ -615,7 +654,6 @@ void Scheduler::broadcastFlush()
 
 void Scheduler::flushLocally()
 {
-    const auto& logger = faabric::util::getLogger();
     logger->info("Flushing host {}",
                  faabric::util::getSystemConfig().endpointHost);
 
@@ -670,30 +708,45 @@ void Scheduler::registerThread(uint32_t msgId)
 void Scheduler::setThreadResult(const faabric::Message& msg,
                                 int32_t returnValue)
 {
+    std::vector<faabric::util::SnapshotDiff> empty;
+    setThreadResult(msg, returnValue, empty);
+}
+
+void Scheduler::setThreadResult(
+  const faabric::Message& msg,
+  int32_t returnValue,
+  const std::vector<faabric::util::SnapshotDiff>& diffs)
+{
     // Vacate the slot taken by this thread
     vacateSlot();
 
     bool isMaster = msg.masterhost() == conf.endpointHost;
-    const auto& logger = faabric::util::getLogger();
 
     if (isMaster) {
         setThreadResult(msg.id(), returnValue);
     } else {
-        logger->debug("Sending thread result {} for {} to {}",
-                      returnValue,
-                      msg.id(),
-                      msg.masterhost());
+        SnapshotClient& c = getSnapshotClient(msg.masterhost());
 
-        faabric::ThreadResultRequest req;
-        req.set_messageid(msg.id());
-        req.set_returnvalue(returnValue);
-        getFunctionCallClient(msg.masterhost()).setThreadResult(req);
+        if (diffs.empty()) {
+            logger->debug("Sending thread result {} for {} to {}",
+                          returnValue,
+                          msg.id(),
+                          msg.masterhost());
+            c.pushThreadResult(msg.id(), returnValue);
+
+        } else {
+            logger->debug("Sending thread result {} for {} to {} plus {} diffs",
+                          returnValue,
+                          msg.id(),
+                          msg.masterhost(),
+                          diffs.size());
+            c.pushThreadResult(msg.id(), returnValue, msg.snapshotkey(), diffs);
+        }
     }
 }
 
 void Scheduler::setThreadResult(uint32_t msgId, int32_t returnValue)
 {
-    const auto& logger = faabric::util::getLogger();
     logger->debug("Setting result for thread {} to {}", msgId, returnValue);
     threadResults[msgId].set_value(returnValue);
 }
@@ -701,7 +754,6 @@ void Scheduler::setThreadResult(uint32_t msgId, int32_t returnValue)
 int32_t Scheduler::awaitThreadResult(uint32_t messageId)
 {
     if (threadResults.count(messageId) == 0) {
-        const auto& logger = faabric::util::getLogger();
         logger->error("Thread {} not registered on this host", messageId);
         throw std::runtime_error("Awaiting unregistered thread");
     }

--- a/src/scheduler/SnapshotClient.cpp
+++ b/src/scheduler/SnapshotClient.cpp
@@ -192,7 +192,11 @@ void SnapshotClient::pushThreadResult(
 
     } else {
         const auto& logger = faabric::util::getLogger();
-        logger->debug("Sending thread result for {} to {}", messageId, host);
+        logger->debug(
+          "Sending thread result for {} to {} (plus {} snapshot diffs)",
+          messageId,
+          host,
+          diffs.size());
 
         flatbuffers::FlatBufferBuilder mb;
 

--- a/src/scheduler/SnapshotClient.cpp
+++ b/src/scheduler/SnapshotClient.cpp
@@ -9,10 +9,24 @@ namespace faabric::scheduler {
 // Mocking
 // -----------------------------------
 
+static std::mutex mockMutex;
+
 static std::vector<std::pair<std::string, faabric::util::SnapshotData>>
   snapshotPushes;
 
+static std::vector<
+  std::pair<std::string, std::vector<faabric::util::SnapshotDiff>>>
+  snapshotDiffPushes;
+
 static std::vector<std::pair<std::string, std::string>> snapshotDeletes;
+
+static std::vector<
+  std::pair<std::string,
+            std::tuple<uint32_t,
+                       int,
+                       std::string,
+                       std::vector<faabric::util::SnapshotDiff>>>>
+  threadResults;
 
 std::vector<std::pair<std::string, faabric::util::SnapshotData>>
 getSnapshotPushes()
@@ -20,15 +34,33 @@ getSnapshotPushes()
     return snapshotPushes;
 }
 
+std::vector<std::pair<std::string, std::vector<faabric::util::SnapshotDiff>>>
+getSnapshotDiffPushes()
+{
+    return snapshotDiffPushes;
+}
+
 std::vector<std::pair<std::string, std::string>> getSnapshotDeletes()
 {
     return snapshotDeletes;
 }
 
+std::vector<std::pair<std::string,
+                      std::tuple<uint32_t,
+                                 int,
+                                 std::string,
+                                 std::vector<faabric::util::SnapshotDiff>>>>
+getThreadResults()
+{
+    return threadResults;
+}
+
 void clearMockSnapshotRequests()
 {
     snapshotPushes.clear();
+    snapshotDiffPushes.clear();
     snapshotDeletes.clear();
+    threadResults.clear();
 }
 
 // -----------------------------------
@@ -48,13 +80,14 @@ void SnapshotClient::sendHeader(faabric::scheduler::SnapshotCalls call)
 }
 
 void SnapshotClient::pushSnapshot(const std::string& key,
-                                  const faabric::util::SnapshotData& req)
+                                  const faabric::util::SnapshotData& data)
 {
-    auto logger = faabric::util::getLogger();
+    const auto& logger = faabric::util::getLogger();
     logger->debug("Pushing snapshot {} to {}", key, host);
 
     if (faabric::util::isMockMode()) {
-        snapshotPushes.emplace_back(host, req);
+        faabric::util::UniqueLock lock(mockMutex);
+        snapshotPushes.emplace_back(host, data);
     } else {
         // Send the header first
         sendHeader(faabric::scheduler::SnapshotCalls::PushSnapshot);
@@ -62,7 +95,7 @@ void SnapshotClient::pushSnapshot(const std::string& key,
         // TODO - avoid copying data here
         flatbuffers::FlatBufferBuilder mb;
         auto keyOffset = mb.CreateString(key);
-        auto dataOffset = mb.CreateVector<uint8_t>(req.data, req.size);
+        auto dataOffset = mb.CreateVector<uint8_t>(data.data, data.size);
         auto requestOffset =
           CreateSnapshotPushRequest(mb, keyOffset, dataOffset);
 
@@ -73,13 +106,56 @@ void SnapshotClient::pushSnapshot(const std::string& key,
     }
 }
 
+void SnapshotClient::pushSnapshotDiffs(
+  std::string snapshotKey,
+  std::vector<faabric::util::SnapshotDiff> diffs)
+{
+    if (faabric::util::isMockMode()) {
+        faabric::util::UniqueLock lock(mockMutex);
+        snapshotDiffPushes.emplace_back(host, diffs);
+    } else {
+        const auto& logger = faabric::util::getLogger();
+        logger->debug("Pushing {} diffs for snapshot {} to {}",
+                      diffs.size(),
+                      snapshotKey,
+                      host);
+
+        // Send the header first
+        sendHeader(faabric::scheduler::SnapshotCalls::PushSnapshotDiffs);
+
+        // TODO - avoid copying data here
+        flatbuffers::FlatBufferBuilder mb;
+
+        // Create objects for all the chunks
+        std::vector<flatbuffers::Offset<SnapshotDiffChunk>> diffsFbVector;
+        for (const auto& d : diffs) {
+            auto dataOffset = mb.CreateVector<uint8_t>(d.data, d.size);
+            auto chunk = CreateSnapshotDiffChunk(mb, d.offset, dataOffset);
+            diffsFbVector.push_back(chunk);
+        }
+
+        // Set up the main request
+        auto keyOffset = mb.CreateString(snapshotKey);
+        auto diffsOffset = mb.CreateVector(diffsFbVector);
+        auto requestOffset =
+          CreateSnapshotDiffPushRequest(mb, keyOffset, diffsOffset);
+
+        // Send it
+        mb.Finish(requestOffset);
+        uint8_t* msg = mb.GetBufferPointer();
+        int size = mb.GetSize();
+        send(msg, size);
+    }
+}
+
 void SnapshotClient::deleteSnapshot(const std::string& key)
 {
-    auto logger = faabric::util::getLogger();
-
     if (faabric::util::isMockMode()) {
+        faabric::util::UniqueLock lock(mockMutex);
         snapshotDeletes.emplace_back(host, key);
+
     } else {
+        const auto& logger = faabric::util::getLogger();
         logger->debug("Deleting snapshot {} from {}", key, host);
 
         // Send the header first
@@ -91,6 +167,53 @@ void SnapshotClient::deleteSnapshot(const std::string& key)
         auto requestOffset = CreateSnapshotDeleteRequest(mb, keyOffset);
 
         mb.Finish(requestOffset);
+        uint8_t* msg = mb.GetBufferPointer();
+        int size = mb.GetSize();
+        send(msg, size);
+    }
+}
+
+void SnapshotClient::pushThreadResult(uint32_t messageId, int returnValue)
+{
+    std::vector<faabric::util::SnapshotDiff> empty;
+    pushThreadResult(messageId, returnValue, "", empty);
+}
+
+void SnapshotClient::pushThreadResult(
+  uint32_t messageId,
+  int returnValue,
+  const std::string& snapshotKey,
+  const std::vector<faabric::util::SnapshotDiff>& diffs)
+{
+    if (faabric::util::isMockMode()) {
+        faabric::util::UniqueLock lock(mockMutex);
+        threadResults.emplace_back(std::make_pair(
+          host, std::make_tuple(messageId, returnValue, snapshotKey, diffs)));
+
+    } else {
+        const auto& logger = faabric::util::getLogger();
+        logger->debug("Sending thread result for {} to {}", messageId, host);
+
+        flatbuffers::FlatBufferBuilder mb;
+
+        // Create objects for all the chunks
+        std::vector<flatbuffers::Offset<SnapshotDiffChunk>> diffsFbVector;
+        for (const auto& d : diffs) {
+            auto dataOffset = mb.CreateVector<uint8_t>(d.data, d.size);
+            auto chunk = CreateSnapshotDiffChunk(mb, d.offset, dataOffset);
+            diffsFbVector.push_back(chunk);
+        }
+
+        auto keyOffset = mb.CreateString(snapshotKey);
+        auto diffsOffset = mb.CreateVector(diffsFbVector);
+        auto requestOffset = CreateThreadResultRequest(
+          mb, messageId, returnValue, keyOffset, diffsOffset);
+
+        mb.Finish(requestOffset);
+
+        // Send the header first
+        sendHeader(faabric::scheduler::SnapshotCalls::ThreadResult);
+
         uint8_t* msg = mb.GetBufferPointer();
         int size = mb.GetSize();
         send(msg, size);

--- a/src/scheduler/SnapshotClient.cpp
+++ b/src/scheduler/SnapshotClient.cpp
@@ -198,8 +198,6 @@ void SnapshotClient::pushThreadResult(
         flatbuffers::FlatBufferBuilder mb;
         flatbuffers::Offset<ThreadResultRequest> requestOffset;
 
-        auto keyOffset = mb.CreateString(snapshotKey);
-
         if (!diffs.empty()) {
             logger->debug(
               "Sending thread result for {} to {} (plus {} snapshot diffs)",
@@ -218,6 +216,7 @@ void SnapshotClient::pushThreadResult(
             // Create message with diffs
             auto diffsOffset = mb.CreateVector(diffsFbVector);
 
+            auto keyOffset = mb.CreateString(snapshotKey);
             requestOffset = CreateThreadResultRequest(
               mb, messageId, returnValue, keyOffset, diffsOffset);
         } else {
@@ -228,7 +227,7 @@ void SnapshotClient::pushThreadResult(
 
             // Create message without diffs
             requestOffset =
-              CreateThreadResultRequest(mb, messageId, returnValue, keyOffset);
+              CreateThreadResultRequest(mb, messageId, returnValue);
         }
 
         SEND_FB_REQUEST(faabric::scheduler::SnapshotCalls::ThreadResult)

--- a/src/scheduler/SnapshotServer.cpp
+++ b/src/scheduler/SnapshotServer.cpp
@@ -48,7 +48,7 @@ void SnapshotServer::recvPushSnapshot(faabric::transport::Message& msg)
     SnapshotPushRequest* r =
       flatbuffers::GetMutableRoot<SnapshotPushRequest>(msg.udata());
 
-    faabric::util::getLogger()->info("Pushing shapshot {} (size {})",
+    faabric::util::getLogger()->info("Receiving shapshot {} (size {})",
                                      r->key()->c_str(),
                                      r->contents()->size());
 
@@ -87,7 +87,7 @@ void SnapshotServer::recvThreadResult(faabric::transport::Message& msg)
       r->return_value());
 
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.setThreadResult(r->message_id(), r->return_value());
+    sch.setThreadResultLocally(r->message_id(), r->return_value());
 }
 
 void SnapshotServer::recvPushSnapshotDiffs(faabric::transport::Message& msg)

--- a/src/scheduler/SnapshotServer.cpp
+++ b/src/scheduler/SnapshotServer.cpp
@@ -1,7 +1,9 @@
 #include <faabric/flat/faabric_generated.h>
+#include <faabric/proto/faabric.pb.h>
 #include <faabric/scheduler/SnapshotServer.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/state/State.h>
+#include <faabric/transport/macros.h>
 #include <faabric/util/func.h>
 #include <faabric/util/logging.h>
 
@@ -64,6 +66,10 @@ void SnapshotServer::recvPushSnapshot(faabric::transport::Message& msg)
     // Note that now the snapshot data is owned by Faabric and will be deleted
     // later, so we don't want the message to delete it
     msg.persist();
+
+    // Send response
+    faabric::EmptyResponse response;
+    SEND_SERVER_RESPONSE(response, r->return_host()->str(), SNAPSHOT_PORT)
 }
 
 void SnapshotServer::recvThreadResult(faabric::transport::Message& msg)
@@ -100,6 +106,10 @@ void SnapshotServer::recvPushSnapshotDiffs(faabric::transport::Message& msg)
                                      r->key()->c_str());
 
     applyDiffsToSnapshot(r->key()->str(), r->chunks());
+
+    // Send response
+    faabric::EmptyResponse response;
+    SEND_SERVER_RESPONSE(response, r->return_host()->str(), SNAPSHOT_PORT)
 }
 
 void SnapshotServer::applyDiffsToSnapshot(

--- a/src/scheduler/SnapshotServer.cpp
+++ b/src/scheduler/SnapshotServer.cpp
@@ -50,9 +50,9 @@ void SnapshotServer::recvPushSnapshot(faabric::transport::Message& msg)
     SnapshotPushRequest* r =
       flatbuffers::GetMutableRoot<SnapshotPushRequest>(msg.udata());
 
-    faabric::util::getLogger()->info("Receiving shapshot {} (size {})",
-                                     r->key()->c_str(),
-                                     r->contents()->size());
+    faabric::util::getLogger()->debug("Receiving shapshot {} (size {})",
+                                      r->key()->c_str(),
+                                      r->contents()->size());
 
     faabric::snapshot::SnapshotRegistry& reg =
       faabric::snapshot::getSnapshotRegistry();
@@ -80,9 +80,9 @@ void SnapshotServer::recvThreadResult(faabric::transport::Message& msg)
     // Apply snapshot diffs *first* (these must be applied before other threads
     // can continue)
     if (r->chunks()->size() > 0) {
-        faabric::util::getLogger()->info("Receiving {} diffs to snapshot {}",
-                                         r->chunks()->size(),
-                                         r->key()->c_str());
+        faabric::util::getLogger()->debug("Receiving {} diffs to snapshot {}",
+                                          r->chunks()->size(),
+                                          r->key()->c_str());
 
         applyDiffsToSnapshot(r->key()->str(), r->chunks());
     }

--- a/src/scheduler/SnapshotServer.cpp
+++ b/src/scheduler/SnapshotServer.cpp
@@ -87,7 +87,7 @@ void SnapshotServer::recvThreadResult(faabric::transport::Message& msg)
         applyDiffsToSnapshot(r->key()->str(), r->chunks());
     }
 
-    faabric::util::getLogger()->info(
+    faabric::util::getLogger()->debug(
       "Receiving thread result {} for message {}",
       r->message_id(),
       r->return_value());
@@ -101,9 +101,9 @@ void SnapshotServer::recvPushSnapshotDiffs(faabric::transport::Message& msg)
     const SnapshotDiffPushRequest* r =
       flatbuffers::GetMutableRoot<SnapshotDiffPushRequest>(msg.udata());
 
-    faabric::util::getLogger()->info("Receiving {} diffs to snapshot {}",
-                                     r->chunks()->size(),
-                                     r->key()->c_str());
+    faabric::util::getLogger()->debug("Receiving {} diffs to snapshot {}",
+                                      r->chunks()->size(),
+                                      r->key()->c_str());
 
     applyDiffsToSnapshot(r->key()->str(), r->chunks());
 

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -7,12 +7,13 @@
 #include <sys/mman.h>
 
 namespace faabric::snapshot {
-SnapshotRegistry::SnapshotRegistry() {}
+SnapshotRegistry::SnapshotRegistry()
+  : logger(faabric::util::getLogger())
+{}
 
 faabric::util::SnapshotData& SnapshotRegistry::getSnapshot(
   const std::string& key)
 {
-    auto logger = faabric::util::getLogger();
     if (snapshotMap.count(key) == 0) {
         logger->error("Snapshot for {} does not exist", key);
         throw std::runtime_error("Snapshot doesn't exist");
@@ -23,7 +24,6 @@ faabric::util::SnapshotData& SnapshotRegistry::getSnapshot(
 
 void SnapshotRegistry::mapSnapshot(const std::string& key, uint8_t* target)
 {
-    auto logger = faabric::util::getLogger();
     faabric::util::SnapshotData d = getSnapshot(key);
 
     if (!faabric::util::isPageAligned((void*)target)) {
@@ -108,8 +108,6 @@ void SnapshotRegistry::clear()
 
 int SnapshotRegistry::writeSnapshotToFd(const std::string& key)
 {
-    auto logger = faabric::util::getLogger();
-
     int fd = ::memfd_create(key.c_str(), 0);
     faabric::util::SnapshotData snapData = getSnapshot(key);
 

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -27,7 +27,8 @@ void SnapshotRegistry::mapSnapshot(const std::string& key, uint8_t* target)
     faabric::util::SnapshotData d = getSnapshot(key);
 
     if (!faabric::util::isPageAligned((void*)target)) {
-        logger->error("Mapping snapshot to non page-aligned address");
+        logger->error(
+          "Mapping snapshot {} to non page-aligned address {}", key, target);
         throw std::runtime_error(
           "Mapping snapshot to non page-aligned address");
     }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIB_FILES
         network.cpp
         queue.cpp
         random.cpp
+        snapshot.cpp
         state.cpp
         string_tools.cpp
         timing.cpp

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -57,10 +57,6 @@ std::string messageToJson(const faabric::Message& msg)
           a);
     }
 
-    if (msg.snapshotsize() > 0) {
-        d.AddMember("snapshot_size", msg.snapshotsize(), a);
-    }
-
     if (msg.funcptr() > 0) {
         d.AddMember("func_ptr", msg.funcptr(), a);
     }
@@ -298,7 +294,6 @@ faabric::Message jsonToMessage(const std::string& jsonIn)
     msg.set_finishtimestamp(getInt64FromJson(d, "finished", 0));
 
     msg.set_snapshotkey(getStringFromJson(d, "snapshot_key", ""));
-    msg.set_snapshotsize(getIntFromJson(d, "snapshot_size", 0));
     msg.set_funcptr(getIntFromJson(d, "func_ptr", 0));
 
     msg.set_pythonuser(getStringFromJson(d, "py_user", ""));

--- a/src/util/memory.cpp
+++ b/src/util/memory.cpp
@@ -1,8 +1,25 @@
 #include <faabric/util/memory.h>
 
-#include <cstdint>
+#include <fcntl.h>
+#include <stdexcept>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+
+#define CLEAR_REFS "/proc/self/clear_refs"
+#define PAGEMAP "/proc/self/pagemap"
+
+#define PAGEMAP_ENTRY_BYTES 8
+#define PAGEMAP_SOFT_DIRTY (1Ull << 55)
 
 namespace faabric::util {
+
+// -------------------------
+// Alignment
+// -------------------------
+
 bool isPageAligned(void* ptr)
 {
     return (((uintptr_t)(const void*)(ptr)) % (HOST_PAGE_SIZE) == 0);
@@ -56,5 +73,74 @@ AlignedChunk getPageAlignedChunk(long offset, long length)
     };
 
     return c;
+}
+
+// -------------------------
+// Dirty page tracking
+// -------------------------
+
+void resetDirtyTracking()
+{
+    FILE* fd = fopen(CLEAR_REFS, "w");
+    if (fd == nullptr) {
+        throw std::runtime_error("Could not open clear_refs");
+    }
+
+    // Write 4 to the file to track from now on
+    // https://www.kernel.org/doc/html/v5.4/admin-guide/mm/soft-dirty.html
+    char value[] = "4";
+    size_t nWritten = fwrite(value, sizeof(char), 1, fd);
+    if (nWritten != 1) {
+        throw std::runtime_error("Failed to write to clear_refs");
+    }
+
+    fclose(fd);
+}
+
+std::vector<uint64_t> readPagemapEntries(uintptr_t ptr, int nEntries)
+{
+    // Work out offset for this pointer in the pagemap
+    off_t offset = (ptr / getpagesize()) * PAGEMAP_ENTRY_BYTES;
+
+    // Open the pagemap
+    FILE* fd = fopen(PAGEMAP, "rb");
+    if (fd == nullptr) {
+        throw std::runtime_error("Could not open pagemap");
+    }
+
+    // Skip to location of this page
+    int r = fseek(fd, offset, SEEK_SET);
+    if (r < 0) {
+        throw std::runtime_error("Could not seek pagemap");
+    }
+
+    // Read the entries
+    std::vector<uint64_t> entries(nEntries, 0);
+    fread(entries.data(), PAGEMAP_ENTRY_BYTES, nEntries, fd);
+    if (ferror(fd)) {
+        throw std::runtime_error("Could not read pagemap");
+    }
+
+    fclose(fd);
+
+    return entries;
+}
+
+std::vector<bool> getDirtyPages(const uint8_t* ptr, int nPages)
+{
+    uintptr_t vptr = (uintptr_t)ptr;
+
+    // Get the pagemap entries
+    std::vector<uint64_t> entries = readPagemapEntries(vptr, nPages);
+
+    // Iterate through to get boolean flags
+    std::vector<bool> flags(nPages, false);
+    for (int i = 0; i < nPages; i++) {
+        if (entries.at(i) & PAGEMAP_SOFT_DIRTY) {
+            flags.at(i) = true;
+        }
+    }
+
+    return flags;
 }
 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -1,0 +1,30 @@
+#include <faabric/util/memory.h>
+#include <faabric/util/snapshot.h>
+
+namespace faabric::util {
+
+std::vector<faabric::util::SnapshotDiff> SnapshotData::getDirtyPages()
+{
+    if (data == nullptr || size == 0) {
+        std::vector<faabric::util::SnapshotDiff> empty;
+        return empty;
+    }
+
+    // Get dirty pages
+    int nPages = faabric::util::getRequiredHostPages(size);
+    std::vector<bool> dirtyFlags = faabric::util::getDirtyPages(data, nPages);
+
+    // Convert to snapshot diffs
+    // TODO - reduce number of diffs by merging adjacent dirty pages
+    std::vector<faabric::util::SnapshotDiff> diffs;
+    for (int i = 0; i < nPages; i++) {
+        if (dirtyFlags.at(i)) {
+            uint32_t offset = i * faabric::util::HOST_PAGE_SIZE;
+            diffs.emplace_back(
+              offset, data + offset, faabric::util::HOST_PAGE_SIZE);
+        }
+    }
+
+    return diffs;
+}
+}

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -1,3 +1,4 @@
+#include <faabric/util/logging.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/snapshot.h>
 
@@ -24,6 +25,9 @@ std::vector<SnapshotDiff> SnapshotData::getDirtyPages()
               offset, data + offset, faabric::util::HOST_PAGE_SIZE);
         }
     }
+
+    faabric::util::getLogger()->debug(
+      "Snapshot has {}/{} dirty pages", diffs.size(), nPages);
 
     return diffs;
 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -3,7 +3,7 @@
 
 namespace faabric::util {
 
-std::vector<faabric::util::SnapshotDiff> SnapshotData::getDirtyPages()
+std::vector<SnapshotDiff> SnapshotData::getDirtyPages()
 {
     if (data == nullptr || size == 0) {
         std::vector<faabric::util::SnapshotDiff> empty;
@@ -11,12 +11,12 @@ std::vector<faabric::util::SnapshotDiff> SnapshotData::getDirtyPages()
     }
 
     // Get dirty pages
-    int nPages = faabric::util::getRequiredHostPages(size);
+    int nPages = getRequiredHostPages(size);
     std::vector<bool> dirtyFlags = faabric::util::getDirtyPages(data, nPages);
 
     // Convert to snapshot diffs
     // TODO - reduce number of diffs by merging adjacent dirty pages
-    std::vector<faabric::util::SnapshotDiff> diffs;
+    std::vector<SnapshotDiff> diffs;
     for (int i = 0; i < nPages; i++) {
         if (dirtyFlags.at(i)) {
             uint32_t offset = i * faabric::util::HOST_PAGE_SIZE;

--- a/tests/dist/DistTestExecutor.h
+++ b/tests/dist/DistTestExecutor.h
@@ -31,8 +31,8 @@ class DistTestExecutor final : public faabric::scheduler::Executor
 
     faabric::util::SnapshotData snapshot() override;
 
-    uint8_t* snapshotMemory;
-    size_t snapshotSize;
+    uint8_t* snapshotMemory = nullptr;
+    size_t snapshotSize = 0;
 
   protected:
     void restore(const faabric::Message& msg) override;

--- a/tests/dist/DistTestExecutor.h
+++ b/tests/dist/DistTestExecutor.h
@@ -8,6 +8,7 @@
 namespace tests {
 
 typedef int (*ExecutorFunction)(
+  faabric::scheduler::Executor* exec,
   int threadPoolIdx,
   int msgIdx,
   std::shared_ptr<faabric::BatchExecuteRequest> req);
@@ -27,6 +28,14 @@ class DistTestExecutor final : public faabric::scheduler::Executor
       int threadPoolIdx,
       int msgIdx,
       std::shared_ptr<faabric::BatchExecuteRequest> req) override;
+
+    faabric::util::SnapshotData snapshot() override;
+
+    uint8_t* snapshotMemory;
+    size_t snapshotSize;
+
+  protected:
+    void restore(const faabric::Message& msg) override;
 };
 
 class DistTestExecutorFactory : public faabric::scheduler::ExecutorFactory

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "faabric_utils.h"
+
 #include "DistTestExecutor.h"
 
 #include <faabric/scheduler/ExecutorFactory.h>
@@ -8,26 +10,16 @@
 
 namespace tests {
 class DistTestsFixture
+  : public SchedulerTestFixture
+  , public ConfTestFixture
+  , public SnapshotTestFixture
 {
   protected:
-    faabric::scheduler::Scheduler& sch;
-    faabric::util::SystemConfig& conf;
-    faabric::snapshot::SnapshotRegistry& reg;
-
     std::set<std::string> otherHosts;
 
   public:
     DistTestsFixture()
-      : sch(faabric::scheduler::getScheduler())
-      , conf(faabric::util::getSystemConfig())
-      , reg(faabric::snapshot::getSnapshotRegistry())
     {
-        // Make sure this host is available
-        sch.addHostToGlobalSet();
-
-        // Clear local snapshot info
-        reg.clear();
-
         // Get other hosts
         std::string thisHost = conf.endpointHost;
         otherHosts = sch.getAvailableHosts();
@@ -37,13 +29,6 @@ class DistTestsFixture
         std::shared_ptr<tests::DistTestExecutorFactory> fac =
           std::make_shared<tests::DistTestExecutorFactory>();
         faabric::scheduler::setExecutorFactory(fac);
-    }
-
-    ~DistTestsFixture()
-    {
-        reg.clear();
-        sch.reset();
-        conf.reset();
     }
 };
 }

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -4,6 +4,7 @@
 
 #include <faabric/scheduler/ExecutorFactory.h>
 #include <faabric/scheduler/Scheduler.h>
+#include <faabric/snapshot/SnapshotRegistry.h>
 
 namespace tests {
 class DistTestsFixture
@@ -11,15 +12,21 @@ class DistTestsFixture
   protected:
     faabric::scheduler::Scheduler& sch;
     faabric::util::SystemConfig& conf;
+    faabric::snapshot::SnapshotRegistry& reg;
+
     std::set<std::string> otherHosts;
 
   public:
     DistTestsFixture()
       : sch(faabric::scheduler::getScheduler())
       , conf(faabric::util::getSystemConfig())
+      , reg(faabric::snapshot::getSnapshotRegistry())
     {
         // Make sure this host is available
         sch.addHostToGlobalSet();
+
+        // Clear local snapshot info
+        reg.clear();
 
         // Get other hosts
         std::string thisHost = conf.endpointHost;
@@ -34,6 +41,7 @@ class DistTestsFixture
 
     ~DistTestsFixture()
     {
+        reg.clear();
         sch.reset();
         conf.reset();
     }

--- a/tests/dist/init.cpp
+++ b/tests/dist/init.cpp
@@ -7,6 +7,6 @@ void initDistTests()
     const auto& logger = faabric::util::getLogger();
     logger->info("Registering distributed test server functions");
 
-    tests::registerThreadFunctions();
+    tests::registerSchedulerTestFunctions();
 }
 }

--- a/tests/dist/init.h
+++ b/tests/dist/init.h
@@ -9,6 +9,6 @@ namespace tests {
 void initDistTests();
 
 // Specific test functions
-void registerThreadFunctions();
+void registerSchedulerTestFunctions();
 
 }

--- a/tests/dist/scheduler/functions.cpp
+++ b/tests/dist/scheduler/functions.cpp
@@ -5,6 +5,8 @@
 #include "init.h"
 
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/Scheduler.h>
+#include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
 
@@ -47,9 +49,42 @@ int handleSimpleFunction(int threadPoolIdx,
     return 0;
 }
 
-void registerThreadFunctions()
+int handleFakeDiffsFunction(int threadPoolIdx,
+                            int msgIdx,
+                            std::shared_ptr<faabric::BatchExecuteRequest> req)
+{
+    faabric::Message& msg = req->mutable_messages()->at(msgIdx);
+
+    std::string msgInput = msg.inputdata();
+    std::string snapshotKey = msg.snapshotkey();
+
+    // Create some fake diffs
+    std::vector<uint8_t> inputBytes = faabric::util::stringToBytes(msgInput);
+    std::vector<uint8_t> keyBytes = faabric::util::stringToBytes(snapshotKey);
+
+    uint32_t offsetA = 10;
+    uint32_t offsetB = 100;
+
+    faabric::util::SnapshotDiff diffA(
+      offsetA, keyBytes.data(), keyBytes.size());
+    faabric::util::SnapshotDiff diffB(
+      offsetB, inputBytes.data(), inputBytes.size());
+
+    std::vector<faabric::util::SnapshotDiff> diffs = { diffA, diffB };
+
+    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
+    sch.setThreadResult(msg, 123, diffs);
+
+    return 0;
+}
+
+void registerSchedulerTestFunctions()
 {
     registerDistTestExecutorCallback("threads", "simple", handleSimpleThread);
+
     registerDistTestExecutorCallback("funcs", "simple", handleSimpleFunction);
+
+    registerDistTestExecutorCallback(
+      "snapshots", "fake-diffs", handleFakeDiffsFunction);
 }
 }

--- a/tests/dist/scheduler/test_snapshots.cpp
+++ b/tests/dist/scheduler/test_snapshots.cpp
@@ -33,8 +33,6 @@ TEST_CASE_METHOD(DistTestsFixture,
     snap.data = snapMemory;
     snap.size = snapSize;
 
-    faabric::snapshot::SnapshotRegistry& reg =
-      faabric::snapshot::getSnapshotRegistry();
     reg.takeSnapshot(snapshotKey, snap);
 
     // Invoke the function that ought to send back some snapshot diffs that

--- a/tests/dist/scheduler/test_snapshots.cpp
+++ b/tests/dist/scheduler/test_snapshots.cpp
@@ -1,0 +1,78 @@
+#include "faabric_utils.h"
+#include <catch.hpp>
+
+#include "fixtures.h"
+#include "init.h"
+
+#include <sys/mman.h>
+
+#include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/Scheduler.h>
+#include <faabric/scheduler/SnapshotClient.h>
+#include <faabric/snapshot/SnapshotRegistry.h>
+#include <faabric/util/bytes.h>
+#include <faabric/util/config.h>
+#include <faabric/util/func.h>
+#include <faabric/util/memory.h>
+#include <faabric/util/snapshot.h>
+
+namespace tests {
+
+TEST_CASE_METHOD(DistTestsFixture,
+                 "Check snapshots sent back from worker are applied",
+                 "[snapshots]")
+{
+    // Set up the snapshot
+    std::string snapshotKey = "dist-snap-check";
+
+    size_t snapSize = 2 * faabric::util::HOST_PAGE_SIZE;
+    uint8_t* snapMemory = (uint8_t*)mmap(
+      nullptr, snapSize, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    faabric::util::SnapshotData snap;
+    snap.data = snapMemory;
+    snap.size = snapSize;
+
+    faabric::snapshot::SnapshotRegistry& reg =
+      faabric::snapshot::getSnapshotRegistry();
+    reg.takeSnapshot(snapshotKey, snap);
+
+    // Invoke the function that ought to send back some snapshot diffs that
+    // should be applied
+    std::shared_ptr<faabric::BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("snapshots", "fake-diffs", 1);
+    req->set_type(faabric::BatchExecuteRequest::THREADS);
+
+    // Set up some input data
+    faabric::Message& m = req->mutable_messages()->at(0);
+    std::vector<uint8_t> inputData = { 0, 1, 2, 3, 4, 5, 6 };
+    m.set_inputdata(inputData.data(), inputData.size());
+    m.set_snapshotkey(snapshotKey);
+
+    // Force the function to be executed remotely
+    faabric::HostResources res;
+    res.set_slots(0);
+    sch.setThisHostResources(res);
+
+    std::vector<std::string> expectedHosts = { WORKER_IP };
+    std::vector<std::string> executedHosts = sch.callFunctions(req);
+    REQUIRE(expectedHosts == executedHosts);
+
+    int actualResult = sch.awaitThreadResult(m.id());
+    REQUIRE(actualResult == 123);
+
+    // Check the diffs have been applied
+    size_t sizeA = snapshotKey.size();
+    size_t sizeB = inputData.size();
+    uint8_t* startA = snapMemory + 10;
+    uint8_t* startB = snapMemory + 100;
+    std::vector<uint8_t> actualA(startA, startA + sizeA);
+    std::vector<uint8_t> actualB(startB, startB + sizeB);
+
+    std::vector<uint8_t> expectedA = faabric::util::stringToBytes(snapshotKey);
+    std::vector<uint8_t> expectedB = inputData;
+
+    REQUIRE(actualA == expectedA);
+    REQUIRE(actualB == expectedB);
+}
+}

--- a/tests/dist/scheduler/test_threads.cpp
+++ b/tests/dist/scheduler/test_threads.cpp
@@ -41,9 +41,6 @@ TEST_CASE_METHOD(DistTestsFixture,
     snap.data = snapshotData;
     snap.size = snapshotSize;
 
-    faabric::snapshot::SnapshotRegistry& reg =
-      faabric::snapshot::getSnapshotRegistry();
-
     std::string snapKey = std::to_string(faabric::util::generateGid());
     reg.takeSnapshot(snapKey, snap);
 

--- a/tests/dist/scheduler/test_threads.cpp
+++ b/tests/dist/scheduler/test_threads.cpp
@@ -10,6 +10,7 @@
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
+#include <faabric/util/gids.h>
 
 namespace tests {
 
@@ -19,7 +20,7 @@ std::string setUpDummySnapshot()
     faabric::snapshot::SnapshotRegistry& reg =
       faabric::snapshot::getSnapshotRegistry();
     faabric::util::SnapshotData snap;
-    std::string snapKey = "foobar";
+    std::string snapKey = std::to_string(faabric::util::generateGid());
     snap.data = snapData.data();
     snap.size = snapData.size();
 

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -226,12 +226,13 @@ class TestExecutorFactory : public ExecutorFactory
 };
 
 class TestExecutorFixture
-  : public SchedulerTestFixture
+  : public RedisTestFixture
+  , public SchedulerTestFixture
   , public ConfTestFixture
+  , public SnapshotTestFixture
 {
   public:
     TestExecutorFixture()
-      : reg(faabric::snapshot::getSnapshotRegistry())
     {
         std::shared_ptr<TestExecutorFactory> fac =
           std::make_shared<TestExecutorFactory>();
@@ -245,8 +246,6 @@ class TestExecutorFixture
     ~TestExecutorFixture() { munmap(snapshotData, snapshotSize); }
 
   protected:
-    faabric::snapshot::SnapshotRegistry& reg;
-
     std::string snapshotKey = "foobar";
     uint8_t* snapshotData = nullptr;
     int snapshotNPages = 10;

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -486,7 +486,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
     for (auto& r : results) {
         REQUIRE(r.first == thisHost);
         auto args = r.second;
-        sch.setThreadResult(std::get<0>(args), std::get<1>(args));
+        sch.setThreadResultLocally(std::get<0>(args), std::get<1>(args));
     }
 
     // Rejoin the other thread

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -225,7 +225,9 @@ class TestExecutorFactory : public ExecutorFactory
     }
 };
 
-class TestExecutorFixture : public BaseTestFixture
+class TestExecutorFixture
+  : public SchedulerTestFixture
+  , public ConfTestFixture
 {
   public:
     TestExecutorFixture()

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -226,8 +226,8 @@ class TestExecutorFactory : public ExecutorFactory
 };
 
 class TestExecutorFixture
-  : public RedisTestFixture
-  , public SchedulerTestFixture
+  : public SchedulerTestFixture
+  , public RedisTestFixture
   , public ConfTestFixture
   , public SnapshotTestFixture
 {

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -1,7 +1,10 @@
 #include "faabric_utils.h"
 #include <catch.hpp>
 
+#include <sys/mman.h>
+
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/redis/Redis.h>
 #include <faabric/scheduler/ExecutorFactory.h>
 #include <faabric/scheduler/FunctionCallClient.h>
 #include <faabric/scheduler/Scheduler.h>
@@ -10,6 +13,7 @@
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
 #include <faabric/util/macros.h>
+#include <faabric/util/memory.h>
 #include <faabric/util/testing.h>
 
 using namespace faabric::scheduler;
@@ -21,21 +25,6 @@ namespace tests {
 
 std::atomic<int> restoreCount = 0;
 
-std::string setUpDummySnapshot()
-{
-    std::vector<uint8_t> snapData = { 0, 1, 2, 3, 4 };
-    faabric::snapshot::SnapshotRegistry& reg =
-      faabric::snapshot::getSnapshotRegistry();
-    faabric::util::SnapshotData snap;
-    std::string snapKey = "foobar";
-    snap.data = snapData.data();
-    snap.size = snapData.size();
-
-    reg.takeSnapshot(snapKey, snap);
-
-    return snapKey;
-}
-
 class TestExecutor final : public Executor
 {
   public:
@@ -45,7 +34,40 @@ class TestExecutor final : public Executor
 
     ~TestExecutor() {}
 
-    void restore(const faabric::Message& msg) { restoreCount += 1; }
+    uint8_t* dummyMemory = nullptr;
+    size_t dummyMemorySize = 0;
+
+    void postFinish()
+    {
+        if (dummyMemory != nullptr) {
+            munmap(dummyMemory, dummyMemorySize);
+        }
+    }
+
+    void restore(const faabric::Message& msg)
+    {
+        restoreCount += 1;
+
+        // Initialise the dummy memory and map to snapshot
+        faabric::snapshot::SnapshotRegistry& reg =
+          faabric::snapshot::getSnapshotRegistry();
+        faabric::util::SnapshotData& snap = reg.getSnapshot(msg.snapshotkey());
+
+        // Note this has to be mmapped to be page-aligned
+        dummyMemorySize = snap.size;
+        dummyMemory = (uint8_t*)mmap(
+          nullptr, snap.size, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+        reg.mapSnapshot(msg.snapshotkey(), dummyMemory);
+    }
+
+    faabric::util::SnapshotData snapshot()
+    {
+        faabric::util::SnapshotData snap;
+        snap.data = dummyMemory;
+        snap.size = dummyMemorySize;
+        return snap;
+    }
 
     int32_t executeTask(int threadPoolIdx,
                         int msgIdx,
@@ -53,6 +75,9 @@ class TestExecutor final : public Executor
     {
         auto logger = faabric::util::getLogger();
         faabric::Message& msg = reqOrig->mutable_messages()->at(msgIdx);
+
+        std::string funcStr = faabric::util::funcToString(msg, true);
+
         bool isThread =
           reqOrig->type() == faabric::BatchExecuteRequest::THREADS;
 
@@ -76,7 +101,15 @@ class TestExecutor final : public Executor
                 "dummy", "thread-check", nThreads);
             chainedReq->set_type(faabric::BatchExecuteRequest::THREADS);
 
-            std::string snapKey = setUpDummySnapshot();
+            // Create a dummy snapshot
+            std::string snapKey = funcStr + "-snap";
+            faabric::snapshot::SnapshotRegistry& reg =
+              faabric::snapshot::getSnapshotRegistry();
+            faabric::util::SnapshotData snap;
+            snap.data = new uint8_t[10];
+            snap.size = 10;
+
+            reg.takeSnapshot(snapKey, snap);
 
             for (int i = 0; i < chainedReq->messages_size(); i++) {
                 faabric::Message& m = chainedReq->mutable_messages()->at(i);
@@ -88,6 +121,7 @@ class TestExecutor final : public Executor
             Scheduler& sch = getScheduler();
             sch.callFunctions(chainedReq);
 
+            // Await the results
             for (int i = 0; i < chainedReq->messages_size(); i++) {
                 uint32_t mid = chainedReq->messages().at(i).id();
                 int threadRes = sch.awaitThreadResult(mid);
@@ -95,10 +129,20 @@ class TestExecutor final : public Executor
                 assert(threadRes == mid / 100);
             }
 
+            // Delete the snapshot
+            delete[] snap.data;
+            reg.deleteSnapshot(snapKey);
+
             logger->trace("TestExecutor got {} thread results",
                           chainedReq->messages_size());
             return 0;
-        } else if (msg.function() == "chain-check-a") {
+        }
+
+        if (msg.function() == "ret-one") {
+            return 1;
+        }
+
+        if (msg.function() == "chain-check-a") {
             if (msg.inputdata() == "chained") {
                 // Set up output data for the chained call
                 msg.set_outputdata("chain-check-a successful");
@@ -115,13 +159,13 @@ class TestExecutor final : public Executor
                 sch.callFunctions(reqThis);
                 sch.callFunctions(reqOther);
 
-                for (auto& m : reqThis->messages()) {
+                for (const auto& m : reqThis->messages()) {
                     faabric::Message res =
                       sch.getFunctionResult(m.id(), SHORT_TEST_TIMEOUT_MS);
                     assert(res.outputdata() == "chain-check-a successful");
                 }
 
-                for (auto& m : reqOther->messages()) {
+                for (const auto& m : reqOther->messages()) {
                     faabric::Message res =
                       sch.getFunctionResult(m.id(), SHORT_TEST_TIMEOUT_MS);
                     assert(res.outputdata() == "chain-check-b successful");
@@ -129,21 +173,43 @@ class TestExecutor final : public Executor
 
                 msg.set_outputdata("All chain checks successful");
             }
-        } else if (msg.function() == "chain-check-b") {
+            return 0;
+        }
+
+        if (msg.function() == "chain-check-b") {
             msg.set_outputdata("chain-check-b successful");
-        } else if (msg.function() == "echo") {
+            return 0;
+        }
+
+        if (msg.function() == "snap-check") {
+            // Modify a page of the dummy memory
+            uint8_t pageIdx = threadPoolIdx;
+            logger->debug("TextExecutor Modifying page {} of memory", pageIdx);
+            uint8_t* offsetPtr =
+              dummyMemory + (pageIdx * faabric::util::HOST_PAGE_SIZE);
+
+            std::vector<uint8_t> data = { pageIdx,
+                                          (uint8_t)(pageIdx + 1),
+                                          (uint8_t)(pageIdx + 2) };
+            std::memcpy(offsetPtr, data.data(), data.size());
+        }
+
+        if (msg.function() == "echo") {
             msg.set_outputdata(msg.inputdata());
             return 0;
-        } else if (msg.function() == "ret-one") {
-            return 1;
-        } else if (msg.function() == "error") {
-            throw std::runtime_error("This is a test error");
-        } else if (reqOrig->type() == faabric::BatchExecuteRequest::THREADS) {
-            return msg.id() / 100;
-        } else {
-            msg.set_outputdata(
-              fmt::format("Simple function {} executed", msg.id()));
         }
+
+        if (msg.function() == "error") {
+            throw std::runtime_error("This is a test error");
+        }
+
+        if (reqOrig->type() == faabric::BatchExecuteRequest::THREADS) {
+            return msg.id() / 100;
+        }
+
+        // Default
+        msg.set_outputdata(
+          fmt::format("Simple function {} executed", msg.id()));
 
         return 0;
     }
@@ -159,41 +225,69 @@ class TestExecutorFactory : public ExecutorFactory
     }
 };
 
-void executeWithTestExecutor(std::shared_ptr<faabric::BatchExecuteRequest> req,
-                             bool forceLocal)
+class TestExecutorFixture : public BaseTestFixture
 {
-    std::shared_ptr<TestExecutorFactory> fac =
-      std::make_shared<TestExecutorFactory>();
-    setExecutorFactory(fac);
+  public:
+    TestExecutorFixture()
+      : reg(faabric::snapshot::getSnapshotRegistry())
+    {
+        std::shared_ptr<TestExecutorFactory> fac =
+          std::make_shared<TestExecutorFactory>();
+        setExecutorFactory(fac);
 
-    auto& conf = faabric::util::getSystemConfig();
-    int boundOriginal = conf.boundTimeout;
-    int overrideCpuOriginal = conf.overrideCpuCount;
+        setUpDummySnapshot();
 
-    conf.overrideCpuCount = 10;
-    conf.boundTimeout = SHORT_TEST_TIMEOUT_MS;
+        restoreCount = 0;
+    }
 
-    auto& sch = faabric::scheduler::getScheduler();
-    sch.callFunctions(req, forceLocal);
+    ~TestExecutorFixture() { munmap(snapshotData, snapshotSize); }
 
-    conf.boundTimeout = boundOriginal;
-    conf.overrideCpuCount = overrideCpuOriginal;
-}
+  protected:
+    faabric::snapshot::SnapshotRegistry& reg;
 
-TEST_CASE("Test executing simple function", "[executor]")
+    std::string snapshotKey = "foobar";
+    uint8_t* snapshotData;
+    int snapshotNPages = 10;
+    size_t snapshotSize = snapshotNPages * faabric::util::HOST_PAGE_SIZE;
+
+    std::vector<std::string> executeWithTestExecutor(
+      std::shared_ptr<faabric::BatchExecuteRequest> req,
+      bool forceLocal)
+    {
+        conf.overrideCpuCount = 10;
+        conf.boundTimeout = SHORT_TEST_TIMEOUT_MS;
+
+        return sch.callFunctions(req, forceLocal);
+    }
+
+  private:
+    void setUpDummySnapshot()
+    {
+        snapshotData = (uint8_t*)mmap(
+          nullptr, snapshotSize, PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+
+        faabric::util::SnapshotData snap;
+        snap.data = snapshotData;
+        snap.size = snapshotSize;
+
+        reg.takeSnapshot(snapshotKey, snap, true);
+    }
+};
+
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing simple function",
+                 "[executor]")
 {
-    cleanFaabric();
-    restoreCount = 0;
-
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "simple", 1);
     uint32_t msgId = req->messages().at(0).id();
 
     REQUIRE(req->messages_size() == 1);
 
-    executeWithTestExecutor(req, false);
+    std::vector<std::string> actualHosts = executeWithTestExecutor(req, false);
+    std::vector<std::string> expectedHosts = { conf.endpointHost };
+    REQUIRE(actualHosts == expectedHosts);
 
-    auto& sch = faabric::scheduler::getScheduler();
     faabric::Message result =
       sch.getFunctionResult(msgId, SHORT_TEST_TIMEOUT_MS);
     std::string expected = fmt::format("Simple function {} executed", msgId);
@@ -201,35 +295,32 @@ TEST_CASE("Test executing simple function", "[executor]")
 
     // Check that restore has not been called
     REQUIRE(restoreCount == 0);
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test executing chained functions", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing chained functions",
+                 "[executor]")
 {
-    cleanFaabric();
-    restoreCount = 0;
-
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "chain-check-a", 1);
     uint32_t msgId = req->messages().at(0).id();
 
-    executeWithTestExecutor(req, false);
+    std::vector<std::string> actualHosts = executeWithTestExecutor(req, false);
+    std::vector<std::string> expectedHosts = { conf.endpointHost };
+    REQUIRE(actualHosts == expectedHosts);
 
-    auto& sch = faabric::scheduler::getScheduler();
     faabric::Message result =
       sch.getFunctionResult(msgId, SHORT_TEST_TIMEOUT_MS);
     REQUIRE(result.outputdata() == "All chain checks successful");
 
     // Check that restore has not been called
     REQUIRE(restoreCount == 0);
-    sch.shutdown();
 }
 
-TEST_CASE("Test executing threads directly", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing threads directly",
+                 "[executor]")
 {
-    cleanFaabric();
-    restoreCount = 0;
     int nThreads = 0;
 
     SECTION("Underloaded") { nThreads = 10; }
@@ -241,18 +332,18 @@ TEST_CASE("Test executing threads directly", "[executor]")
     req->set_type(faabric::BatchExecuteRequest::THREADS);
 
     std::vector<uint32_t> messageIds;
-    std::string snapKey = setUpDummySnapshot();
     for (int i = 0; i < nThreads; i++) {
         faabric::Message& msg = req->mutable_messages()->at(i);
-        msg.set_snapshotkey(snapKey);
+        msg.set_snapshotkey(snapshotKey);
         msg.set_appindex(i);
 
         messageIds.emplace_back(req->messages().at(i).id());
     }
 
-    executeWithTestExecutor(req, false);
+    std::vector<std::string> actualHosts = executeWithTestExecutor(req, false);
+    std::vector<std::string> expectedHosts(nThreads, conf.endpointHost);
+    REQUIRE(actualHosts == expectedHosts);
 
-    auto& sch = faabric::scheduler::getScheduler();
     for (int i = 0; i < nThreads; i++) {
         uint32_t msgId = messageIds.at(i);
         int32_t result = sch.awaitThreadResult(msgId);
@@ -261,15 +352,12 @@ TEST_CASE("Test executing threads directly", "[executor]")
 
     // Check that restore has not been called as we're on the master
     REQUIRE(restoreCount == 0);
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test executing threads indirectly", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing threads indirectly",
+                 "[executor]")
 {
-    cleanFaabric();
-    restoreCount = 0;
-
     int nThreads;
     SECTION("Underloaded") { nThreads = 8; }
 
@@ -280,7 +368,9 @@ TEST_CASE("Test executing threads indirectly", "[executor]")
     faabric::Message& msg = req->mutable_messages()->at(0);
     msg.set_inputdata(std::to_string(nThreads));
 
-    executeWithTestExecutor(req, false);
+    std::vector<std::string> actualHosts = executeWithTestExecutor(req, false);
+    std::vector<std::string> expectedHosts = { conf.endpointHost };
+    REQUIRE(actualHosts == expectedHosts);
 
     auto& sch = faabric::scheduler::getScheduler();
     faabric::Message res = sch.getFunctionResult(msg.id(), 5000);
@@ -288,28 +378,20 @@ TEST_CASE("Test executing threads indirectly", "[executor]")
 
     // Check that restore has not been called as we're on the master
     REQUIRE(restoreCount == 0);
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test repeatedly executing threads indirectly", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test repeatedly executing threads indirectly",
+                 "[executor]")
 {
-    cleanFaabric();
-
     // We really want to stress things here, but it's quite quick to run, so
     // don't be afraid to bump up the number of threads
     int nRepeats = 10;
     int nThreads = 1000;
 
-    auto& sch = faabric::scheduler::getScheduler();
-
     std::shared_ptr<TestExecutorFactory> fac =
       std::make_shared<TestExecutorFactory>();
     setExecutorFactory(fac);
-
-    auto& conf = faabric::util::getSystemConfig();
-    int boundOriginal = conf.boundTimeout;
-    int overrideCpuOriginal = conf.overrideCpuCount;
 
     conf.overrideCpuCount = 10;
     conf.boundTimeout = LONG_TEST_TIMEOUT_MS;
@@ -320,7 +402,10 @@ TEST_CASE("Test repeatedly executing threads indirectly", "[executor]")
         faabric::Message& msg = req->mutable_messages()->at(0);
         msg.set_inputdata(std::to_string(nThreads));
 
-        executeWithTestExecutor(req, false);
+        std::vector<std::string> actualHosts =
+          executeWithTestExecutor(req, false);
+        std::vector<std::string> expectedHosts = { conf.endpointHost };
+        REQUIRE(actualHosts == expectedHosts);
 
         faabric::Message res =
           sch.getFunctionResult(msg.id(), LONG_TEST_TIMEOUT_MS);
@@ -328,27 +413,17 @@ TEST_CASE("Test repeatedly executing threads indirectly", "[executor]")
 
         sch.reset();
     }
-
-    conf.boundTimeout = boundOriginal;
-    conf.overrideCpuCount = overrideCpuOriginal;
 }
 
-TEST_CASE("Test executing remote threads indirectly", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing remote threads indirectly",
+                 "[executor]")
 {
-    cleanFaabric();
-    restoreCount = 0;
-
-    std::shared_ptr<TestExecutorFactory> fac =
-      std::make_shared<TestExecutorFactory>();
-    setExecutorFactory(fac);
-
     faabric::util::setMockMode(true);
 
-    auto& conf = faabric::util::getSystemConfig();
     std::string thisHost = conf.endpointHost;
 
     // Add other host to available hosts
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
     std::string otherHost = "other";
     sch.addHostToGlobalSet(otherHost);
 
@@ -406,27 +481,24 @@ TEST_CASE("Test executing remote threads indirectly", "[executor]")
     REQUIRE(restoreCount == 1);
 
     // Process the thread result requests
-    std::vector<std::pair<std::string, faabric::ThreadResultRequest>> results =
-      faabric::scheduler::getThreadResults();
+    auto results = faabric::scheduler::getThreadResults();
 
     for (auto& r : results) {
         REQUIRE(r.first == thisHost);
-        sch.setThreadResult(r.second.messageid(), r.second.returnvalue());
+        auto args = r.second;
+        sch.setThreadResult(std::get<0>(args), std::get<1>(args));
     }
 
     // Rejoin the other thread
     if (t.joinable()) {
         t.join();
     }
-
-    // Shutdown
-    sch.shutdown();
 }
 
-TEST_CASE("Test thread results returned on non-master", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test thread results returned on non-master",
+                 "[executor]")
 {
-    cleanFaabric();
-
     faabric::util::setMockMode(true);
     std::string otherHost = "other";
 
@@ -436,10 +508,9 @@ TEST_CASE("Test thread results returned on non-master", "[executor]")
     req->set_type(faabric::BatchExecuteRequest::THREADS);
 
     std::vector<uint32_t> messageIds;
-    std::string snapKey = setUpDummySnapshot();
     for (int i = 0; i < nThreads; i++) {
         faabric::Message& msg = req->mutable_messages()->at(i);
-        msg.set_snapshotkey(snapKey);
+        msg.set_snapshotkey(snapshotKey);
         msg.set_masterhost(otherHost);
 
         messageIds.emplace_back(msg.id());
@@ -450,91 +521,71 @@ TEST_CASE("Test thread results returned on non-master", "[executor]")
     // We have to manually add a wait here as the thread results won't actually
     // get logged on this host
     usleep(SHORT_TEST_TIMEOUT_MS * 1000);
-
-    std::vector<std::pair<std::string, faabric::ThreadResultRequest>> actual =
-      faabric::scheduler::getThreadResults();
+    auto actual = faabric::scheduler::getThreadResults();
     REQUIRE(actual.size() == nThreads);
 
     std::vector<uint32_t> actualMessageIds;
     for (auto& p : actual) {
         REQUIRE(p.first == otherHost);
-        REQUIRE(p.second.returnvalue() == p.second.messageid() / 100);
+        uint32_t messageId = std::get<0>(p.second);
+        int32_t returnValue = std::get<1>(p.second);
+        REQUIRE(returnValue == messageId / 100);
 
-        actualMessageIds.push_back(p.second.messageid());
+        actualMessageIds.push_back(messageId);
     }
 
     std::sort(actualMessageIds.begin(), actualMessageIds.end());
     std::sort(messageIds.begin(), messageIds.end());
 
     REQUIRE(actualMessageIds == messageIds);
-
-    faabric::util::setMockMode(false);
-
-    faabric::scheduler::getScheduler().shutdown();
 }
 
-TEST_CASE("Test non-zero return code", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture, "Test non-zero return code", "[executor]")
 {
-    cleanFaabric();
-
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "ret-one", 1);
     faabric::Message& msg = req->mutable_messages()->at(0);
 
     executeWithTestExecutor(req, false);
 
-    auto& sch = faabric::scheduler::getScheduler();
     faabric::Message res = sch.getFunctionResult(msg.id(), 2000);
     REQUIRE(res.returnvalue() == 1);
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test erroring function", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture, "Test erroring function", "[executor]")
 {
-    cleanFaabric();
-
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "error", 1);
     faabric::Message& msg = req->mutable_messages()->at(0);
 
     executeWithTestExecutor(req, false);
 
-    auto& sch = faabric::scheduler::getScheduler();
     faabric::Message res = sch.getFunctionResult(msg.id(), 2000);
     REQUIRE(res.returnvalue() == 1);
 
     std::string expectedErrorMsg = fmt::format(
       "Task {} threw exception. What: This is a test error", msg.id());
     REQUIRE(res.outputdata() == expectedErrorMsg);
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test erroring thread", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture, "Test erroring thread", "[executor]")
 {
-    cleanFaabric();
-
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "error", 1);
     faabric::Message& msg = req->mutable_messages()->at(0);
     req->set_type(faabric::BatchExecuteRequest::THREADS);
 
-    std::string snapKey = setUpDummySnapshot();
-    msg.set_snapshotkey(snapKey);
+    msg.set_snapshotkey(snapshotKey);
     executeWithTestExecutor(req, false);
 
-    auto& sch = faabric::scheduler::getScheduler();
     int32_t res = sch.awaitThreadResult(msg.id());
     REQUIRE(res == 1);
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test executing different functions", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing different functions",
+                 "[executor]")
 {
-    cleanFaabric();
-
     // Set up multiple requests
     std::shared_ptr<BatchExecuteRequest> reqA =
       faabric::util::batchExecFactory("dummy", "echo", 2);
@@ -550,15 +601,10 @@ TEST_CASE("Test executing different functions", "[executor]")
       std::make_shared<TestExecutorFactory>();
     setExecutorFactory(fac);
 
-    auto& conf = faabric::util::getSystemConfig();
-    int boundOriginal = conf.boundTimeout;
-    int overrideCpuOriginal = conf.overrideCpuCount;
-
     conf.overrideCpuCount = 10;
     conf.boundTimeout = SHORT_TEST_TIMEOUT_MS;
 
     // Execute all the functions
-    auto& sch = faabric::scheduler::getScheduler();
     sch.callFunctions(reqA, false);
     sch.callFunctions(reqB, false);
     sch.callFunctions(reqC, false);
@@ -585,17 +631,12 @@ TEST_CASE("Test executing different functions", "[executor]")
                                               reqC->messages().at(0).id()));
     REQUIRE(resC2.outputdata() == fmt::format("Simple function {} executed",
                                               reqC->messages().at(1).id()));
-
-    conf.boundTimeout = boundOriginal;
-    conf.overrideCpuCount = overrideCpuOriginal;
-
-    sch.shutdown();
 }
 
-TEST_CASE("Test claiming and releasing executor", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test claiming and releasing executor",
+                 "[executor]")
 {
-    cleanFaabric();
-
     faabric::Message msgA = faabric::util::messageFactory("foo", "bar");
     faabric::Message msgB = faabric::util::messageFactory("foo", "bar");
 
@@ -623,16 +664,15 @@ TEST_CASE("Test claiming and releasing executor", "[executor]")
     REQUIRE(!execB->tryClaim());
 }
 
-TEST_CASE("Test executor timing out waiting", "[executor]")
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executor timing out waiting",
+                 "[executor]")
 {
-    cleanFaabric();
-
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory("foo", "bar", 1);
     faabric::Message& msg = req->mutable_messages()->at(0);
 
     // Set a very short bound timeout so we can check it works
-    auto& conf = faabric::util::getSystemConfig();
     conf.boundTimeout = 300;
 
     auto& sch = faabric::scheduler::getScheduler();
@@ -643,9 +683,180 @@ TEST_CASE("Test executor timing out waiting", "[executor]")
     usleep((conf.boundTimeout + 500) * 1000);
 
     REQUIRE(sch.getFunctionExecutorCount(msg) == 0);
+}
 
-    conf.reset();
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test snapshot diffs returned to master",
+                 "[executor]")
+{
+    int nThreads = 4;
+    std::shared_ptr<faabric::BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("dummy", "snap-check", nThreads);
+    req->set_type(faabric::BatchExecuteRequest::THREADS);
 
-    sch.shutdown();
+    faabric::util::setMockMode(true);
+    std::string otherHost = "other";
+
+    // Set up a load of messages executing with a different master host
+    std::vector<uint32_t> messageIds;
+    for (int i = 0; i < nThreads; i++) {
+        faabric::Message& msg = req->mutable_messages()->at(i);
+        msg.set_snapshotkey(snapshotKey);
+        msg.set_masterhost(otherHost);
+        msg.set_appindex(i);
+
+        messageIds.emplace_back(msg.id());
+    }
+
+    executeWithTestExecutor(req, true);
+
+    // Wait for executor to have finished - sometimes takes a while
+    usleep(SHORT_TEST_TIMEOUT_MS * 1000);
+
+    // Check thread results returned
+    REQUIRE(faabric::scheduler::getThreadResults().size() == nThreads);
+
+    // Check results have been sent back to the master host
+    auto actualResults = faabric::scheduler::getThreadResults();
+    REQUIRE(actualResults.size() == nThreads);
+
+    // Check only one has diffs attached
+    std::vector<faabric::util::SnapshotDiff> diffList;
+    for (const auto& res : actualResults) {
+        REQUIRE(res.first == otherHost);
+
+        std::vector<faabric::util::SnapshotDiff> thisDiffs =
+          std::get<3>(res.second);
+        if (thisDiffs.empty()) {
+            continue;
+        }
+
+        if (!diffList.empty()) {
+            FAIL("Found more than one thread result with diffs");
+        }
+        diffList = thisDiffs;
+    }
+
+    // Each thread should have edited one page, check diffs are correct
+    REQUIRE(diffList.size() == nThreads);
+    for (int i = 0; i < diffList.size(); i++) {
+        // Check offset and data (according to logic defined in the dummy
+        // executor)
+        uint8_t pageIndex = i + 1;
+        REQUIRE(diffList.at(i).offset ==
+                pageIndex * faabric::util::HOST_PAGE_SIZE);
+
+        std::vector<uint8_t> expected = { pageIndex,
+                                          (uint8_t)(pageIndex + 1),
+                                          (uint8_t)(pageIndex + 2) };
+
+        std::vector<uint8_t> actual(diffList.at(i).data,
+                                    diffList.at(i).data + 3);
+
+        REQUIRE(actual == expected);
+    }
+}
+
+TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test snapshot diffs pushed to workers after initial snapshot",
+                 "[executor]")
+{
+    faabric::util::setMockMode(true);
+
+    std::string thisHost = conf.endpointHost;
+    std::string otherHost = "other";
+    sch.addHostToGlobalSet(otherHost);
+
+    int nThreads = 5;
+
+    // Execute some on this host, some on the others
+    faabric::HostResources res;
+    res.set_slots(2);
+    sch.setThisHostResources(res);
+
+    // Set up other host to have some resources
+    faabric::HostResources resOther;
+    resOther.set_slots(10);
+    faabric::scheduler::queueResourceResponse(otherHost, resOther);
+
+    // Execute a batch of threads
+    std::shared_ptr<BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("dummy", "blah", nThreads);
+    req->set_type(faabric::BatchExecuteRequest::THREADS);
+    faabric::Message& msg = req->mutable_messages()->at(0);
+
+    std::vector<uint32_t> messageIds;
+    for (int i = 0; i < nThreads; i++) {
+        faabric::Message& msg = req->mutable_messages()->at(i);
+        msg.set_snapshotkey(snapshotKey);
+        messageIds.emplace_back(msg.id());
+    }
+
+    // Execute the functions
+    std::vector<std::string> actualHosts = executeWithTestExecutor(req, false);
+
+    // Check they're executed on the right hosts
+    std::vector<std::string> expectedHosts = {
+        thisHost, thisHost, otherHost, otherHost, otherHost
+    };
+    REQUIRE(actualHosts == expectedHosts);
+
+    // Await local results
+    for (int i = 0; i < actualHosts.size(); i++) {
+        if (actualHosts.at(i) == thisHost) {
+            sch.awaitThreadResult(messageIds.at(i));
+        }
+    }
+
+    // Check the other host is registered
+    std::set<std::string> expectedRegistered = { otherHost };
+    REQUIRE(sch.getFunctionRegisteredHosts(msg) == expectedRegistered);
+
+    // Check snapshot has been pushed
+    auto pushes = faabric::scheduler::getSnapshotPushes();
+    REQUIRE(pushes.at(0).first == otherHost);
+    REQUIRE(pushes.at(0).second.size == snapshotSize);
+
+    REQUIRE(faabric::scheduler::getSnapshotDiffPushes().empty());
+
+    // Check that we're not registering any dirty pages on the snapshot
+    faabric::util::SnapshotData& snapData = reg.getSnapshot(snapshotKey);
+    REQUIRE(snapData.getDirtyPages().empty());
+
+    // Now reset snapshot pushes of all kinds
+    faabric::scheduler::clearMockSnapshotRequests();
+
+    // Make an edit to the snapshot memory and get the expected diffs
+    snapshotData[0] = 2;
+    snapshotData[(2 * faabric::util::HOST_PAGE_SIZE) + 1] = 3;
+    std::vector<faabric::util::SnapshotDiff> expectedDiffs =
+      snapData.getDirtyPages();
+    REQUIRE(expectedDiffs.size() == 2);
+
+    // Invoke just one more function
+    std::shared_ptr<BatchExecuteRequest> reqB =
+      faabric::util::batchExecFactory("dummy", "blah", 1);
+    reqB->set_type(faabric::BatchExecuteRequest::THREADS);
+    reqB->mutable_messages()->at(0).set_snapshotkey(snapshotKey);
+
+    std::vector<std::string> expectedHostsB = { thisHost };
+    std::vector<std::string> actualHostsB =
+      executeWithTestExecutor(reqB, false);
+    REQUIRE(actualHostsB == expectedHostsB);
+
+    // Check the full snapshot hasn't been pushed
+    REQUIRE(faabric::scheduler::getSnapshotPushes().empty());
+
+    // Check the diffs are pushed as expected
+    auto diffPushes = faabric::scheduler::getSnapshotDiffPushes();
+    REQUIRE(diffPushes.size() == 1);
+    REQUIRE(diffPushes.at(0).first == otherHost);
+    std::vector<faabric::util::SnapshotDiff> actualDiffs =
+      diffPushes.at(0).second;
+
+    for (int i = 0; i < actualDiffs.size(); i++) {
+        REQUIRE(actualDiffs.at(i).offset == expectedDiffs.at(i).offset);
+        REQUIRE(actualDiffs.at(i).size == expectedDiffs.at(i).size);
+    }
 }
 }

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -2,8 +2,8 @@
 
 #include <DummyExecutor.h>
 #include <DummyExecutorFactory.h>
+
 #include <faabric/proto/faabric.pb.h>
-#include <faabric/redis/Redis.h>
 #include <faabric/scheduler/ExecutorFactory.h>
 #include <faabric/scheduler/FunctionCallClient.h>
 #include <faabric/scheduler/FunctionCallServer.h>
@@ -23,8 +23,9 @@ using namespace scheduler;
 
 namespace tests {
 class ClientServerFixture
-  : public SchedulerTestFixture
-  , public RedisTestFixture
+  : public RedisTestFixture
+  , public SchedulerTestFixture
+  , public StateTestFixture
 {
   protected:
     FunctionCallServer server;
@@ -101,8 +102,6 @@ TEST_CASE_METHOD(ClientServerFixture, "Test sending MPI message", "[scheduler]")
     localWorld.destroy();
     remoteWorld.destroy();
     registry.clear();
-
-    state::getGlobalState().forceClearAll(true);
 }
 
 TEST_CASE_METHOD(ClientServerFixture,

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -22,7 +22,7 @@
 using namespace scheduler;
 
 namespace tests {
-class ClientServerFixture : public BaseTestFixture
+class ClientServerFixture : public SchedulerTestFixture
 {
   protected:
     FunctionCallServer server;

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -22,17 +22,15 @@
 using namespace scheduler;
 
 namespace tests {
-class ClientServerFixture
+class ClientServerFixture : public BaseTestFixture
 {
   protected:
-    Scheduler& sch;
     FunctionCallServer server;
     FunctionCallClient cli;
 
   public:
     ClientServerFixture()
-      : sch(faabric::scheduler::getScheduler())
-      , cli(LOCALHOST)
+      : cli(LOCALHOST)
     {
         server.start();
         usleep(1000 * TEST_TIMEOUT_MS);
@@ -46,7 +44,6 @@ class ClientServerFixture
     ~ClientServerFixture()
     {
         cli.close();
-        sch.reset();
         server.stop();
     }
 };
@@ -279,50 +276,5 @@ TEST_CASE_METHOD(ClientServerFixture, "Test unregister request", "[scheduler]")
 
     sch.setThisHostResources(originalResources);
     faabric::scheduler::clearMockRequests();
-}
-
-TEST_CASE_METHOD(ClientServerFixture, "Test set thread result", "[scheduler]")
-{
-    // Register threads on this host
-    int threadIdA = 123;
-    int threadIdB = 345;
-    int returnValueA = 88;
-    int returnValueB = 99;
-    sch.registerThread(threadIdA);
-    sch.registerThread(threadIdB);
-
-    // Make the request
-    faabric::ThreadResultRequest reqA;
-    faabric::ThreadResultRequest reqB;
-
-    reqA.set_messageid(threadIdA);
-    reqA.set_returnvalue(returnValueA);
-
-    reqB.set_messageid(threadIdB);
-    reqB.set_returnvalue(returnValueB);
-
-    // Set up two threads to await the results
-    std::thread tA([threadIdA, returnValueA] {
-        faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-        int32_t r = sch.awaitThreadResult(threadIdA);
-        REQUIRE(r == returnValueA);
-    });
-
-    std::thread tB([threadIdB, returnValueB] {
-        faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-        int32_t r = sch.awaitThreadResult(threadIdB);
-        REQUIRE(r == returnValueB);
-    });
-
-    cli.setThreadResult(reqA);
-    cli.setThreadResult(reqB);
-
-    if (tA.joinable()) {
-        tA.join();
-    }
-
-    if (tB.joinable()) {
-        tB.join();
-    }
 }
 }

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -22,7 +22,9 @@
 using namespace scheduler;
 
 namespace tests {
-class ClientServerFixture : public SchedulerTestFixture
+class ClientServerFixture
+  : public SchedulerTestFixture
+  , public RedisTestFixture
 {
   protected:
     FunctionCallServer server;

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -50,17 +50,19 @@ class SlowExecutorFactory : public ExecutorFactory
     }
 };
 
-class SchedulerTestFixture : public BaseTestFixture
+class SlowExecutorFixture
+  : public SchedulerTestFixture
+  , public ConfTestFixture
 {
   public:
-    SchedulerTestFixture()
+    SlowExecutorFixture()
     {
         std::shared_ptr<ExecutorFactory> fac =
           std::make_shared<SlowExecutorFactory>();
         setExecutorFactory(fac);
     };
 
-    ~SchedulerTestFixture()
+    ~SlowExecutorFixture()
     {
         std::shared_ptr<DummyExecutorFactory> fac =
           std::make_shared<DummyExecutorFactory>();
@@ -68,7 +70,7 @@ class SchedulerTestFixture : public BaseTestFixture
     };
 };
 
-TEST_CASE_METHOD(SchedulerTestFixture, "Test scheduler clear-up", "[scheduler]")
+TEST_CASE_METHOD(SlowExecutorFixture, "Test scheduler clear-up", "[scheduler]")
 {
     faabric::util::setMockMode(true);
 
@@ -126,7 +128,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test scheduler clear-up", "[scheduler]")
     REQUIRE(resCheck.usedslots() == 0);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Test scheduler available hosts",
                  "[scheduler]")
 {
@@ -154,7 +156,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(actualHosts == expectedHosts);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture, "Test batch scheduling", "[scheduler]")
+TEST_CASE_METHOD(SlowExecutorFixture, "Test batch scheduling", "[scheduler]")
 {
     std::string expectedSnapshot;
     faabric::BatchExecuteRequest::BatchExecuteType execMode;
@@ -338,7 +340,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test batch scheduling", "[scheduler]")
     REQUIRE(pTwo.second->messages_size() == nCallsTwo);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Test overloaded scheduler",
                  "[scheduler]")
 {
@@ -420,7 +422,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(sch.getFunctionExecutorCount(firstMsg) == expectedExecutors);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture, "Test unregistering host", "[scheduler]")
+TEST_CASE_METHOD(SlowExecutorFixture, "Test unregistering host", "[scheduler]")
 {
     faabric::util::setMockMode(true);
 
@@ -458,7 +460,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test unregistering host", "[scheduler]")
     REQUIRE(sch.getFunctionRegisteredHostCount(msg) == 0);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture, "Check test mode", "[scheduler]")
+TEST_CASE_METHOD(SlowExecutorFixture, "Check test mode", "[scheduler]")
 {
     faabric::Message msgA = faabric::util::messageFactory("demo", "echo");
     faabric::Message msgB = faabric::util::messageFactory("demo", "echo");
@@ -490,7 +492,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Check test mode", "[scheduler]")
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Global message queue tests",
                  "[scheduler]")
 {
@@ -516,7 +518,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     checkMessageEquality(call, actualCall2);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Check multithreaded function results",
                  "[scheduler]")
 {
@@ -552,7 +554,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Check getting function status",
                  "[scheduler]")
 {
@@ -605,7 +607,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(result.executedhost() == expectedHost);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Check setting long-lived function status",
                  "[scheduler]")
 {
@@ -629,7 +631,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     checkMessageEquality(actualMsg, expected);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Check logging chained functions",
                  "[scheduler]")
 {
@@ -654,7 +656,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(sch.getChainedFunctions(msg.id()) == expected);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Test non-master batch request returned to master",
                  "[scheduler]")
 {
@@ -677,7 +679,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(actualReqs.at(0).second->id() == req->id());
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Test broadcast snapshot deletion",
                  "[scheduler]")
 {
@@ -730,7 +732,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(actualDeleteRequests == expectedDeleteRequests);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SlowExecutorFixture,
                  "Test set thread results on remote host",
                  "[scheduler]")
 {

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -52,6 +52,7 @@ class SlowExecutorFactory : public ExecutorFactory
 
 class SlowExecutorFixture
   : public SchedulerTestFixture
+  , public RedisTestFixture
   , public ConfTestFixture
 {
   public:

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -51,8 +51,8 @@ class SlowExecutorFactory : public ExecutorFactory
 };
 
 class SlowExecutorFixture
-  : public SchedulerTestFixture
-  , public RedisTestFixture
+  : public RedisTestFixture
+  , public SchedulerTestFixture
   , public ConfTestFixture
 {
   public:

--- a/tests/test/scheduler/test_snapshot_client_server.cpp
+++ b/tests/test/scheduler/test_snapshot_client_server.cpp
@@ -11,7 +11,7 @@
 
 namespace tests {
 
-class SnapshotClientServerFixture : public BaseTestFixture
+class SnapshotClientServerFixture : public SchedulerTestFixture
 {
   protected:
     faabric::scheduler::SnapshotServer server;

--- a/tests/test/scheduler/test_snapshot_client_server.cpp
+++ b/tests/test/scheduler/test_snapshot_client_server.cpp
@@ -1,11 +1,15 @@
 #include "faabric_utils.h"
+#include "fixtures.h"
 #include <catch.hpp>
+
+#include <sys/mman.h>
 
 #include <faabric/scheduler/SnapshotClient.h>
 #include <faabric/scheduler/SnapshotServer.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/util/config.h>
 #include <faabric/util/environment.h>
+#include <faabric/util/gids.h>
 #include <faabric/util/network.h>
 #include <faabric/util/testing.h>
 
@@ -14,19 +18,16 @@ namespace tests {
 class SnapshotClientServerFixture
   : public SchedulerTestFixture
   , public RedisTestFixture
+  , public SnapshotTestFixture
 {
   protected:
     faabric::scheduler::SnapshotServer server;
     faabric::scheduler::SnapshotClient cli;
-    snapshot::SnapshotRegistry& registry;
 
   public:
     SnapshotClientServerFixture()
       : cli(LOCALHOST)
-      , registry(snapshot::getSnapshotRegistry())
     {
-        registry.clear();
-
         server.start();
         usleep(1000 * SHORT_TEST_TIMEOUT_MS);
     }
@@ -35,7 +36,6 @@ class SnapshotClientServerFixture
     {
         cli.close();
         server.stop();
-        registry.clear();
     }
 };
 
@@ -44,7 +44,7 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
                  "[scheduler]")
 {
     // Check nothing to start with
-    REQUIRE(registry.getSnapshotCount() == 0);
+    REQUIRE(reg.getSnapshotCount() == 0);
 
     // Prepare some snapshot data
     std::string snapKeyA = "foo";
@@ -69,9 +69,9 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     usleep(1000 * 500);
 
     // Check snapshots created in regsitry
-    REQUIRE(registry.getSnapshotCount() == 2);
-    const faabric::util::SnapshotData& actualA = registry.getSnapshot(snapKeyA);
-    const faabric::util::SnapshotData& actualB = registry.getSnapshot(snapKeyB);
+    REQUIRE(reg.getSnapshotCount() == 2);
+    const faabric::util::SnapshotData& actualA = reg.getSnapshot(snapKeyA);
+    const faabric::util::SnapshotData& actualB = reg.getSnapshot(snapKeyB);
 
     REQUIRE(actualA.size == snapA.size);
     REQUIRE(actualB.size == snapB.size);
@@ -81,6 +81,19 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
 
     REQUIRE(actualDataA == dataA);
     REQUIRE(actualDataB == dataB);
+}
+
+void checkDiffsApplied(const uint8_t* snapBase,
+                       std::vector<faabric::util::SnapshotDiff> diffs)
+{
+    for (const auto& d : diffs) {
+        std::vector<uint8_t> actual(snapBase + d.offset,
+                                    snapBase + d.offset + d.size);
+
+        std::vector<uint8_t> expected(d.data, d.data + d.size);
+
+        REQUIRE(actual == expected);
+    }
 }
 
 TEST_CASE_METHOD(SnapshotClientServerFixture,
@@ -95,6 +108,52 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     sch.registerThread(threadIdA);
     sch.registerThread(threadIdB);
 
+    // Set up a snapshot
+    faabric::util::SnapshotData snap;
+    snap.size = 5 * faabric::util::HOST_PAGE_SIZE;
+    snap.data = (uint8_t*)mmap(
+      nullptr, snap.size, PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+
+    std::string snapKey = std::to_string(faabric::util::generateGid());
+    reg.takeSnapshot(snapKey, snap);
+
+    // Set up some diffs
+    std::vector<uint8_t> diffDataA1 = { 0, 1, 2, 3 };
+    std::vector<uint8_t> diffDataA2 = { 4, 5, 6 };
+    std::vector<uint8_t> diffDataB = { 7, 7, 8, 8, 8 };
+
+    std::vector<faabric::util::SnapshotDiff> diffsA;
+    std::vector<faabric::util::SnapshotDiff> diffsB;
+
+    SECTION("Without diffs")
+    {
+        cli.pushThreadResult(threadIdA, returnValueA);
+        cli.pushThreadResult(threadIdB, returnValueB);
+    }
+
+    SECTION("Empty diffs")
+    {
+        cli.pushThreadResult(threadIdA, returnValueA, snapKey, diffsA);
+        cli.pushThreadResult(threadIdB, returnValueB, snapKey, diffsB);
+    }
+
+    SECTION("With diffs")
+    {
+        faabric::util::SnapshotDiff diffA1(
+          5, diffDataA1.data(), diffDataA1.size());
+        faabric::util::SnapshotDiff diffA2(2 * faabric::util::HOST_PAGE_SIZE,
+                                           diffDataA2.data(),
+                                           diffDataA2.size());
+        diffsA = { diffA1, diffA2 };
+        cli.pushThreadResult(threadIdA, returnValueA, snapKey, diffsA);
+
+        faabric::util::SnapshotDiff diffB(3 * faabric::util::HOST_PAGE_SIZE,
+                                          diffDataB.data(),
+                                          diffDataB.size());
+        diffsB = { diffB };
+        cli.pushThreadResult(threadIdB, returnValueB, snapKey, diffsB);
+    }
+
     // Set up two threads to await the results
     std::thread tA([threadIdA, returnValueA] {
         faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
@@ -108,9 +167,6 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
         REQUIRE(r == returnValueB);
     });
 
-    cli.pushThreadResult(threadIdA, returnValueA);
-    cli.pushThreadResult(threadIdB, returnValueB);
-
     if (tA.joinable()) {
         tA.join();
     }
@@ -118,5 +174,11 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     if (tB.joinable()) {
         tB.join();
     }
+
+    // Check changes have been applied
+    checkDiffsApplied(snap.data, diffsA);
+    checkDiffsApplied(snap.data, diffsB);
+
+    munmap(snap.data, snap.size);
 }
 }

--- a/tests/test/scheduler/test_snapshot_client_server.cpp
+++ b/tests/test/scheduler/test_snapshot_client_server.cpp
@@ -11,7 +11,9 @@
 
 namespace tests {
 
-class SnapshotClientServerFixture : public SchedulerTestFixture
+class SnapshotClientServerFixture
+  : public SchedulerTestFixture
+  , public RedisTestFixture
 {
   protected:
     faabric::scheduler::SnapshotServer server;

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -13,7 +13,7 @@ const int testPort = 9999;
 const int testReplyPort = 9996;
 
 namespace tests {
-class MessageContextFixture : public BaseTestFixture
+class MessageContextFixture : public SchedulerTestFixture
 {
   protected:
     MessageContext& context;

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -1,3 +1,4 @@
+#include "faabric_utils.h"
 #include <catch.hpp>
 
 #include <thread>
@@ -12,7 +13,7 @@ const int testPort = 9999;
 const int testReplyPort = 9996;
 
 namespace tests {
-class MessageContextFixture
+class MessageContextFixture : public BaseTestFixture
 {
   protected:
     MessageContext& context;
@@ -61,7 +62,7 @@ TEST_CASE_METHOD(MessageContextFixture,
     REQUIRE_NOTHROW(src.send(msg, expectedMsg.size()));
 
     // Receive message
-    Message recvMsg = dst.recv();
+    faabric::transport::Message recvMsg = dst.recv();
     REQUIRE(recvMsg.size() == expectedMsg.size());
     std::string actualMsg(recvMsg.data(), recvMsg.size());
     REQUIRE(actualMsg == expectedMsg);
@@ -88,7 +89,7 @@ TEST_CASE_METHOD(MessageContextFixture, "Test await response", "[transport]")
         src.send(msg, expectedMsg.size());
 
         // Block waiting for a response
-        Message recvMsg = src.awaitResponse(testReplyPort);
+        faabric::transport::Message recvMsg = src.awaitResponse(testReplyPort);
         assert(recvMsg.size() == expectedResponse.size());
         std::string actualResponse(recvMsg.data(), recvMsg.size());
         assert(actualResponse == expectedResponse);
@@ -99,7 +100,7 @@ TEST_CASE_METHOD(MessageContextFixture, "Test await response", "[transport]")
     // Receive message
     RecvMessageEndpoint dst(testPort);
     dst.open(context);
-    Message recvMsg = dst.recv();
+    faabric::transport::Message recvMsg = dst.recv();
     REQUIRE(recvMsg.size() == expectedMsg.size());
     std::string actualMsg(recvMsg.data(), recvMsg.size());
     REQUIRE(actualMsg == expectedMsg);
@@ -146,7 +147,7 @@ TEST_CASE_METHOD(MessageContextFixture,
     RecvMessageEndpoint dst(testPort);
     dst.open(context);
     for (int i = 0; i < numMessages; i++) {
-        Message recvMsg = dst.recv();
+        faabric::transport::Message recvMsg = dst.recv();
         // Check just a subset of the messages
         // Note - this implicitly tests in-order message delivery
         if ((i % (numMessages / 10)) == 0) {
@@ -195,7 +196,7 @@ TEST_CASE_METHOD(MessageContextFixture,
     RecvMessageEndpoint dst(testPort);
     dst.open(context);
     for (int i = 0; i < numSenders * numMessages; i++) {
-        Message recvMsg = dst.recv();
+        faabric::transport::Message recvMsg = dst.recv();
         // Check just a subset of the messages
         if ((i % numMessages) == 0) {
             REQUIRE(recvMsg.size() == expectedMsg.size());

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LIB_FILES
     DummyExecutorFactory.cpp
     DummyExecutorFactory.h
     exec_graph_utils.cpp
+    fixtures.h
     message_utils.cpp
     system_utils.cpp
     faabric_utils.h

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "fixtures.h"
+
 #include <faabric/scheduler/ExecGraph.h>
 #include <faabric/state/State.h>
 #include <faabric/state/StateServer.h>

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "faabric/snapshot/SnapshotRegistry.h"
 #include "faabric/util/memory.h"
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/Scheduler.h>
@@ -20,7 +21,7 @@ class RedisTestFixture
     faabric::redis::Redis& redis;
 };
 
-class SchedulerTestFixture : public RedisTestFixture
+class SchedulerTestFixture
 {
   public:
     SchedulerTestFixture()
@@ -54,6 +55,21 @@ class SchedulerTestFixture : public RedisTestFixture
 
   protected:
     faabric::scheduler::Scheduler& sch;
+};
+
+class SnapshotTestFixture
+{
+  public:
+    SnapshotTestFixture()
+      : reg(faabric::snapshot::getSnapshotRegistry())
+    {
+        reg.clear();
+    }
+
+    ~SnapshotTestFixture() { reg.clear(); }
+
+  protected:
+    faabric::snapshot::SnapshotRegistry& reg;
 };
 
 class ConfTestFixture

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "faabric/util/memory.h"
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/testing.h>
@@ -13,6 +14,8 @@ class BaseTestFixture
       , conf(faabric::util::getSystemConfig())
       , redis(faabric::redis::Redis::getQueue())
     {
+        faabric::util::resetDirtyTracking();
+
         faabric::util::setMockMode(false);
         faabric::util::setTestMode(true);
 
@@ -39,6 +42,8 @@ class BaseTestFixture
         conf.reset();
 
         redis.flushAll();
+
+        faabric::util::resetDirtyTracking();
     };
 
   protected:

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "faabric/snapshot/SnapshotRegistry.h"
-#include "faabric/util/memory.h"
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/Scheduler.h>
+#include <faabric/snapshot/SnapshotRegistry.h>
+#include <faabric/state/State.h>
+#include <faabric/util/memory.h>
 #include <faabric/util/testing.h>
 
 namespace tests {
@@ -19,6 +20,32 @@ class RedisTestFixture
 
   protected:
     faabric::redis::Redis& redis;
+};
+
+class StateTestFixture
+{
+  public:
+    StateTestFixture()
+      : state(faabric::state::getGlobalState())
+    {
+        doCleanUp();
+    }
+
+    ~StateTestFixture() { doCleanUp(); }
+
+  protected:
+    faabric::state::State& state;
+    void doCleanUp()
+    {
+        // Clear out any cached state, do so for both modes
+        faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+        std::string& originalStateMode = conf.stateMode;
+        conf.stateMode = "inmemory";
+        state.forceClearAll(true);
+        conf.stateMode = "redis";
+        state.forceClearAll(true);
+        conf.stateMode = originalStateMode;
+    }
 };
 
 class SchedulerTestFixture

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <faabric/redis/Redis.h>
+#include <faabric/scheduler/Scheduler.h>
+#include <faabric/util/testing.h>
+
+namespace tests {
+class BaseTestFixture
+{
+  public:
+    BaseTestFixture()
+      : sch(faabric::scheduler::getScheduler())
+      , conf(faabric::util::getSystemConfig())
+      , redis(faabric::redis::Redis::getQueue())
+    {
+        faabric::util::setMockMode(false);
+        faabric::util::setTestMode(true);
+
+        faabric::scheduler::clearMockRequests();
+        faabric::scheduler::clearMockSnapshotRequests();
+
+        redis.flushAll();
+
+        sch.shutdown();
+        sch.addHostToGlobalSet();
+    };
+
+    ~BaseTestFixture()
+    {
+        faabric::util::setMockMode(false);
+        faabric::util::setTestMode(true);
+
+        faabric::scheduler::clearMockRequests();
+        faabric::scheduler::clearMockSnapshotRequests();
+
+        sch.shutdown();
+        sch.addHostToGlobalSet();
+
+        conf.reset();
+
+        redis.flushAll();
+    };
+
+  protected:
+    faabric::scheduler::Scheduler& sch;
+    faabric::util::SystemConfig& conf;
+    faabric::redis::Redis& redis;
+};
+}

--- a/tests/utils/message_utils.cpp
+++ b/tests/utils/message_utils.cpp
@@ -16,7 +16,6 @@ void checkMessageEquality(const faabric::Message& msgA,
 
     REQUIRE(msgA.timestamp() == msgB.timestamp());
     REQUIRE(msgA.snapshotkey() == msgB.snapshotkey());
-    REQUIRE(msgA.snapshotsize() == msgB.snapshotsize());
     REQUIRE(msgA.funcptr() == msgB.funcptr());
 
     REQUIRE(msgA.pythonuser() == msgB.pythonuser());


### PR DESCRIPTION
The aim of this PR is:

- Return diffs from the workers back to the master after executing a batch of threads. This means tracking dirty pages on worker hosts when executing a batch of threads, then returning the resulting memory diff back to the master when finished.
- Push diffs from the master host to workers when executing subsequent batches of threads (i.e. push the whole snapshot to the host when executing the first batch, then only push diffs after that). This means tracking dirty pages on the master _between_ executing batches of threads.

Changes:

- Add pushing diffs between hosts. This is either pushing diffs on their own (master -> worker), or pushing diffs along with a thread result (worker -> master). See notes below on this.
- Add dirty page checking based on [soft-dirty PTEs](https://www.kernel.org/doc/html/v5.4/admin-guide/mm/soft-dirty.html).
- Add `snapshot()` method to executor subclasses so that Faabric can request a pointer to their memory (which it then uses to work out dirty pages).
- Convert both snapshot push operations (full and diffs) to await a response synchronous, as the master host needs to know the snapshot data has been pushed and set up before sending function messages.
- Add test fixtures where possible to reduce verbosity of tests.
- Made `logger` an instance variable where possible to avoid calling `getLogger` all over the place.

Because the diffs from child threads have to be applied before other threads can continue, we have to make sure that they are applied _before_ the thread result is returned (as the thread result is the thing that other threads wait on). Therefore we have to piggyback the diffs on the existing thread result message.

I've ported the thread result message to use flatbuffers which is where all the other snapshot stuff lives. For now I've put it in with the existing `SnapshotClient` and `SnapshotServer` in an attempt to minimise the number of changes in this PR, but eventually we'll need to commit to either protobuf or flatbuffers. Flatbuffers seem potentially more efficient, but the awkwardness of passing them around and accessing the data within is a major downside. 