### PR TITLE
Fine-grained snapshot diffs

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -22,6 +22,18 @@ class Scheduler;
 
 Scheduler& getScheduler();
 
+class ExecutorTask
+{
+  public:
+    ExecutorTask(int messageIndexIn,
+                 std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
+                 std::shared_ptr<std::atomic<int>> batchCounterIn);
+
+    int messageIndex = 0;
+    std::shared_ptr<faabric::BatchExecuteRequest> req;
+    std::shared_ptr<std::atomic<int>> batchCounter;
+};
+
 class Executor
 {
   public:
@@ -67,15 +79,11 @@ class Executor
 
     std::atomic<bool> pendingSnapshotPush = false;
 
-    std::atomic<int> executingTaskCount = 0;
-
     std::mutex threadsMutex;
     std::vector<std::shared_ptr<std::thread>> threadPoolThreads;
     std::vector<std::shared_ptr<std::thread>> deadThreads;
 
-    std::vector<faabric::util::Queue<
-      std::pair<int, std::shared_ptr<faabric::BatchExecuteRequest>>>>
-      threadQueues;
+    std::vector<faabric::util::Queue<ExecutorTask>> threadQueues;
 
     void threadPoolThread(int threadPoolIdx);
 };

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -27,11 +27,13 @@ class ExecutorTask
   public:
     ExecutorTask(int messageIndexIn,
                  std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
-                 std::shared_ptr<std::atomic<int>> batchCounterIn);
+                 std::shared_ptr<std::atomic<int>> batchCounterIn,
+                 bool needsSnapshotPushIn);
 
     int messageIndex = 0;
     std::shared_ptr<faabric::BatchExecuteRequest> req;
     std::shared_ptr<std::atomic<int>> batchCounter;
+    bool needsSnapshotPush = false;
 };
 
 class Executor
@@ -76,8 +78,6 @@ class Executor
     std::string lastSnapshot;
 
     std::atomic<bool> claimed = false;
-
-    std::atomic<bool> pendingSnapshotPush = false;
 
     std::mutex threadsMutex;
     std::vector<std::shared_ptr<std::thread>> threadPoolThreads;

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -83,7 +83,7 @@ class Executor
     std::vector<std::shared_ptr<std::thread>> threadPoolThreads;
     std::vector<std::shared_ptr<std::thread>> deadThreads;
 
-    std::vector<faabric::util::Queue<ExecutorTask>> threadQueues;
+    std::vector<faabric::util::Queue<ExecutorTask>> threadTaskQueues;
 
     void threadPoolThread(int threadPoolIdx);
 };

--- a/include/faabric/util/memory.h
+++ b/include/faabric/util/memory.h
@@ -37,5 +37,5 @@ AlignedChunk getPageAlignedChunk(long offset, long length);
 // -------------------------
 void resetDirtyTracking();
 
-std::vector<bool> getDirtyPages(const uint8_t* ptr, int nPages);
+std::vector<int> getDirtyPageNumbers(const uint8_t* ptr, int nPages);
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -27,6 +27,10 @@ class SnapshotData
     int fd = 0;
 
     std::vector<SnapshotDiff> getDirtyPages();
-};
 
+    std::vector<SnapshotDiff> getChangeDiffs(const uint8_t* updated,
+            size_t updatedSize);
+
+    void applyDiff(size_t diffOffset, const uint8_t* diffData, size_t diffLen);
+};
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -29,7 +29,7 @@ class SnapshotData
     std::vector<SnapshotDiff> getDirtyPages();
 
     std::vector<SnapshotDiff> getChangeDiffs(const uint8_t* updated,
-            size_t updatedSize);
+                                             size_t updatedSize);
 
     void applyDiff(size_t diffOffset, const uint8_t* diffData, size_t diffLen);
 };

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -12,6 +12,11 @@ SnapshotRegistry::SnapshotRegistry() {}
 faabric::util::SnapshotData& SnapshotRegistry::getSnapshot(
   const std::string& key)
 {
+    if (key.empty()) {
+        SPDLOG_ERROR("Attempting to get snapshot with empty key");
+        throw std::runtime_error("Getting snapshot with empty key");
+    }
+
     if (snapshotMap.count(key) == 0) {
         SPDLOG_ERROR("Snapshot for {} does not exist", key);
         throw std::runtime_error("Snapshot doesn't exist");

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -119,10 +119,9 @@ SnapshotServer::recvPushSnapshotDiffs(const uint8_t* buffer, size_t bufferSize)
 
     // Copy diffs to snapshot
     for (const auto* r : *r->chunks()) {
-        const uint8_t* chunkPtr = r->data()->data();
-        uint8_t* dest = snap.data + r->offset();
-        std::memcpy(dest, chunkPtr, r->data()->size());
+        snap.applyDiff(r->offset(), r->data()->data(), r->data()->size());
     }
+
     // Send response
     return std::make_unique<faabric::EmptyResponse>();
 }

--- a/src/util/memory.cpp
+++ b/src/util/memory.cpp
@@ -132,7 +132,7 @@ std::vector<uint64_t> readPagemapEntries(uintptr_t ptr, int nEntries)
     return entries;
 }
 
-std::vector<bool> getDirtyPages(const uint8_t* ptr, int nPages)
+std::vector<int> getDirtyPageNumbers(const uint8_t* ptr, int nPages)
 {
     uintptr_t vptr = (uintptr_t)ptr;
 
@@ -140,13 +140,13 @@ std::vector<bool> getDirtyPages(const uint8_t* ptr, int nPages)
     std::vector<uint64_t> entries = readPagemapEntries(vptr, nPages);
 
     // Iterate through to get boolean flags
-    std::vector<bool> flags(nPages, false);
+    std::vector<int> pageNumbers;
     for (int i = 0; i < nPages; i++) {
         if (entries.at(i) & PAGEMAP_SOFT_DIRTY) {
-            flags.at(i) = true;
+            pageNumbers.emplace_back(i);
         }
     }
 
-    return flags;
+    return pageNumbers;
 }
 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -82,8 +82,8 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
 }
 
 void SnapshotData::applyDiff(size_t diffOffset,
-                              const uint8_t* diffData,
-                              size_t diffLen)
+                             const uint8_t* diffData,
+                             size_t diffLen)
 {
     uint8_t* dest = data + diffOffset;
     std::memcpy(dest, diffData, diffLen);

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -37,6 +37,9 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
       getDirtyPageNumbers(updated, nThisPages);
 
     // Get byte-wise diffs _within_ the dirty pages
+    // NOTE - this will cause diffs to be split across pages if they hit a page
+    // boundary, but we can be relatively confident that variables will be
+    // page-aligned so this shouldn't be a problem
     std::vector<SnapshotDiff> diffs;
     for (int i : dirtyPageNumbers) {
         int pageOffset = i * HOST_PAGE_SIZE;
@@ -63,6 +66,7 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
         // If we've reached the end with a diff in progress, we need to close it
         // off
         if (diffInProgress) {
+            offset++;
             diffs.emplace_back(
               diffStart, updated + diffStart, offset - diffStart);
         }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -7,27 +7,82 @@ namespace faabric::util {
 std::vector<SnapshotDiff> SnapshotData::getDirtyPages()
 {
     if (data == nullptr || size == 0) {
-        std::vector<faabric::util::SnapshotDiff> empty;
+        std::vector<SnapshotDiff> empty;
         return empty;
     }
 
     // Get dirty pages
     int nPages = getRequiredHostPages(size);
-    std::vector<bool> dirtyFlags = faabric::util::getDirtyPages(data, nPages);
+    std::vector<int> dirtyPageNumbers = getDirtyPageNumbers(data, nPages);
 
     // Convert to snapshot diffs
     // TODO - reduce number of diffs by merging adjacent dirty pages
     std::vector<SnapshotDiff> diffs;
-    for (int i = 0; i < nPages; i++) {
-        if (dirtyFlags.at(i)) {
-            uint32_t offset = i * faabric::util::HOST_PAGE_SIZE;
-            diffs.emplace_back(
-              offset, data + offset, faabric::util::HOST_PAGE_SIZE);
-        }
+    for (int i : dirtyPageNumbers) {
+        uint32_t offset = i * HOST_PAGE_SIZE;
+        diffs.emplace_back(offset, data + offset, HOST_PAGE_SIZE);
     }
 
     SPDLOG_DEBUG("Snapshot has {}/{} dirty pages", diffs.size(), nPages);
 
     return diffs;
 }
+
+std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
+                                                       size_t updatedSize)
+{
+    // Work out which pages have changed in the comparison
+    size_t nThisPages = getRequiredHostPages(size);
+    std::vector<int> dirtyPageNumbers =
+      getDirtyPageNumbers(updated, nThisPages);
+
+    // Get byte-wise diffs _within_ the dirty pages
+    std::vector<SnapshotDiff> diffs;
+    for (int i : dirtyPageNumbers) {
+        int pageOffset = i * HOST_PAGE_SIZE;
+
+        // Iterate through each byte of the page
+        bool diffInProgress = false;
+        int diffStart = 0;
+        int offset = pageOffset;
+        for (int b = 0; b < HOST_PAGE_SIZE; b++) {
+            offset = pageOffset + b;
+            bool isDirtyByte = *(data + offset) != *(updated + offset);
+            if (isDirtyByte && !diffInProgress) {
+                // Diff starts here if it's different and diff not in progress
+                diffInProgress = true;
+                diffStart = offset;
+            } else if (!isDirtyByte && diffInProgress) {
+                // Diff ends if it's not different and diff is in progress
+                diffInProgress = false;
+                diffs.emplace_back(
+                  diffStart, updated + diffStart, offset - diffStart);
+            }
+        }
+
+        // If we've reached the end with a diff in progress, we need to close it
+        // off
+        if (diffInProgress) {
+            diffs.emplace_back(
+              diffStart, updated + diffStart, offset - diffStart);
+        }
+    }
+
+    // If comparison has more pages than the original, add another diff
+    // containing all the new pages
+    if (updatedSize > size) {
+        diffs.emplace_back(size, updated + size, updatedSize - size);
+    }
+
+    return diffs;
+}
+
+void SnapshotData::applyDiff(size_t diffOffset,
+                              const uint8_t* diffData,
+                              size_t diffLen)
+{
+    uint8_t* dest = data + diffOffset;
+    std::memcpy(dest, diffData, diffLen);
+}
+
 }

--- a/tests/dist/scheduler/functions.cpp
+++ b/tests/dist/scheduler/functions.cpp
@@ -118,7 +118,7 @@ int handleFakeDiffsThreadedFunction(
             m.set_snapshotkey(snapshotKey);
         }
 
-        // Dispatch the message, we expect them all to be executed other hosts
+        // Dispatch the message, expecting them all to execute on other hosts
         std::string thisHost = faabric::util::getSystemConfig().endpointHost;
         faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
         std::vector<std::string> executedHosts = sch.callFunctions(req);

--- a/tests/dist/scheduler/functions.cpp
+++ b/tests/dist/scheduler/functions.cpp
@@ -116,6 +116,13 @@ int handleFakeDiffsThreadedFunction(
             m.set_appindex(i);
             m.set_inputdata(std::string("thread_" + std::to_string(i)));
             m.set_snapshotkey(snapshotKey);
+
+            // Make a small modification to a page that will also be edited by
+            // the child thread to make sure it's not overwritten
+            std::vector<uint8_t> localChange(3, i);
+            uint32_t offset = 2 * i * faabric::util::HOST_PAGE_SIZE;
+            std::memcpy(
+              snapMemory + offset, localChange.data(), localChange.size());
         }
 
         // Dispatch the message, expecting them all to execute on other hosts
@@ -144,9 +151,22 @@ int handleFakeDiffsThreadedFunction(
         }
 
         // Check that the changes have been made to the snapshot memory
-        bool diffsApplied = true;
+        bool success = true;
         for (int i = 0; i < nThreads; i++) {
-            uint32_t offset = 2 * i * faabric::util::HOST_PAGE_SIZE;
+            // Check local modifications
+            std::vector<uint8_t> expectedLocal(3, i);
+            uint32_t localOffset = 2 * i * faabric::util::HOST_PAGE_SIZE;
+            std::vector<uint8_t> actualLocal(snapMemory + localOffset,
+                                             snapMemory + localOffset +
+                                               expectedLocal.size());
+
+            if (actualLocal != expectedLocal) {
+                SPDLOG_ERROR("Local modifications not present for {}", i);
+                success = false;
+            }
+
+            // Check remote modifications
+            uint32_t offset = 2 * i * faabric::util::HOST_PAGE_SIZE + 10;
             std::string expectedData("thread_" + std::to_string(i));
             auto* charPtr = reinterpret_cast<char*>(snapMemory + offset);
             std::string actual(charPtr);
@@ -154,17 +174,17 @@ int handleFakeDiffsThreadedFunction(
             if (actual != expectedData) {
                 SPDLOG_ERROR(
                   "Diff not as expected. {} != {}", actual, expectedData);
-                diffsApplied = false;
+                success = false;
             }
         }
 
-        if (!diffsApplied) {
+        if (!success) {
             return 222;
         }
 
     } else {
         int idx = msg.appindex();
-        uint32_t offset = 2 * idx * faabric::util::HOST_PAGE_SIZE;
+        uint32_t offset = 2 * idx * faabric::util::HOST_PAGE_SIZE + 10;
 
         // Modify the executor's memory
         std::vector<uint8_t> inputBytes =

--- a/tests/dist/scheduler/test_snapshots.cpp
+++ b/tests/dist/scheduler/test_snapshots.cpp
@@ -75,7 +75,7 @@ TEST_CASE_METHOD(DistTestsFixture,
 }
 
 TEST_CASE_METHOD(DistTestsFixture,
-                 "Check snapshots sent back from child threads",
+                 "Check snapshot diffs sent back from child threads",
                  "[snapshots]")
 {
     std::string user = "snapshots";

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -123,8 +123,8 @@ class TestExecutor final : public Executor
             sch.callFunctions(chainedReq);
 
             // Await the results
-            for (int i = 0; i < chainedReq->messages_size(); i++) {
-                uint32_t mid = chainedReq->messages().at(i).id();
+            for (const auto& msg : chainedReq->messages()) {
+                uint32_t mid = msg.id();
                 int threadRes = sch.awaitThreadResult(mid);
                 UNUSED(threadRes);
                 assert(threadRes == mid / 100);
@@ -264,14 +264,8 @@ class TestExecutorFixture
   private:
     void setUpDummySnapshot()
     {
-        snapshotData = (uint8_t*)mmap(
-          nullptr, snapshotSize, PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-        faabric::util::SnapshotData snap;
-        snap.data = snapshotData;
-        snap.size = snapshotSize;
-
-        reg.takeSnapshot(snapshotKey, snap, true);
+        takeSnapshot(snapshotKey, snapshotNPages, true);
+        faabric::util::resetDirtyTracking();
     }
 };
 

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -95,13 +95,8 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
                  "[snapshot]")
 {
     // Set up a snapshot
-    faabric::util::SnapshotData snap;
-    snap.size = 5 * faabric::util::HOST_PAGE_SIZE;
-    snap.data = (uint8_t*)mmap(
-      nullptr, snap.size, PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
     std::string snapKey = std::to_string(faabric::util::generateGid());
-    reg.takeSnapshot(snapKey, snap);
+    faabric::util::SnapshotData snap = takeSnapshot(snapKey, 5, true);
 
     // Set up some diffs
     std::vector<uint8_t> diffDataA1 = { 0, 1, 2, 3 };
@@ -126,7 +121,7 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     checkDiffsApplied(snap.data, diffsA);
     checkDiffsApplied(snap.data, diffsB);
 
-    munmap(snap.data, snap.size);
+    deallocatePages(snap.data, 5);
 }
 
 TEST_CASE_METHOD(SnapshotClientServerFixture,

--- a/tests/test/snapshot/test_snapshot_diffs.cpp
+++ b/tests/test/snapshot/test_snapshot_diffs.cpp
@@ -10,28 +10,88 @@ using namespace faabric::util;
 
 namespace tests {
 
-TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot dirty pages", "[snapshot]")
+void checkSnapshotDiff(int offset,
+                       std::vector<uint8_t> data,
+                       SnapshotDiff& actual)
+{
+    REQUIRE(offset == actual.offset);
+    std::vector<uint8_t> actualData(actual.data, actual.data + actual.size);
+    REQUIRE(data == actualData);
+}
+
+TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
 {
     std::string snapKey = "foobar123";
-    int nPages = 5;
-    SnapshotData snap = takeSnapshot(snapKey, nPages, true);
+    int snapPages = 5;
+    size_t snapSize = snapPages * HOST_PAGE_SIZE;
+    SnapshotData snap = takeSnapshot(snapKey, snapPages, true);
 
-    uint8_t* sharedMem = allocatePages(nPages);
+    // Make shared memory larger than original snapshot
+    int sharedMemPages = 8;
+    size_t sharedMemSize = sharedMemPages * HOST_PAGE_SIZE;
+    uint8_t* sharedMem = allocatePages(sharedMemPages);
 
+    // Map the snapshot to the start of the memory
     reg.mapSnapshot(snapKey, sharedMem);
 
     // Reset dirty tracking
     faabric::util::resetDirtyTracking();
 
-    // Make a change to the shared memory
-    *(sharedMem + 2 * HOST_PAGE_SIZE) = 2;
+    // Set up some chunks of data to write into the memory
+    std::vector<uint8_t> dataA = { 1, 2, 3, 4 };
+    std::vector<uint8_t> dataB = { 4, 5, 6 };
+    std::vector<uint8_t> dataC = { 7, 6, 5, 4, 3 };
+    std::vector<uint8_t> dataD = { 1, 1, 1, 1 };
+
+    // Set up some offsets, both on and over page boundaries
+    int offsetA = HOST_PAGE_SIZE;
+    int offsetB = HOST_PAGE_SIZE + 20;
+    int offsetC = 2 * HOST_PAGE_SIZE - 2;
+    int offsetD = 3 * HOST_PAGE_SIZE - dataD.size();
+
+    // Write the data
+    std::memcpy(sharedMem + offsetA, dataA.data(), dataA.size());
+    std::memcpy(sharedMem + offsetB, dataB.data(), dataB.size());
+    std::memcpy(sharedMem + offsetC, dataC.data(), dataC.size());
+    std::memcpy(sharedMem + offsetD, dataD.data(), dataD.size());
+
+    // Write the data to the region that exceeds the size of the original
+    std::vector<uint8_t> dataExtra(
+      (sharedMemPages - snapPages) * HOST_PAGE_SIZE, 5);
+    std::memcpy(sharedMem + snapSize, dataExtra.data(), dataExtra.size());
+
+    // Include an offset which doesn't change the data, but will register a
+    // dirty page
+    std::vector<uint8_t> dataNoChange = { 0, 0, 0 };
+    int offsetNoChange = 4 * HOST_PAGE_SIZE - 10;
+    std::memcpy(
+      sharedMem + offsetNoChange, dataNoChange.data(), dataNoChange.size());
 
     // Check original has no dirty pages
     REQUIRE(snap.getDirtyPages().empty());
 
-    // Check shared memory does have dirty pages
-    std::vector<int> sharedDirtyPages = getDirtyPageNumbers(sharedMem, nPages);
-    std::vector<int> expected = { 2 };
+    // Check shared memory does have dirty pages (including the non-change)
+    std::vector<int> sharedDirtyPages =
+      getDirtyPageNumbers(sharedMem, sharedMemPages);
+    std::vector<int> expected = { 1, 2, 3, 5, 6, 7 };
     REQUIRE(sharedDirtyPages == expected);
+
+    // Check change diffs note that diffs across page boundaries will be split
+    // into two
+    std::vector<SnapshotDiff> changeDiffs =
+      snap.getChangeDiffs(sharedMem, sharedMemSize);
+    REQUIRE(changeDiffs.size() == 6);
+
+    // One chunk will be split over 2 pages
+    std::vector<uint8_t> dataCPart1 = { 7, 6 };
+    std::vector<uint8_t> dataCPart2 = { 5, 4, 3 };
+    int offsetC2 = 2 * HOST_PAGE_SIZE;
+
+    checkSnapshotDiff(offsetA, dataA, changeDiffs.at(0));
+    checkSnapshotDiff(offsetB, dataB, changeDiffs.at(1));
+    checkSnapshotDiff(offsetC, dataCPart1, changeDiffs.at(2));
+    checkSnapshotDiff(offsetC2, dataCPart2, changeDiffs.at(3));
+    checkSnapshotDiff(offsetD, dataD, changeDiffs.at(4));
+    checkSnapshotDiff(snapSize, dataExtra, changeDiffs.at(5));
 }
 }

--- a/tests/test/snapshot/test_snapshot_diffs.cpp
+++ b/tests/test/snapshot/test_snapshot_diffs.cpp
@@ -1,0 +1,37 @@
+#include <catch.hpp>
+
+#include "faabric_utils.h"
+
+#include <faabric/snapshot/SnapshotRegistry.h>
+#include <faabric/util/memory.h>
+
+using namespace faabric::snapshot;
+using namespace faabric::util;
+
+namespace tests {
+
+TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot dirty pages", "[snapshot]")
+{
+    std::string snapKey = "foobar123";
+    int nPages = 5;
+    SnapshotData snap = takeSnapshot(snapKey, nPages, true);
+
+    uint8_t* sharedMem = allocatePages(nPages);
+
+    reg.mapSnapshot(snapKey, sharedMem);
+
+    // Reset dirty tracking
+    faabric::util::resetDirtyTracking();
+
+    // Make a change to the shared memory
+    *(sharedMem + 2 * HOST_PAGE_SIZE) = 2;
+
+    // Check original has no dirty pages
+    REQUIRE(snap.getDirtyPages().empty());
+
+    // Check shared memory does have dirty pages
+    std::vector<int> sharedDirtyPages = getDirtyPageNumbers(sharedMem, nPages);
+    std::vector<int> expected = { 2 };
+    REQUIRE(sharedDirtyPages == expected);
+}
+}

--- a/tests/test/snapshot/test_snapshot_registry.cpp
+++ b/tests/test/snapshot/test_snapshot_registry.cpp
@@ -86,4 +86,11 @@ TEST_CASE_METHOD(SnapshotTestFixture,
     deallocatePages(actualDataB, 2);
     deallocatePages(actualDataC, 3);
 }
+
+TEST_CASE_METHOD(SnapshotTestFixture,
+                 "Test can't get snapshot with empty key",
+                 "[snapshot]")
+{
+    REQUIRE_THROWS(reg.getSnapshot(""));
+}
 }

--- a/tests/test/util/test_memory.cpp
+++ b/tests/test/util/test_memory.cpp
@@ -252,10 +252,9 @@ TEST_CASE("Test dirty page checking", "[util]")
 
     resetDirtyTracking();
 
-    std::vector<bool> allFalse(nPages, false);
-    std::vector<bool> actual =
-      faabric::util::getDirtyPages(sharedMemory, nPages);
-    REQUIRE(actual == allFalse);
+    std::vector<int> actual =
+      faabric::util::getDirtyPageNumbers(sharedMemory, nPages);
+    REQUIRE(actual.empty());
 
     // Dirty two of the pages
     uint8_t* pageZero = sharedMemory;
@@ -265,23 +264,23 @@ TEST_CASE("Test dirty page checking", "[util]")
     pageOne[10] = 1;
     pageThree[123] = 4;
 
-    std::vector<bool> expected = { false, true, false, true, false, false };
-    actual = faabric::util::getDirtyPages(sharedMemory, nPages);
+    std::vector<int> expected = { 1, 3 };
+    actual = faabric::util::getDirtyPageNumbers(sharedMemory, nPages);
     REQUIRE(actual == expected);
 
     // And another
     uint8_t* pageFive = pageThree + (2 * faabric::util::HOST_PAGE_SIZE);
     pageFive[99] = 3;
 
-    expected = { false, true, false, true, false, true };
-    actual = faabric::util::getDirtyPages(sharedMemory, nPages);
+    expected = { 1, 3, 5 };
+    actual = faabric::util::getDirtyPageNumbers(sharedMemory, nPages);
     REQUIRE(actual == expected);
 
     // Reset
     resetDirtyTracking();
 
-    actual = faabric::util::getDirtyPages(sharedMemory, nPages);
-    REQUIRE(actual == allFalse);
+    actual = faabric::util::getDirtyPageNumbers(sharedMemory, nPages);
+    REQUIRE(actual.empty());
 
     // Check the data hasn't changed
     REQUIRE(pageOne[10] == 1);
@@ -293,14 +292,14 @@ TEST_CASE("Test dirty page checking", "[util]")
     pageThree[100] = 2;
     pageFour[22] = 5;
 
-    expected = { false, false, false, true, true, false };
-    actual = faabric::util::getDirtyPages(sharedMemory, nPages);
+    expected = { 3, 4 };
+    actual = faabric::util::getDirtyPageNumbers(sharedMemory, nPages);
     REQUIRE(actual == expected);
 
     // Final reset and check
     resetDirtyTracking();
-    actual = faabric::util::getDirtyPages(sharedMemory, nPages);
-    REQUIRE(actual == allFalse);
+    actual = faabric::util::getDirtyPageNumbers(sharedMemory, nPages);
+    REQUIRE(actual.empty());
 
     munmap(sharedMemory, memSize);
 }


### PR DESCRIPTION
Previously snapshot diffs were only down to a page-level granularity, which meant that distributed threads modifying a shared array would trample on each other (as they would all have their own modified version of the same page).

This PR adds a couple of steps to the existing snapshot diff process:

- Push the snapshot to worker hosts before thread execution
- Map thread memory from the snapshot
- Reset dirty page checks
- Execute the thread
- Get dirty pages
- _Perform a bytewise comparison of the thread's memory with the original snapshot_
- _Push the bytewise diffs back to the original host_ (instead of the page-wise diffs)

Changes:

- Add logic for working out bytewise diffs based on dirty pages
- Encapsulate all the batch-level variables in an executor inside an `ExeutorTask` class (instead of a mix of a `std::pair` and class members on the `Executor`)
- Move logic related to applying diffs into the `SnapshotData` class 
- Share test code via `SnapshotTestFixture`
- Check for zero-size snapshots (previously missing)
