### PR TITLE
Add barrier

### DIFF
--- a/include/faabric/util/barrier.h
+++ b/include/faabric/util/barrier.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+
+namespace faabric::util {
+
+#define DEFAULT_LATCH_TIMEOUT_MS 10000
+
+class Barrier
+{
+  public:
+    // WARNING: this barrier must be shared between threads using a shared
+    // pointer, otherwise there seems to be some nasty race conditions related
+    // to its destruction.
+    static std::shared_ptr<Barrier> create(
+      int count,
+      std::function<void()> completionFunctionIn,
+      int timeoutMs = DEFAULT_LATCH_TIMEOUT_MS);
+
+    static std::shared_ptr<Barrier> create(
+      int count,
+      int timeoutMs = DEFAULT_LATCH_TIMEOUT_MS);
+
+    explicit Barrier(int countIn,
+                     std::function<void()> completionFunctionIn,
+                     int timeoutMsIn);
+
+    void wait();
+
+  private:
+    int count = 0;
+    int visits = 0;
+    int currentPhase = 1;
+
+    std::function<void()> completionFunction;
+
+    int timeoutMs;
+
+    std::mutex mx;
+    std::condition_variable cv;
+};
+}

--- a/include/faabric/util/barrier.h
+++ b/include/faabric/util/barrier.h
@@ -6,7 +6,7 @@
 
 namespace faabric::util {
 
-#define DEFAULT_LATCH_TIMEOUT_MS 10000
+#define DEFAULT_BARRIER_TIMEOUT_MS 10000
 
 class Barrier
 {
@@ -17,11 +17,11 @@ class Barrier
     static std::shared_ptr<Barrier> create(
       int count,
       std::function<void()> completionFunctionIn,
-      int timeoutMs = DEFAULT_LATCH_TIMEOUT_MS);
+      int timeoutMs = DEFAULT_BARRIER_TIMEOUT_MS);
 
     static std::shared_ptr<Barrier> create(
       int count,
-      int timeoutMs = DEFAULT_LATCH_TIMEOUT_MS);
+      int timeoutMs = DEFAULT_BARRIER_TIMEOUT_MS);
 
     explicit Barrier(int countIn,
                      std::function<void()> completionFunctionIn,

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(RapidJSON)
 file(GLOB HEADERS "${FAABRIC_INCLUDE_DIR}/faabric/util/*.h")
 
 set(LIB_FILES
+        barrier.cpp
         bytes.cpp
         config.cpp
         clock.cpp

--- a/src/util/barrier.cpp
+++ b/src/util/barrier.cpp
@@ -1,0 +1,51 @@
+#include <faabric/util/barrier.h>
+#include <faabric/util/locks.h>
+#include <faabric/util/logging.h>
+
+namespace faabric::util {
+
+std::shared_ptr<Barrier> Barrier::create(
+  int count,
+  std::function<void()> completionFunctionIn,
+  int timeoutMs)
+{
+    return std::make_shared<Barrier>(count, completionFunctionIn, timeoutMs);
+}
+
+std::shared_ptr<Barrier> Barrier::create(int count, int timeoutMs)
+{
+    return std::make_shared<Barrier>(
+      count, []() {}, timeoutMs);
+}
+
+Barrier::Barrier(int countIn,
+                 std::function<void()> completionFunctionIn,
+                 int timeoutMsIn)
+  : count(countIn)
+  , completionFunction(completionFunctionIn)
+  , timeoutMs(timeoutMsIn)
+{}
+
+void Barrier::wait()
+{
+    UniqueLock lock(mx);
+
+    visits++;
+    int phaseCompletionVisits = currentPhase * count;
+
+    if (visits == phaseCompletionVisits) {
+        completionFunction();
+        currentPhase++;
+        cv.notify_all();
+    } else {
+        auto timePoint = std::chrono::system_clock::now() +
+                         std::chrono::milliseconds(timeoutMs);
+
+        if (!cv.wait_until(lock, timePoint, [this, phaseCompletionVisits] {
+                return visits >= phaseCompletionVisits;
+            })) {
+            throw std::runtime_error("Barrier timed out");
+        }
+    }
+}
+}

--- a/tests/test/util/test_barrier.cpp
+++ b/tests/test/util/test_barrier.cpp
@@ -1,0 +1,54 @@
+#include <catch.hpp>
+
+#include "faabric_utils.h"
+
+#include <faabric/util/barrier.h>
+#include <faabric/util/bytes.h>
+#include <faabric/util/macros.h>
+
+#include <thread>
+#include <unistd.h>
+
+using namespace faabric::util;
+
+namespace tests {
+TEST_CASE("Test barrier operation", "[util]")
+{
+    int nThreads = 5;
+    int nSums = 1000;
+    std::vector<std::atomic<int>> sums(nSums);
+
+    std::atomic<int> completionCount = 0;
+
+    // Shared barrier between all threads
+    auto b =
+      Barrier::create(nThreads, [&completionCount] { completionCount++; });
+
+    // Have n-1 threads iterating through sums, adding, then waiting on the
+    // barrier
+    std::vector<std::thread> threads;
+    for (int i = 1; i < nThreads; i++) {
+        threads.emplace_back([nSums, &b, &sums]() {
+            for (int s = 0; s < nSums; s++) {
+                sums.at(s).fetch_add(s + 1);
+                b->wait();
+            }
+        });
+    }
+
+    for (int s = 0; s < nSums; s++) {
+        b->wait();
+
+        REQUIRE(sums.at(s) == (nThreads - 1) * (s + 1));
+
+        // Only the latest completion function should have run
+        REQUIRE(completionCount == s + 1);
+    }
+
+    for (auto& t : threads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+}
+}


### PR DESCRIPTION
Although the `Latch` is useful in most situations, we do still need a `Barrier` occasionally.

In both cases, there is a C++20 stdlib replacement, so these will only be necessary until we upgrade.

The ability to pass a completion function included here is to conform to the interface provided by the [stdlib equivalent](https://en.cppreference.com/w/cpp/thread/barrier).