### PR TITLE
Make flush synchronous

### DIFF
--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -102,6 +102,9 @@ void FunctionCallClient::sendFlush()
         call.set_returnhost(faabric::util::getSystemConfig().endpointHost);
 
         SEND_MESSAGE(faabric::scheduler::FunctionCalls::Flush, call);
+
+        // Await the response
+        awaitResponse(FUNCTION_CALL_PORT + REPLY_PORT_OFFSET);
     }
 }
 

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -54,6 +54,9 @@ void FunctionCallServer::recvFlush(faabric::transport::Message& body)
 
     // Clear the scheduler
     scheduler.flushLocally();
+
+    faabric::EmptyResponse response;
+    SEND_SERVER_RESPONSE(response, msg.returnhost(), FUNCTION_CALL_PORT)
 }
 
 void FunctionCallServer::recvExecuteFunctions(faabric::transport::Message& body)


### PR DESCRIPTION
Flush is used rarely, but when it is, the caller cares about whether the flush has completed (e.g. in the distributed tests when it needs to know if it can carry on). Therefore, I've added an empty response to the flush call.