### PR TITLE
MpiWolrd: add logger as class member + increase pool size

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -217,6 +217,8 @@ class MpiWorld
     std::string thisHost;
     faabric::util::TimePoint creationTime;
 
+    const std::shared_ptr<spdlog::logger> logger;
+
     std::shared_mutex worldMutex;
     std::atomic_flag isDestroyed = false;
 


### PR DESCRIPTION
Increase by one the thread pool size to avoid a deadlock that was making the MPI async tests in faasm fail. I've added a short explanation in the comments.

I also add a member to `MpiWorld` to hold the logger and avoid querying for it every time.