### PR TITLE
Marginal gains in send/recv fast-path

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -195,6 +195,10 @@ class MpiWorld
 
     std::shared_ptr<InMemoryMpiQueue> getLocalQueue(int sendRank, int recvRank);
 
+    void setLocalQueues();
+
+    int getKeyForRanks(int sendRank, int recvRank);
+
     long getLocalQueueSize(int sendRank, int recvRank);
 
     void overrideHost(const std::string& newHost);
@@ -220,12 +224,11 @@ class MpiWorld
     std::string function;
 
     std::shared_ptr<state::StateKeyValue> stateKV;
-    std::unordered_map<int, std::string> rankHostMap;
+    std::vector<std::string> rankHostMap;
 
     std::unordered_map<std::string, uint8_t*> windowPointerMap;
 
-    std::unordered_map<std::string, std::shared_ptr<InMemoryMpiQueue>>
-      localQueueMap;
+    std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueueMap;
 
     std::shared_ptr<faabric::scheduler::MpiAsyncThreadPool> threadPool;
     int getMpiThreadPoolSize();

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -195,10 +195,6 @@ class MpiWorld
 
     std::shared_ptr<InMemoryMpiQueue> getLocalQueue(int sendRank, int recvRank);
 
-    void setLocalQueues();
-
-    int getKeyForRanks(int sendRank, int recvRank);
-
     long getLocalQueueSize(int sendRank, int recvRank);
 
     void overrideHost(const std::string& newHost);
@@ -224,11 +220,11 @@ class MpiWorld
     std::string function;
 
     std::shared_ptr<state::StateKeyValue> stateKV;
-    std::vector<std::string> rankHostMap;
+    std::vector<std::string> rankHosts;
 
     std::unordered_map<std::string, uint8_t*> windowPointerMap;
 
-    std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueueMap;
+    std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueues;
 
     std::shared_ptr<faabric::scheduler::MpiAsyncThreadPool> threadPool;
     int getMpiThreadPoolSize();
@@ -239,5 +235,9 @@ class MpiWorld
       const std::string& otherHost);
 
     void closeThreadLocalClients();
+
+    int getIndexForRanks(int sendRank, int recvRank);
+
+    void initLocalQueues();
 };
 }

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -235,8 +235,6 @@ class MpiWorld
     faabric::scheduler::FunctionCallClient& getFunctionCallClient(
       const std::string& otherHost);
 
-    void checkRankOnThisHost(int rank);
-
     void closeThreadLocalClients();
 };
 }

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -301,21 +301,6 @@ TEST_CASE("Test send and recv on same host", "[mpi]")
         REQUIRE(status.bytesSize == messageData.size() * sizeof(int));
     }
 
-    /*
-    SECTION("Test recv with type missmatch")
-    {
-        // Receive a message from a different type
-        auto buffer = new int[messageData.size()];
-        REQUIRE_THROWS(world.recv(rankA1,
-                                  rankA2,
-                                  BYTES(buffer),
-                                  MPI_INT,
-                                  messageData.size(),
-                                  nullptr,
-                                  faabric::MPIMessage::SENDRECV));
-    }
-    */
-
     tearDown({ &world });
 }
 
@@ -667,54 +652,6 @@ TEST_CASE("Test probe", "[mpi]")
     tearDown({ &world });
 }
 
-/*
-TEST_CASE("Test can't get in-memory queue for non-local ranks", "[mpi]")
-{
-    cleanFaabric();
-
-    std::string otherHost = LOCALHOST;
-
-    auto& sch = faabric::scheduler::getScheduler();
-
-    // Force the scheduler to initialise a world in the remote host by setting
-    // a worldSize bigger than the slots available locally
-    int worldSize = 4;
-    faabric::HostResources localResources;
-    localResources.set_slots(2);
-    localResources.set_usedslots(1);
-    faabric::HostResources otherResources;
-    otherResources.set_slots(2);
-
-    // Set up a remote host
-    sch.addHostToGlobalSet(otherHost);
-
-    // Mock everything to make sure the other host has resources as well
-    faabric::util::setMockMode(true);
-    sch.setThisHostResources(localResources);
-    faabric::scheduler::queueResourceResponse(otherHost, otherResources);
-
-    faabric::Message msg = faabric::util::messageFactory(user, func);
-    msg.set_mpiworldsize(worldSize);
-    scheduler::MpiWorld worldA;
-    worldA.create(msg, worldId, worldSize);
-
-    scheduler::MpiWorld worldB;
-    worldB.overrideHost(otherHost);
-    worldB.initialiseFromMsg(msg);
-
-    // Check that we can't access rank on another host locally
-    REQUIRE_THROWS(worldA.getLocalQueue(0, 2));
-
-    // Double check even when we've retrieved the rank
-    REQUIRE(worldA.getHostForRank(2) == otherHost);
-    REQUIRE_THROWS(worldA.getLocalQueue(0, 2));
-
-    faabric::util::setMockMode(false);
-    tearDown({ &worldA, &worldB });
-}
-*/
-
-/*
 TEST_CASE("Check sending to invalid rank", "[mpi]")
 {
     cleanFaabric();
@@ -729,7 +666,6 @@ TEST_CASE("Check sending to invalid rank", "[mpi]")
 
     tearDown({ &world });
 }
-*/
 
 TEST_CASE("Test collective messaging locally and across hosts", "[mpi]")
 {

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -301,6 +301,7 @@ TEST_CASE("Test send and recv on same host", "[mpi]")
         REQUIRE(status.bytesSize == messageData.size() * sizeof(int));
     }
 
+    /*
     SECTION("Test recv with type missmatch")
     {
         // Receive a message from a different type
@@ -313,6 +314,7 @@ TEST_CASE("Test send and recv on same host", "[mpi]")
                                   nullptr,
                                   faabric::MPIMessage::SENDRECV));
     }
+    */
 
     tearDown({ &world });
 }
@@ -665,6 +667,7 @@ TEST_CASE("Test probe", "[mpi]")
     tearDown({ &world });
 }
 
+/*
 TEST_CASE("Test can't get in-memory queue for non-local ranks", "[mpi]")
 {
     cleanFaabric();
@@ -709,7 +712,9 @@ TEST_CASE("Test can't get in-memory queue for non-local ranks", "[mpi]")
     faabric::util::setMockMode(false);
     tearDown({ &worldA, &worldB });
 }
+*/
 
+/*
 TEST_CASE("Check sending to invalid rank", "[mpi]")
 {
     cleanFaabric();
@@ -724,6 +729,7 @@ TEST_CASE("Check sending to invalid rank", "[mpi]")
 
     tearDown({ &world });
 }
+*/
 
 TEST_CASE("Test collective messaging locally and across hosts", "[mpi]")
 {


### PR DESCRIPTION
In this PR I revist the `send/recv` fast-path and try to prune unnecessary complexity. The most notable changes are:
1. Switch from `if`-based undefined behaviour to assertions. This is risky and controversial, as the checks will be removed in `Release` builds. I say we use with care, but feels acceptable in this situation.
2. Switch from lock-protected maps to lock-free vectors by initialising resources in advance, rather than lazily. Resource initialisation in both cases is thread safe as it is already protected by the locking in the world registry.

In my rudimentary stress test, I can see a noticeable increase in throughput (5-10%).

Lastly, removing the `if`+exception scheme, some tests which relied on `REQUIRE_THROWS` are now failing. It remains to be discussed what to do with them.