### PR TITLE
Skip executor reset for threads

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -25,15 +25,19 @@ Scheduler& getScheduler();
 class ExecutorTask
 {
   public:
+    ExecutorTask() = default;
+
     ExecutorTask(int messageIndexIn,
                  std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
                  std::shared_ptr<std::atomic<int>> batchCounterIn,
-                 bool needsSnapshotPushIn);
+                 bool needsSnapshotPushIn,
+                 bool skipResetIn);
 
     int messageIndex = 0;
     std::shared_ptr<faabric::BatchExecuteRequest> req;
     std::shared_ptr<std::atomic<int>> batchCounter;
     bool needsSnapshotPush = false;
+    bool skipReset = false;
 };
 
 class Executor

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -8,6 +8,7 @@
 #include <faabric/util/func.h>
 #include <faabric/util/gids.h>
 #include <faabric/util/logging.h>
+#include <faabric/util/macros.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/queue.h>
 #include <faabric/util/timing.h>
@@ -275,7 +276,10 @@ void Executor::threadPoolThread(int threadPoolIdx)
         // Note that we have to release the claim _after_ resetting, otherwise
         // the executor won't be ready for reuse.
         if (isLastInBatch) {
-            if (!task.skipReset) {
+            if (task.skipReset) {
+                SPDLOG_TRACE("Skipping reset for {}",
+                             faabric::util::funcToString(msg, true));
+            } else {
                 reset(msg);
             }
 


### PR DESCRIPTION
Currently the executor will always reset when completing a batch of tasks. This is correct in all but one case, where an executor is executing a batch of child threads spawned from a parent function executed by the _same_ executor. If the executor resets after executing this batch, it nukes the memory of the parent function before it's completed. This will only be the case if executing threads on the master host, so a shortcut is `skipReset = isMaster && isThreads`.