### PR TITLE
Set default MPI world size when initialising from message

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -176,9 +176,9 @@ void MpiWorld::initialiseFromMsg(const faabric::Message& msg, bool forceLocal)
     int msgWorldSize = msg.mpiworldsize();
     if (msgWorldSize <= 0) {
         size = conf.defaultMpiWorldSize;
-        logger->warn("Defaulting to default world size ({}) for {}",
-                     msgWorldSize,
-                     faabric::util::funcToString(msg, false));
+        SPDLOG_WARN("Defaulting to default world size ({}) for {}",
+                    msgWorldSize,
+                    faabric::util::funcToString(msg, false));
     } else {
         size = msgWorldSize;
     }
@@ -1092,7 +1092,7 @@ std::shared_ptr<InMemoryMpiQueue> MpiWorld::getLocalQueue(int sendRank,
 {
     assert(getHostForRank(recvRank) == thisHost);
     if (localQueues.size() != size * size) {
-        logger->error(
+        SPDLOG_ERROR(
           "Number of local MPI queues does not match world size ({} != {})",
           localQueues.size(),
           size * size);

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -172,10 +172,9 @@ void MpiWorld::initialiseFromMsg(const faabric::Message& msg, bool forceLocal)
       getMpiThreadPoolSize());
 
     // Set the world size from the message if present, otherwise set to default
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
     int msgWorldSize = msg.mpiworldsize();
     if (msgWorldSize <= 0) {
-        size = conf.defaultMpiWorldSize;
+        size = faabric::util::getSystemConfig().defaultMpiWorldSize;
         SPDLOG_WARN("Defaulting to default world size ({}) for {}",
                     msgWorldSize,
                     faabric::util::funcToString(msg, false));

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -47,16 +47,32 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test world creation", "[mpi]")
 
 TEST_CASE_METHOD(MpiTestFixture, "Test world loading from msg", "[mpi]")
 {
-    // Create another copy from state
     scheduler::MpiWorld worldB;
-    // Force creating the second world in the _same_ host
-    bool forceLocal = true;
-    worldB.initialiseFromMsg(msg, forceLocal);
 
-    REQUIRE(worldB.getSize() == worldSize);
+    int requestedWorldSize;
+    int expectedWorldSize;
+    int defaultWorldSize = faabric::util::getSystemConfig().defaultMpiWorldSize;
+
+    SECTION("Default world size")
+    {
+        requestedWorldSize = 0;
+        expectedWorldSize = defaultWorldSize;
+    }
+
+    SECTION("Custom world size")
+    {
+        requestedWorldSize = defaultWorldSize + 10;
+        expectedWorldSize = requestedWorldSize;
+    }
+
+    msg.set_mpiworldsize(requestedWorldSize);
+    worldB.initialiseFromMsg(msg, true);
+
     REQUIRE(worldB.getId() == worldId);
     REQUIRE(worldB.getUser() == user);
     REQUIRE(worldB.getFunction() == func);
+
+    REQUIRE(worldB.getSize() == expectedWorldSize);
 
     worldB.destroy();
 }


### PR DESCRIPTION
The default world size wasn't getting set via the `initialiseFromMsg` function, which is an alternative route for creating a world other than the `create` method. 

This only causes a problem the first time an application results in `getLocalQueue` getting called, at which point there are no local queues initialised (because the world size is zero). This was only covered by an assertion, so I switched it to an exception for a clearer error message.

I realise this could also happen if the world size requested in the message doesn't match that used by the application (e.g. if I set world size to 5 then try to send something to rank 10). This is difficult to test for ahead of time, so we just need to make sure there are execptions with meaningful messages thrown when it causes a problem.