### PR TITLE
Changing zeromq dependency, and updating deprecated socket option

### DIFF
--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -122,12 +122,13 @@ ExternalProject_Add(libzeromq_ext
     GIT_REPOSITORY "https://github.com/zeromq/libzmq.git"
     GIT_TAG "v4.3.4"
     CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}"
+        "-DCMAKE_BUILD_TESTS:BOOL=OFF"
     BUILD_BYPRODUCTS ${ZEROMQ_LIBRARY}
 )
 ExternalProject_Get_Property(libzeromq_ext SOURCE_DIR)
 set(LIBZEROMQ_INCLUDE_DIR ${SOURCE_DIR})
 ExternalProject_Add(cppzeromq_ext
-    GIT_REPOSITORY "https://github.com/faasm/cppzmq.git"
+    GIT_REPOSITORY "https://github.com/zeromq/cppzmq.git"
     GIT_TAG "v4.7.1"
     CMAKE_CACHE_ARGS "-DCPPZMQ_BUILD_TESTS:BOOL=OFF"
         "-DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}"

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -81,8 +81,8 @@ void MessageEndpoint::open(faabric::transport::MessageContext& context,
     }
 
     // Set socket options
-    this->socket->setsockopt(ZMQ_RCVTIMEO, recvTimeoutMs);
-    this->socket->setsockopt(ZMQ_SNDTIMEO, sendTimeoutMs);
+    this->socket->set(zmq::sockopt::rcvtimeo, recvTimeoutMs);
+    this->socket->set(zmq::sockopt::sndtimeo, recvTimeoutMs);
 }
 
 void MessageEndpoint::send(uint8_t* serialisedMsg, size_t msgSize, bool more)


### PR DESCRIPTION
I originally [forked the C++ binding for zeromq](https://github.com/faasm/cppzmq) because I couldn't manage to disable a CMake option from our `CMakeLists.txt`. After some re-factoring in later PRs, this is in fact working, so we can change the dependency.

When the PR is merged in I will delete the fork.