### PR TITLE
Fix MPI world creation of size 1

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -136,8 +136,11 @@ void MpiWorld::create(const faabric::Message& call, int newId, int newSize)
         msg.set_mpiworldsize(size);
     }
 
-    // Send the init messages (note that message i corresponds to rank i+1)
-    std::vector<std::string> executedAt = sch.callFunctions(req);
+    std::vector<std::string> executedAt;
+    if (size > 1) {
+        // Send the init messages (note that message i corresponds to rank i+1)
+        executedAt = sch.callFunctions(req);
+    }
     assert(executedAt.size() == size - 1);
 
     // Prepend this host for rank 0

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -43,6 +43,19 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test world creation", "[mpi]")
     world.destroy();
 }
 
+TEST_CASE_METHOD(MpiBaseTestFixture, "Test creating world of size 1", "[mpi]")
+{
+    // Create the world
+    MpiWorld world;
+    int worldSize = 1;
+
+    REQUIRE_NOTHROW(world.create(msg, worldId, worldSize));
+
+    REQUIRE(world.getSize() == worldSize);
+
+    world.destroy();
+}
+
 TEST_CASE_METHOD(MpiTestFixture, "Test world loading from msg", "[mpi]")
 {
     // Create another copy from state

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -45,13 +45,18 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test world creation", "[mpi]")
 
 TEST_CASE_METHOD(MpiBaseTestFixture, "Test creating world of size 1", "[mpi]")
 {
-    // Create the world
+    // Create a world of size 1
     MpiWorld world;
     int worldSize = 1;
-
     REQUIRE_NOTHROW(world.create(msg, worldId, worldSize));
 
     REQUIRE(world.getSize() == worldSize);
+    REQUIRE(world.getId() == worldId);
+    REQUIRE(world.getUser() == user);
+    REQUIRE(world.getFunction() == func);
+
+    // Check no messages are sent
+    REQUIRE(sch.getRecordedMessagesAll().empty());
 
     world.destroy();
 }


### PR DESCRIPTION
Running MPI applications with world size 1 would not work as we'd call `callFunctions` with an empty protobuf message, and the library would raise an error.

Adding a simple check, and a test that (surprisingly) failed before and now passes.