### PR TITLE
Fix segmentation fault on big message serialization

### DIFF
--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -14,10 +14,8 @@ namespace faabric::util {
 std::vector<uint8_t> messageToBytes(const faabric::Message& msg)
 {
     size_t byteSize = msg.ByteSizeLong();
-    uint8_t buffer[byteSize];
-    msg.SerializeToArray(buffer, (int)byteSize);
-
-    std::vector<uint8_t> inputData(buffer, buffer + byteSize);
+    std::vector<uint8_t> inputData(byteSize, 0);
+    msg.SerializeToArray(inputData.data(), (int)inputData.size());
 
     return inputData;
 }


### PR DESCRIPTION
I'm not entirely sure why the original code crashes with SIGSEGV on some messages in my testing, but Variable-Length Arrays aren't generally standard C++ anyway and this fix also has the benefit of having one less copy of the serialized message.