### PR TITLE
Add section logging to test loggers

### DIFF
--- a/tests/dist/main.cpp
+++ b/tests/dist/main.cpp
@@ -13,36 +13,7 @@
 
 using namespace faabric::scheduler;
 
-struct LogListener : Catch::TestEventListenerBase
-{
-    // Note, we must call base class versions of overridden methods
-    // https://github.com/catchorg/Catch2/pull/1617
-    using TestEventListenerBase::TestEventListenerBase;
-
-    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
-    {
-        this->Catch::TestEventListenerBase::testCaseStarting(testInfo);
-
-        SPDLOG_INFO("=============================================");
-        SPDLOG_INFO("TEST: {}", testInfo.name);
-        SPDLOG_INFO("=============================================");
-    }
-
-    void sectionStarting(Catch::SectionInfo const& sectionInfo) override
-    {
-        this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);
-
-        // Tests without any sections will be default have one section with the
-        // same name as the test
-        if (sectionInfo.name != currentTestCaseInfo->name) {
-            SPDLOG_INFO("---------------------------------------------");
-            SPDLOG_INFO("SECTION: {}", sectionInfo.name);
-            SPDLOG_INFO("---------------------------------------------");
-        }
-    }
-};
-
-CATCH_REGISTER_LISTENER(LogListener)
+FAABRIC_CATCH_LOGGER
 
 int main(int argc, char* argv[])
 {

--- a/tests/dist/main.cpp
+++ b/tests/dist/main.cpp
@@ -15,13 +15,25 @@ using namespace faabric::scheduler;
 
 struct LogListener : Catch::TestEventListenerBase
 {
+    // Note, we must call base class versions of overridden methods
+    // https://github.com/catchorg/Catch2/pull/1617
     using TestEventListenerBase::TestEventListenerBase;
 
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
+        this->Catch::TestEventListenerBase::testCaseStarting(testInfo);
+
+        SPDLOG_INFO("=============================================");
+        SPDLOG_INFO("TEST: {}", testInfo.name);
+        SPDLOG_INFO("=============================================");
+    }
+
+    void sectionStarting(Catch::SectionInfo const& sectionInfo) override
+    {
+        this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);
 
         SPDLOG_INFO("---------------------------------------------");
-        SPDLOG_INFO("TEST: {}", testInfo.name);
+        SPDLOG_INFO("SECTION: {}", sectionInfo.name);
         SPDLOG_INFO("---------------------------------------------");
     }
 };

--- a/tests/dist/main.cpp
+++ b/tests/dist/main.cpp
@@ -32,9 +32,13 @@ struct LogListener : Catch::TestEventListenerBase
     {
         this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);
 
-        SPDLOG_INFO("---------------------------------------------");
-        SPDLOG_INFO("SECTION: {}", sectionInfo.name);
-        SPDLOG_INFO("---------------------------------------------");
+        // Tests without any sections will be default have one section with the
+        // same name as the test
+        if (sectionInfo.name != currentTestCaseInfo->name) {
+            SPDLOG_INFO("---------------------------------------------");
+            SPDLOG_INFO("SECTION: {}", sectionInfo.name);
+            SPDLOG_INFO("---------------------------------------------");
+        }
     }
 };
 

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -9,13 +9,25 @@
 
 struct LogListener : Catch::TestEventListenerBase
 {
+    // Note, we must call base class versions of overridden methods
+    // https://github.com/catchorg/Catch2/pull/1617
     using TestEventListenerBase::TestEventListenerBase;
 
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
+        this->Catch::TestEventListenerBase::testCaseStarting(testInfo);
+
+        SPDLOG_INFO("=============================================");
+        SPDLOG_INFO("TEST: {}", testInfo.name);
+        SPDLOG_INFO("=============================================");
+    }
+
+    void sectionStarting(Catch::SectionInfo const& sectionInfo) override
+    {
+        this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);
 
         SPDLOG_INFO("---------------------------------------------");
-        SPDLOG_INFO("TEST: {}", testInfo.name);
+        SPDLOG_INFO("SECTION: {}", sectionInfo.name);
         SPDLOG_INFO("---------------------------------------------");
     }
 };

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -7,36 +7,7 @@
 #include <faabric/util/logging.h>
 #include <faabric/util/testing.h>
 
-struct LogListener : Catch::TestEventListenerBase
-{
-    // Note, we must call base class versions of overridden methods
-    // https://github.com/catchorg/Catch2/pull/1617
-    using TestEventListenerBase::TestEventListenerBase;
-
-    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
-    {
-        this->Catch::TestEventListenerBase::testCaseStarting(testInfo);
-
-        SPDLOG_INFO("=============================================");
-        SPDLOG_INFO("TEST: {}", testInfo.name);
-        SPDLOG_INFO("=============================================");
-    }
-
-    void sectionStarting(Catch::SectionInfo const& sectionInfo) override
-    {
-        this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);
-
-        // Tests without any sections will be default have one section with the
-        // same name as the test
-        if (sectionInfo.name != currentTestCaseInfo->name) {
-            SPDLOG_INFO("---------------------------------------------");
-            SPDLOG_INFO("SECTION: {}", sectionInfo.name);
-            SPDLOG_INFO("---------------------------------------------");
-        }
-    }
-};
-
-CATCH_REGISTER_LISTENER(LogListener)
+FAABRIC_CATCH_LOGGER
 
 int main(int argc, char* argv[])
 {

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -26,9 +26,13 @@ struct LogListener : Catch::TestEventListenerBase
     {
         this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);
 
-        SPDLOG_INFO("---------------------------------------------");
-        SPDLOG_INFO("SECTION: {}", sectionInfo.name);
-        SPDLOG_INFO("---------------------------------------------");
+        // Tests without any sections will be default have one section with the
+        // same name as the test
+        if (sectionInfo.name != currentTestCaseInfo->name) {
+            SPDLOG_INFO("---------------------------------------------");
+            SPDLOG_INFO("SECTION: {}", sectionInfo.name);
+            SPDLOG_INFO("---------------------------------------------");
+        }
     }
 };
 

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -12,6 +12,30 @@ using namespace faabric;
 
 #define SHORT_TEST_TIMEOUT_MS 1000
 
+#define FAABRIC_CATCH_LOGGER                                                   \
+    struct LogListener : Catch::TestEventListenerBase                          \
+    {                                                                          \
+        using TestEventListenerBase::TestEventListenerBase;                    \
+        void testCaseStarting(Catch::TestCaseInfo const& testInfo) override    \
+        {                                                                      \
+            this->Catch::TestEventListenerBase::testCaseStarting(testInfo);    \
+            SPDLOG_INFO("=============================================");      \
+            SPDLOG_INFO("TEST: {}", testInfo.name);                            \
+            SPDLOG_INFO("=============================================");      \
+        }                                                                      \
+                                                                               \
+        void sectionStarting(Catch::SectionInfo const& sectionInfo) override   \
+        {                                                                      \
+            this->Catch::TestEventListenerBase::sectionStarting(sectionInfo);  \
+            if (sectionInfo.name != currentTestCaseInfo->name) {               \
+                SPDLOG_INFO("---------------------------------------------");  \
+                SPDLOG_INFO("SECTION: {}", sectionInfo.name);                  \
+                SPDLOG_INFO("---------------------------------------------");  \
+            }                                                                  \
+        }                                                                      \
+    };                                                                         \
+    CATCH_REGISTER_LISTENER(LogListener)
+
 namespace tests {
 void cleanFaabric();
 


### PR DESCRIPTION
We previously didn't log test sections, so it was difficult to tell where they started and ended within a given test's logs. 

For some reason I just can't get this to compile unless the `LogListener` struct is defined in the `main.cpp` file, hence I've had to put it all in a macro...