### PR TITLE
Drain MPI queues before cleanup

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -145,6 +145,13 @@ void MpiWorld::destroy()
             state::getGlobalState().deleteKV(rankState->user, rankState->key);
         }
 
+        // Wait (forever) until all ranks are done consuming their queues to
+        // clear them.
+        // Note - this means that an application with outstanding messages, i.e.
+        // send without recv, will block forever.
+        for (auto& k : localQueueMap) {
+            k.second->waitToDrain(-1);
+        }
         localQueueMap.clear();
     }
 }


### PR DESCRIPTION
The `MpiWorld::destroy()` method was working alright until tested from faasm in faasm/faasm#420. There, I add a `barrier` before calling `destroy()`. However, our barrier implementation is not _fully_ blocking (ironic).

The way barrier works is:
1. Recv in rank 0 a message from all other ranks.
2. Broadcast from rank 0 when received messages from all ranks.

Before the broadcast is issued, all non-zero ranks are blocked on a `recv`, however rank 0 does a `send` (which does not block) and exits the barrier before the other ranks have _actually_ received the barrier. Thus, if this takes a long time, and we clear all the in memory queues before that, undefined behaviour happens.