### PR TITLE
Remove unneeded build in format CI checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,6 @@ jobs:
         run: git fetch origin ${GITHUB_REF}:ci-branch
       - name: "Check out branch"
         run: git checkout --force ci-branch
-      # Note - here we build a release build to be the same as the container
-      - name: "Run cmake"
-        run: inv dev.cmake --build=Release
-      - name: "Rerun build to ensure code is up to date"
-        run: inv dev.cc faabric_tests
       # --- Formatting checks ---
       - name: "Python formatting check"
         run: ./bin/check_python.sh


### PR DESCRIPTION
Similar to faasm/faasm#412. If we don't use `clang-tidy` we don't need to re-build the code. If we ever put `clang-tidy` back in the CI pipeline we must remember to re-include this.