### PR TITLE
Fix race conditions around executor reuse

### DIFF
--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -226,7 +226,7 @@ void Executor::threadPoolThread(int threadPoolIdx)
                      threadPoolIdx,
                      executingTaskCount);
 
-        // Get snapshot diffs _before_ we reset the module
+        // Get snapshot diffs _before_ we reset the executor
         bool isThreads = req->type() == faabric::BatchExecuteRequest::THREADS;
         std::vector<faabric::util::SnapshotDiff> diffs;
         if (isLastTask && isThreads) {

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -249,18 +249,17 @@ void Executor::threadPoolThread(int threadPoolIdx)
             sch.setFunctionResult(msg);
         }
 
-        // If this batch is finished, reset and release the claim on this
-        // executor.
-        // Note that we have to release the claim _after_ resetting otherwise
+        // If this batch is finished, reset the executor and release its claim.
+        // Note that we have to release the claim _after_ resetting, otherwise
         // the executor won't be ready for reuse.
         if (oldTaskCount == 1) {
             reset(msg);
             releaseClaim();
         }
 
-        // Vacate the slot for this task in the scheduler. This must be done
-        // after releasing the claim and resetting the module to avoid a race
-        // condition in the scheduler that allows the host to overcommit.
+        // Vacate the slot occupied by this task. This must be done after
+        // releasing the claim on this executor, otherwise the scheduler may try
+        // to schedule another function and be unable to reuse this executor.
         sch.vacateSlot();
     }
 

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -232,7 +232,7 @@ void Executor::threadPoolThread(int threadPoolIdx)
         if (isLastTask && isThreads) {
             // Get diffs
             faabric::util::SnapshotData d = snapshot();
-            std::vector<faabric::util::SnapshotDiff> diffs = d.getDirtyPages();
+            diffs = d.getDirtyPages();
 
             // Reset dirty page tracking now that we've got the diffs
             faabric::util::resetDirtyTracking();

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -686,9 +686,6 @@ void Scheduler::flushLocally()
 
 void Scheduler::setFunctionResult(faabric::Message& msg)
 {
-    // Vacate the slot taken by this function
-    vacateSlot();
-
     redis::Redis& redis = redis::Redis::getQueue();
 
     // Record which host did the execution
@@ -733,9 +730,6 @@ void Scheduler::setThreadResult(
   int32_t returnValue,
   const std::vector<faabric::util::SnapshotDiff>& diffs)
 {
-    // Vacate the slot taken by this thread
-    vacateSlot();
-
     bool isMaster = msg.masterhost() == conf.endpointHost;
 
     if (isMaster) {

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -14,16 +14,11 @@ class DistTestsFixture
   , public ConfTestFixture
   , public SnapshotTestFixture
 {
-  protected:
-    std::set<std::string> otherHosts;
-
   public:
     DistTestsFixture()
     {
         // Get other hosts
         std::string thisHost = conf.endpointHost;
-        otherHosts = sch.getAvailableHosts();
-        otherHosts.erase(thisHost);
 
         // Set up executor
         std::shared_ptr<tests::DistTestExecutorFactory> fac =


### PR DESCRIPTION
Once an executor has finished execution it needs to do three things:

- Set the function result - this notifies anything waiting on that task's completion.
- Vacate a slot in the scheduler - the scheduler keeps track of how many threads or processes are running concurrently via these slots.
- Release its claim - the scheduler sets a boolean flag called a claim on each executor to keep track of whether it's available for reuse.

The previous flow of events was:

1. Set the function result
2. Vacate the scheduler slot
3. Release the executor claim

If something is waiting on the task result, it can receive the result and submit another instance of the same task _between_ steps 1 and 2 or steps 2 and 3. 

Both cause problems, if it's before 2 then the scheduler will wrongly assume one of its slots is still occupied. If it's before 3, 
the scheduler knows the right number of slots, but still can't reuse the executor.

In fact, the sequence of events should be reversed:

1. Release the executor claim 
2. Vacate the scheduler slot 
3. Set the function result

At the time of writing the initial race condition is reproduced fairly reliably in our Github Actions build; the test case for doing so is also included in this PR.