### PR TITLE
Add send/ recv timeouts to message endpoints

### DIFF
--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -13,6 +13,11 @@
 
 #define ANY_HOST "0.0.0.0"
 
+// These timeouts should be long enough to permit sending and receiving large
+// messages, but short enough not to hang around when something has gone wrong.
+#define DEFAULT_RECV_TIMEOUT_MS 20000
+#define DEFAULT_SEND_TIMEOUT_MS 20000
+
 namespace faabric::transport {
 enum class SocketType
 {
@@ -59,11 +64,21 @@ class MessageEndpoint
 
     int getPort();
 
+    void setRecvTimeoutMs(int value);
+
+    void setSendTimeoutMs(int value);
+
   protected:
     const std::string host;
     const int port;
     std::thread::id tid;
     int id;
+
+  private:
+    int recvTimeoutMs = DEFAULT_RECV_TIMEOUT_MS;
+    int sendTimeoutMs = DEFAULT_SEND_TIMEOUT_MS;
+
+    void validateTimeout(int value);
 };
 
 /* Send and Recv Message Endpoints */

--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -4,6 +4,7 @@
 
 #include <faabric/transport/Message.h>
 #include <faabric/transport/MessageContext.h>
+#include <faabric/util/exception.h>
 
 #include <thread>
 #include <zmq.hpp>
@@ -74,7 +75,6 @@ class MessageEndpoint
     std::thread::id tid;
     int id;
 
-  private:
     int recvTimeoutMs = DEFAULT_RECV_TIMEOUT_MS;
     int sendTimeoutMs = DEFAULT_SEND_TIMEOUT_MS;
 
@@ -101,5 +101,13 @@ class RecvMessageEndpoint : public MessageEndpoint
     void open(MessageContext& context);
 
     void close();
+};
+
+class MessageTimeoutException : public faabric::util::FaabricException
+{
+  public:
+    explicit MessageTimeoutException(std::string message)
+      : FaabricException(std::move(message))
+    {}
 };
 }

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -179,7 +179,7 @@ Message MessageEndpoint::recv(int size)
             SPDLOG_TRACE("Shutting endpoint down after receiving ETERM");
             return Message();
         } else {
-            SPDLOG_ERROR("Error receiving message: {}", e.what());
+            SPDLOG_ERROR("Error receiving message: {} ({})", e.num(), e.what());
             throw;
         }
     }

--- a/src/transport/MessageEndpointClient.cpp
+++ b/src/transport/MessageEndpointClient.cpp
@@ -11,6 +11,11 @@ Message MessageEndpointClient::awaitResponse(int port)
     // Wait for the response, open a temporary endpoint for it
     // Note - we use a different host/port not to clash with existing server
     RecvMessageEndpoint endpoint(port);
+
+    // Inherit timeouts on temporary endpoint
+    endpoint.setRecvTimeoutMs(recvTimeoutMs);
+    endpoint.setSendTimeoutMs(sendTimeoutMs);
+
     endpoint.open(faabric::transport::getGlobalMessageContext());
     Message receivedMessage = endpoint.recv();
     endpoint.close();

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -202,4 +202,43 @@ TEST_CASE_METHOD(MessageContextFixture,
     // Close the destination endpoint
     dst.close();
 }
+
+TEST_CASE_METHOD(MessageContextFixture,
+                 "Test can't set invalid send/recv timeouts",
+                 "[transport]")
+{
+    MessageEndpoint cli(thisHost, testPort);
+
+    SECTION("Sanity check valid timeout")
+    {
+        REQUIRE_NOTHROW(cli.setRecvTimeoutMs(100));
+        REQUIRE_NOTHROW(cli.setSendTimeoutMs(100));
+    }
+
+    SECTION("Recv zero timeout") { REQUIRE_THROWS(cli.setRecvTimeoutMs(0)); }
+
+    SECTION("Send zero timeout") { REQUIRE_THROWS(cli.setSendTimeoutMs(0)); }
+
+    SECTION("Recv negative timeout")
+    {
+        REQUIRE_THROWS(cli.setRecvTimeoutMs(-1));
+    }
+
+    SECTION("Send negative timeout")
+    {
+        REQUIRE_THROWS(cli.setSendTimeoutMs(-1));
+    }
+
+    SECTION("Recv, socket already initialised")
+    {
+        cli.open(context, SocketType::PULL, false);
+        REQUIRE_THROWS(cli.setRecvTimeoutMs(100));
+    }
+
+    SECTION("Send, socket already initialised")
+    {
+        cli.open(context, SocketType::PULL, false);
+        REQUIRE_THROWS(cli.setSendTimeoutMs(100));
+    }
+}
 }


### PR DESCRIPTION
At the moment we don't set any timeouts in our use of 0MQ, which means we get an infinite hang if something goes wrong. Instead we would like things to time out, so this PR sets the send timeout and recv timeout on every 0MQ socket by default.

I actually can't work out in which scenario the send timeout would be triggered, hence there's no test for it and it could be overkill. However, for now I'd like to keep it in case it catches any of the issues we've been seeing.