### PR TITLE
Return error on failed endpoint request

### DIFF
--- a/include/faabric/endpoint/Endpoint.h
+++ b/include/faabric/endpoint/Endpoint.h
@@ -13,7 +13,7 @@ class Endpoint
 
     Endpoint(int port, int threadCount);
 
-    void start(bool awaitSignal=true);
+    void start(bool awaitSignal = true);
 
     void stop();
 

--- a/include/faabric/endpoint/Endpoint.h
+++ b/include/faabric/endpoint/Endpoint.h
@@ -15,10 +15,14 @@ class Endpoint
 
     void start();
 
+    void stop();
+
     virtual std::shared_ptr<Pistache::Http::Handler> getHandler() = 0;
 
   private:
     int port = faabric::util::getSystemConfig().endpointPort;
     int threadCount = faabric::util::getSystemConfig().endpointNumThreads;
+
+    Pistache::Http::Endpoint httpEndpoint;
 };
 }

--- a/include/faabric/endpoint/Endpoint.h
+++ b/include/faabric/endpoint/Endpoint.h
@@ -13,7 +13,7 @@ class Endpoint
 
     Endpoint(int port, int threadCount);
 
-    void start();
+    void start(bool awaitSignal=true);
 
     void stop();
 

--- a/include/faabric/endpoint/FaabricEndpointHandler.h
+++ b/include/faabric/endpoint/FaabricEndpointHandler.h
@@ -15,9 +15,9 @@ class FaabricEndpointHandler : public Pistache::Http::Handler
     void onRequest(const Pistache::Http::Request& request,
                    Pistache::Http::ResponseWriter response) override;
 
-    std::string handleFunction(const std::string& requestStr);
+    std::pair<int, std::string> handleFunction(const std::string& requestStr);
 
   private:
-    std::string executeFunction(faabric::Message& msg);
+    std::pair<int, std::string> executeFunction(faabric::Message& msg);
 };
 }

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -123,8 +123,6 @@ class Scheduler
 
     void flushLocally();
 
-    std::string getMessageStatus(unsigned int messageId);
-
     void setFunctionResult(faabric::Message& msg);
 
     faabric::Message getFunctionResult(unsigned int messageId, int timeout);

--- a/src/endpoint/Endpoint.cpp
+++ b/src/endpoint/Endpoint.cpp
@@ -14,16 +14,20 @@ Endpoint::Endpoint(int portIn, int threadCountIn)
 
 void Endpoint::start(bool awaitSignal)
 {
-    SPDLOG_INFO("Starting HTTP endpoint");
+    SPDLOG_INFO("Starting HTTP endpoint on {}", port);
 
     // Set up signal handler
     sigset_t signals;
-    if (sigemptyset(&signals) != 0 || sigaddset(&signals, SIGTERM) != 0 ||
-        sigaddset(&signals, SIGKILL) != 0 || sigaddset(&signals, SIGINT) != 0 ||
-        sigaddset(&signals, SIGHUP) != 0 || sigaddset(&signals, SIGQUIT) != 0 ||
-        pthread_sigmask(SIG_BLOCK, &signals, nullptr) != 0) {
+    if (awaitSignal) {
+        if (sigemptyset(&signals) != 0 || sigaddset(&signals, SIGTERM) != 0 ||
+            sigaddset(&signals, SIGKILL) != 0 ||
+            sigaddset(&signals, SIGINT) != 0 ||
+            sigaddset(&signals, SIGHUP) != 0 ||
+            sigaddset(&signals, SIGQUIT) != 0 ||
+            pthread_sigmask(SIG_BLOCK, &signals, nullptr) != 0) {
 
-        throw std::runtime_error("Install signal handler failed");
+            throw std::runtime_error("Install signal handler failed");
+        }
     }
 
     // Configure endpoint

--- a/src/endpoint/Endpoint.cpp
+++ b/src/endpoint/Endpoint.cpp
@@ -9,6 +9,7 @@ namespace faabric::endpoint {
 Endpoint::Endpoint(int portIn, int threadCountIn)
   : port(portIn)
   , threadCount(threadCountIn)
+  , httpEndpoint(Pistache::Address(Pistache::Ipv4::any(), Pistache::Port(port)))
 {}
 
 void Endpoint::start()
@@ -25,15 +26,12 @@ void Endpoint::start()
         throw std::runtime_error("Install signal handler failed");
     }
 
-    Pistache::Address addr(Pistache::Ipv4::any(), Pistache::Port(this->port));
-
     // Configure endpoint
     auto opts = Pistache::Http::Endpoint::options()
                   .threads(threadCount)
                   .backlog(256)
                   .flags(Pistache::Tcp::Options::ReuseAddr);
 
-    Pistache::Http::Endpoint httpEndpoint(addr);
     httpEndpoint.init(opts);
 
     // Configure and start endpoint
@@ -50,6 +48,12 @@ void Endpoint::start()
         SPDLOG_INFO("Sigwait return value: {}", signal);
     }
 
+    httpEndpoint.shutdown();
+}
+
+void Endpoint::stop()
+{
+    SPDLOG_INFO("Shutting down endpoint on {}", port);
     httpEndpoint.shutdown();
 }
 }

--- a/src/endpoint/Endpoint.cpp
+++ b/src/endpoint/Endpoint.cpp
@@ -12,7 +12,7 @@ Endpoint::Endpoint(int portIn, int threadCountIn)
   , httpEndpoint(Pistache::Address(Pistache::Ipv4::any(), Pistache::Port(port)))
 {}
 
-void Endpoint::start()
+void Endpoint::start(bool awaitSignal)
 {
     SPDLOG_INFO("Starting HTTP endpoint");
 
@@ -38,17 +38,19 @@ void Endpoint::start()
     httpEndpoint.setHandler(this->getHandler());
     httpEndpoint.serveThreaded();
 
-    // Wait for a signal
-    SPDLOG_INFO("Awaiting signal");
-    int signal = 0;
-    int status = sigwait(&signals, &signal);
-    if (status == 0) {
-        SPDLOG_INFO("Received signal: {}", signal);
-    } else {
-        SPDLOG_INFO("Sigwait return value: {}", signal);
-    }
+    if (awaitSignal) {
+        // Wait for a signal
+        SPDLOG_INFO("Awaiting signal");
+        int signal = 0;
+        int status = sigwait(&signals, &signal);
+        if (status == 0) {
+            SPDLOG_INFO("Received signal: {}", signal);
+        } else {
+            SPDLOG_INFO("Sigwait return value: {}", signal);
+        }
 
-    httpEndpoint.shutdown();
+        httpEndpoint.shutdown();
+    }
 }
 
 void Endpoint::stop()

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -55,6 +55,7 @@ std::pair<int, std::string> FaabricEndpointHandler::handleFunction(
 {
     std::pair<int, std::string> response;
     if (requestStr.empty()) {
+        SPDLOG_ERROR("Faabric handler received empty request");
         response = std::make_pair(1, "Empty request");
     } else {
         faabric::Message msg = faabric::util::jsonToMessage(requestStr);
@@ -62,6 +63,7 @@ std::pair<int, std::string> FaabricEndpointHandler::handleFunction(
           faabric::scheduler::getScheduler();
 
         if (msg.isstatusrequest()) {
+            SPDLOG_DEBUG("Processing status request");
             const faabric::Message result =
               sched.getFunctionResult(msg.id(), 0);
 
@@ -73,6 +75,7 @@ std::pair<int, std::string> FaabricEndpointHandler::handleFunction(
                 response = std::make_pair(1, "FAILED: " + result.outputdata());
             }
         } else if (msg.isexecgraphrequest()) {
+            SPDLOG_DEBUG("Processing execution graph request");
             faabric::scheduler::ExecGraph execGraph =
               sched.getFunctionExecGraph(msg.id());
             response =

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -784,19 +784,6 @@ faabric::Message Scheduler::getFunctionResult(unsigned int messageId,
     return msgResult;
 }
 
-std::string Scheduler::getMessageStatus(unsigned int messageId)
-{
-    const faabric::Message result = getFunctionResult(messageId, 0);
-
-    if (result.type() == faabric::Message_MessageType_EMPTY) {
-        return "RUNNING";
-    } else if (result.returnvalue() == 0) {
-        return "SUCCESS: " + result.outputdata();
-    } else {
-        return "FAILED: " + result.outputdata();
-    }
-}
-
 faabric::HostResources Scheduler::getThisHostResources()
 {
     return thisHostResources;

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -14,18 +14,16 @@ namespace tests {
 TEST_CASE_METHOD(SchedulerTestFixture, "Test request to endpoint", "[endpoint]")
 {
     int port = 8081;
-    std::string url = "localhost:8081";
     faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
     std::thread serverThread([&endpoint]() { endpoint.start(false); });
 
     SLEEP_MS(1000);
 
-    endpoint.stop();
+    std::pair<int, std::string> result = submitGetRequestToUrl(LOCALHOST, port);
+    REQUIRE(result.first == 500);
 
-    std::pair<int, std::string> result =
-      getRequestToUrl("localhost", port, "blah");
-    REQUIRE(result.first == 404);
+    endpoint.stop();
 
     if (serverThread.joinable()) {
         serverThread.join();

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -13,12 +13,22 @@ using namespace Pistache;
 namespace tests {
 TEST_CASE_METHOD(SchedulerTestFixture, "Test request to endpoint", "[endpoint]")
 {
-    faabric::endpoint::FaabricEndpoint endpoint;
+    int port = 8081;
+    std::string url = "localhost:8081";
+    faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
-    std::thread serverThread([&endpoint]() { endpoint.start(); });
+    std::thread serverThread([&endpoint]() { endpoint.start(false); });
 
-    SLEEP_MS(5000);
+    SLEEP_MS(1000);
 
     endpoint.stop();
+
+    std::pair<int, std::string> result =
+      getRequestToUrl("localhost", port, "blah");
+    REQUIRE(result.first == 404);
+
+    if (serverThread.joinable()) {
+        serverThread.join();
+    }
 }
 }

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -1,0 +1,24 @@
+#include <catch.hpp>
+
+#include "faabric_utils.h"
+
+#include <faabric/endpoint/FaabricEndpoint.h>
+#include <faabric/endpoint/FaabricEndpointHandler.h>
+#include <faabric/scheduler/Scheduler.h>
+#include <faabric/util/json.h>
+#include <faabric/util/macros.h>
+
+using namespace Pistache;
+
+namespace tests {
+TEST_CASE_METHOD(SchedulerTestFixture, "Test request to endpoint", "[endpoint]")
+{
+    faabric::endpoint::FaabricEndpoint endpoint;
+
+    std::thread serverThread([&endpoint]() { endpoint.start(); });
+
+    SLEEP_MS(5000);
+
+    endpoint.stop();
+}
+}

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -4,24 +4,133 @@
 
 #include <faabric/endpoint/FaabricEndpoint.h>
 #include <faabric/endpoint/FaabricEndpointHandler.h>
+#include <faabric/scheduler/ExecutorFactory.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/json.h>
 #include <faabric/util/macros.h>
 
 using namespace Pistache;
+using namespace faabric::scheduler;
 
 namespace tests {
-TEST_CASE_METHOD(SchedulerTestFixture, "Test request to endpoint", "[endpoint]")
+
+// This is a bit gnarly, we get "Address already in use" errors if we try to use
+// the same port for each case, so we need to switch it every time.
+static int port = 8001;
+
+class EndpointApiTestExecutor final : public Executor
 {
-    int port = 8081;
+  public:
+    EndpointApiTestExecutor(faabric::Message& msg)
+      : Executor(msg)
+    {}
+
+    ~EndpointApiTestExecutor() {}
+
+    int32_t executeTask(
+      int threadPoolIdx,
+      int msgIdx,
+      std::shared_ptr<faabric::BatchExecuteRequest> reqOrig) override
+    {
+        faabric::Message& msg = reqOrig->mutable_messages()->at(msgIdx);
+
+        std::string funcStr = faabric::util::funcToString(msg, true);
+
+        int returnVal = 0;
+        if (msg.function() == "valid") {
+            msg.set_outputdata(
+              fmt::format("Endpoint API test executed {}", msg.id()));
+
+        } else if (msg.function() == "error") {
+            returnVal = 1;
+            msg.set_outputdata(fmt::format(
+              "Endpoint API returning {} for {}", returnVal, msg.id()));
+        } else {
+            throw std::runtime_error("Endpoint API error");
+        }
+
+        return returnVal;
+    }
+};
+
+class EndpointApiTestExecutorFactory : public ExecutorFactory
+{
+  protected:
+    std::shared_ptr<Executor> createExecutor(faabric::Message& msg) override
+    {
+        return std::make_shared<EndpointApiTestExecutor>(msg);
+    }
+};
+
+class EndpointApiTestFixture : public SchedulerTestFixture
+{
+  public:
+    EndpointApiTestFixture()
+    {
+        executorFactory = std::make_shared<EndpointApiTestExecutorFactory>();
+        setExecutorFactory(executorFactory);
+    }
+
+    ~EndpointApiTestFixture() {}
+
+  protected:
+    std::shared_ptr<EndpointApiTestExecutorFactory> executorFactory;
+};
+
+TEST_CASE_METHOD(EndpointApiTestFixture,
+                 "Test requests to endpoint",
+                 "[endpoint]")
+{
+    port++;
+
     faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
     std::thread serverThread([&endpoint]() { endpoint.start(false); });
 
-    SLEEP_MS(1000);
+    // Wait for the server to start
+    SLEEP_MS(2000);
 
-    std::pair<int, std::string> result = submitGetRequestToUrl(LOCALHOST, port);
-    REQUIRE(result.first == 500);
+    std::string body;
+    int expectedReturnCode = 200;
+    std::string expectedResponseBody;
+
+    SECTION("Empty request")
+    {
+        expectedReturnCode = 500;
+        expectedResponseBody = "Empty request";
+    }
+
+    SECTION("Valid request")
+    {
+        faabric::Message msg = faabric::util::messageFactory("foo", "valid");
+        body = faabric::util::messageToJson(msg);
+        expectedReturnCode = 200;
+        expectedResponseBody =
+          fmt::format("Endpoint API test executed {}\n", msg.id());
+    }
+
+    SECTION("Error request")
+    {
+        faabric::Message msg = faabric::util::messageFactory("foo", "error");
+        body = faabric::util::messageToJson(msg);
+        expectedReturnCode = 500;
+        expectedResponseBody =
+          fmt::format("Endpoint API returning 1 for {}\n", msg.id());
+    }
+
+    SECTION("Invalid function")
+    {
+        faabric::Message msg = faabric::util::messageFactory("foo", "junk");
+        body = faabric::util::messageToJson(msg);
+        expectedReturnCode = 500;
+        expectedResponseBody = fmt::format(
+          "Task {} threw exception. What: Endpoint API error\n", msg.id());
+    }
+
+    std::pair<int, std::string> result =
+      submitGetRequestToUrl(LOCALHOST, port, body);
+    REQUIRE(result.first == expectedReturnCode);
+    REQUIRE(result.second == expectedResponseBody);
 
     endpoint.stop();
 

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -16,7 +16,7 @@ namespace tests {
 
 // This is a bit gnarly, we get "Address already in use" errors if we try to use
 // the same port for each case, so we need to switch it every time.
-static int port = 8001;
+static int port = 8080;
 
 class EndpointApiTestExecutor final : public Executor
 {

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIB_FILES
     exec_graph_utils.cpp
     fixtures.h
     message_utils.cpp
+    http_utils.cpp
     system_utils.cpp
     faabric_utils.h
     )

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -71,4 +71,5 @@ void checkExecGraphNodeEquality(const scheduler::ExecGraphNode& nodeA,
 void checkExecGraphEquality(const scheduler::ExecGraph& graphA,
                             const scheduler::ExecGraph& graphB);
 
+std::pair<int, std::string> getRequestToUrl(std::string url);
 }

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -71,6 +71,7 @@ void checkExecGraphNodeEquality(const scheduler::ExecGraphNode& nodeA,
 void checkExecGraphEquality(const scheduler::ExecGraph& graphA,
                             const scheduler::ExecGraph& graphB);
 
-std::pair<int, std::string> submitGetRequestToUrl(std::string host,
-                                            int port);
+std::pair<int, std::string> submitGetRequestToUrl(const std::string& host,
+                                                  int port,
+                                                  const std::string& body);
 }

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -71,5 +71,7 @@ void checkExecGraphNodeEquality(const scheduler::ExecGraphNode& nodeA,
 void checkExecGraphEquality(const scheduler::ExecGraph& graphA,
                             const scheduler::ExecGraph& graphB);
 
-std::pair<int, std::string> getRequestToUrl(std::string url);
+std::pair<int, std::string> getRequestToUrl(std::string host,
+                                            int port,
+                                            std::string url);
 }

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -71,7 +71,6 @@ void checkExecGraphNodeEquality(const scheduler::ExecGraphNode& nodeA,
 void checkExecGraphEquality(const scheduler::ExecGraph& graphA,
                             const scheduler::ExecGraph& graphB);
 
-std::pair<int, std::string> getRequestToUrl(std::string host,
-                                            int port,
-                                            std::string url);
+std::pair<int, std::string> submitGetRequestToUrl(std::string host,
+                                            int port);
 }

--- a/tests/utils/http_utils.cpp
+++ b/tests/utils/http_utils.cpp
@@ -21,8 +21,9 @@ using namespace Pistache;
 
 namespace tests {
 
-std::pair<int, std::string> submitGetRequestToUrl(std::string host,
-                                                  int port)
+std::pair<int, std::string> submitGetRequestToUrl(const std::string& host,
+                                                  int port,
+                                                  const std::string& body)
 
 {
     Http::Client client;
@@ -32,9 +33,12 @@ std::pair<int, std::string> submitGetRequestToUrl(std::string host,
     SPDLOG_DEBUG("Making HTTP GET request to {}", fullUrl);
 
     // Set up the request and callbacks
+    auto requestBuilder = client.get(fullUrl);
+    if (!body.empty()) {
+        requestBuilder.body(body);
+    }
     Async::Promise<Http::Response> resp =
-      client.get(fullUrl)
-        .timeout(std::chrono::milliseconds(HTTP_REQ_TIMEOUT))
+      requestBuilder.timeout(std::chrono::milliseconds(HTTP_REQ_TIMEOUT))
         .send();
 
     std::stringstream out;
@@ -42,10 +46,7 @@ std::pair<int, std::string> submitGetRequestToUrl(std::string host,
     resp.then(
       [&](Http::Response response) {
           respCode = response.code();
-          if (respCode == Http::Code::Ok) {
-              auto body = response.body();
-              out << body;
-          }
+          out << response.body();
       },
       Async::Throw);
 

--- a/tests/utils/http_utils.cpp
+++ b/tests/utils/http_utils.cpp
@@ -18,12 +18,16 @@
 using namespace Pistache;
 
 namespace tests {
-std::pair<int, std::string> getRequestToUrl(std::string url)
+
+std::pair<int, std::string> getRequestToUrl(std::string host,
+                                            int port,
+                                            std::string url)
 {
     Http::Client client;
     client.init();
 
-    auto rb = client.get(url);
+    std::string fullUrl = fmt::format("{}:{}/{}", host, port, url);
+    auto rb = client.get(fullUrl);
 
     // Set up the request and callbacks
     Async::Promise<Http::Response> resp =
@@ -52,4 +56,5 @@ std::pair<int, std::string> getRequestToUrl(std::string url)
     client.shutdown();
 
     return std::make_pair((int)respCode, out.str());
+}
 }

--- a/tests/utils/http_utils.cpp
+++ b/tests/utils/http_utils.cpp
@@ -1,0 +1,55 @@
+#include <faabric/util/bytes.h>
+#include <faabric/util/http.h>
+#include <faabric/util/logging.h>
+
+#include <pistache/async.h>
+#include <pistache/client.h>
+#include <pistache/http.h>
+#include <pistache/http_header.h>
+#include <pistache/net.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using namespace Pistache;
+
+namespace tests {
+std::pair<int, std::string> getRequestToUrl(std::string url)
+{
+    Http::Client client;
+    client.init();
+
+    auto rb = client.get(url);
+
+    // Set up the request and callbacks
+    Async::Promise<Http::Response> resp =
+      rb.timeout(std::chrono::milliseconds(HTTP_FILE_TIMEOUT)).send();
+
+    std::stringstream out;
+    Http::Code respCode;
+    resp.then(
+      [&](Http::Response response) {
+          respCode = response.code();
+          if (respCode == Http::Code::Ok) {
+              auto body = response.body();
+              out << body;
+          }
+      },
+      [&](std::exception_ptr exc) {
+          PrintException excPrinter;
+          excPrinter(exc);
+      });
+
+    // Make calls synchronous
+    Async::Barrier<Http::Response> barrier(resp);
+    std::chrono::milliseconds timeout(HTTP_FILE_TIMEOUT);
+    barrier.wait_for(timeout);
+
+    client.shutdown();
+
+    return std::make_pair((int)respCode, out.str());
+}


### PR DESCRIPTION
Faabric's HTTP endpoint currently returns a `200` response regardless of the result of the function. 

The high-level HTTP API is also missing tests, which I've now added.