### PR TITLE
Add barrier tests + Change queue timeout

### DIFF
--- a/include/faabric/util/queue.h
+++ b/include/faabric/util/queue.h
@@ -6,7 +6,7 @@
 
 #include <queue>
 
-#define DEFAULT_QUEUE_TIMEOUT_MS 500
+#define DEFAULT_QUEUE_TIMEOUT_MS 5000
 
 namespace faabric::util {
 class QueueTimeoutException : public faabric::util::FaabricException

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -1155,6 +1155,7 @@ void MpiWorld::barrier(int thisRank)
 {
     if (thisRank == 0) {
         // This is the root, hence just does the waiting
+        SPDLOG_TRACE("MPI - barrier init {}", thisRank);
 
         // Await messages from all others
         for (int r = 1; r < size; r++) {

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -185,8 +185,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test local barrier", "[mpi]")
     std::vector<int> sendData = { 0, 1, 2 };
     std::vector<int> recvData = { -1, -1, -1 };
 
-    std::thread sendThread([&world, rankA1, rankA2, &sendData, &recvData] {
-        assert(sendData != recvData);
+    std::thread senderThread([&world, rankA1, rankA2, &sendData, &recvData] {
         world.send(
           rankA1, rankA2, BYTES(sendData.data()), MPI_INT, sendData.size());
 
@@ -194,14 +193,18 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test local barrier", "[mpi]")
         assert(sendData == recvData);
     });
 
-    world.recv(
-      rankA1, rankA2, BYTES(recvData.data()), MPI_INT, recvData.size(), MPI_STATUS_IGNORE);
+    world.recv(rankA1,
+               rankA2,
+               BYTES(recvData.data()),
+               MPI_INT,
+               recvData.size(),
+               MPI_STATUS_IGNORE);
 
     REQUIRE(recvData == sendData);
 
     world.barrier(rankA2);
 
-    sendThread.join();
+    senderThread.join();
     world.destroy();
 }
 

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -8,6 +8,8 @@
 #include <faabric/util/random.h>
 #include <faabric_utils.h>
 
+#include <thread>
+
 using namespace faabric::scheduler;
 
 namespace tests {
@@ -168,6 +170,38 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test cartesian communicator", "[mpi]")
         }
     }
 
+    world.destroy();
+}
+
+TEST_CASE_METHOD(MpiBaseTestFixture, "Test local barrier", "[mpi]")
+{
+    // Create the world
+    int worldSize = 2;
+    MpiWorld world;
+    world.create(msg, worldId, worldSize);
+
+    int rankA1 = 0;
+    int rankA2 = 1;
+    std::vector<int> sendData = { 0, 1, 2 };
+    std::vector<int> recvData = { -1, -1, -1 };
+
+    std::thread sendThread([&world, rankA1, rankA2, &sendData, &recvData] {
+        assert(sendData != recvData);
+        world.send(
+          rankA1, rankA2, BYTES(sendData.data()), MPI_INT, sendData.size());
+
+        world.barrier(rankA1);
+        assert(sendData == recvData);
+    });
+
+    world.recv(
+      rankA1, rankA2, BYTES(recvData.data()), MPI_INT, recvData.size(), MPI_STATUS_IGNORE);
+
+    REQUIRE(recvData == sendData);
+
+    world.barrier(rankA2);
+
+    sendThread.join();
     world.destroy();
 }
 


### PR DESCRIPTION
After #118, dequeuing has a timeout of 500 ms. Unfortunately, there is an MPI test in faasm ([the barrier test](https://github.com/faasm/cpp/blob/master/func/mpi/mpi_barrier.cpp)) that blocks for 1s dequeuing (note that the 1s timeout is enforced through `sleep` calls). Thus we either:
* Make the timeout in `faabric` larger (in this PR, happy to revert)
* Have a `MPI_QUEUE_TIMEOUT` (originally opted for this, but given how controversial timeout values are, I doubt adding more will solve anything)
* Change the test in `clients/cpp`

In favour of changing the timeout value here is that there may be occasions in which we deliberately block on a `send/recv` as a fake synchronization point, hence 500 ms may be a bit short.

In the process of debugging this issue, I've realised we weren't testing the barrier at all in `faabric` so added a couple tests for that.

Lastly, after this gets merged in I will bump the faabric dependency in faasm. It's cumbersome to do so often, but helps catching this sort of bugs early.