### PR TITLE
Snapshot diff merge operations

### DIFF
--- a/include/faabric/util/bytes.h
+++ b/include/faabric/util/bytes.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include <faabric/util/macros.h>
+
 namespace faabric::util {
 std::vector<uint8_t> stringToBytes(const std::string& str);
 
@@ -41,5 +43,11 @@ size_t readBytesOf(const std::vector<uint8_t>& container,
     uint8_t* outStart = reinterpret_cast<uint8_t*>(outValue);
     std::copy_n(container.data() + offset, sizeof(T), outStart);
     return offset + sizeof(T);
+}
+
+template<typename T>
+std::vector<uint8_t> valueToBytes(T val)
+{
+    return std::vector(BYTES(&val), BYTES(&val) + sizeof(T));
 }
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -71,8 +71,6 @@ class SnapshotData
                         SnapshotMergeOperation operation);
 
   private:
-    std::mutex snapMx;
-
     // Note - we care about the order of this map, as we iterate through it in
     // order of offsets
     std::map<uint32_t, SnapshotMergeRegion> mergeRegions;

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -27,8 +27,8 @@ struct SnapshotMergeRegion
 {
     uint32_t offset = 0;
     size_t length = 0;
-    SnapshotDataType dataType;
-    SnapshotMergeOperation operation;
+    SnapshotDataType dataType = SnapshotDataType::Raw;
+    SnapshotMergeOperation operation = SnapshotMergeOperation::Overwrite;
 };
 
 class SnapshotDiff
@@ -37,8 +37,8 @@ class SnapshotDiff
     uint32_t offset = 0;
     size_t size = 0;
     const uint8_t* data = nullptr;
-    SnapshotDataType dataType;
-    SnapshotMergeOperation operation;
+    SnapshotDataType dataType = SnapshotDataType::Raw;
+    SnapshotMergeOperation operation = SnapshotMergeOperation::Overwrite;
 
     SnapshotDiff() = default;
 

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -70,6 +71,8 @@ class SnapshotData
                         SnapshotMergeOperation operation);
 
   private:
+    std::mutex snapMx;
+
     // Note - we care about the order of this map, as we iterate through it in
     // order of offsets
     std::map<uint32_t, SnapshotMergeRegion> mergeRegions;

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -19,6 +20,15 @@ struct SnapshotDiff
     }
 };
 
+class SnapshotDiffMerger
+{
+  public:
+    virtual void applyDiff(size_t diffOffset,
+                           const uint8_t* diffData,
+                           size_t diffLen,
+                           uint8_t* targetBase);
+};
+
 class SnapshotData
 {
   public:
@@ -26,11 +36,20 @@ class SnapshotData
     uint8_t* data = nullptr;
     int fd = 0;
 
+    SnapshotData();
+
     std::vector<SnapshotDiff> getDirtyPages();
 
     std::vector<SnapshotDiff> getChangeDiffs(const uint8_t* updated,
                                              size_t updatedSize);
 
     void applyDiff(size_t diffOffset, const uint8_t* diffData, size_t diffLen);
+
+    std::shared_ptr<SnapshotDiffMerger> getMerger();
+
+    void setMerger(std::shared_ptr<SnapshotDiffMerger> mergerIn);
+
+  private:
+    std::shared_ptr<SnapshotDiffMerger> merger;
 };
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -30,13 +31,16 @@ struct SnapshotMergeRegion
     SnapshotMergeOperation operation;
 };
 
-struct SnapshotDiff
+class SnapshotDiff
 {
+  public:
     uint32_t offset = 0;
     size_t size = 0;
     const uint8_t* data = nullptr;
     SnapshotDataType dataType;
     SnapshotMergeOperation operation;
+
+    SnapshotDiff() = default;
 
     SnapshotDiff(uint32_t offsetIn, const uint8_t* dataIn, size_t sizeIn)
     {
@@ -65,9 +69,9 @@ class SnapshotData
                         SnapshotDataType dataType,
                         SnapshotMergeOperation operation);
 
-    void applyDiff(size_t diffOffset, const uint8_t* diffData, size_t diffLen);
-
   private:
-    std::vector<SnapshotMergeRegion> mergeRegions;
+    // Note - we care about the order of this map, as we iterate through it in
+    // order of offsets
+    std::map<uint32_t, SnapshotMergeRegion> mergeRegions;
 };
 }

--- a/src/flat/faabric.fbs
+++ b/src/flat/faabric.fbs
@@ -7,9 +7,19 @@ table SnapshotDeleteRequest {
   key:string;
 }
 
+enum SnapshotDiffDataType : byte {
+    Raw = 1, Integer
+}
+
+enum SnapshotDiffMergeOp : byte {
+    Overwrite = 1, Sum, Product, Subtract, Max, Min
+}
+
 table SnapshotDiffChunk {
   offset:int;
   data:[ubyte];
+  dataType: SnapshotDiffDataType = Raw;
+  mergeOp: SnapshotDiffMergeOp = Overwrite;
 }
 
 table SnapshotDiffPushRequest {

--- a/src/flat/faabric.fbs
+++ b/src/flat/faabric.fbs
@@ -7,19 +7,11 @@ table SnapshotDeleteRequest {
   key:string;
 }
 
-enum SnapshotDiffDataType : byte {
-    Raw = 1, Integer
-}
-
-enum SnapshotDiffMergeOp : byte {
-    Overwrite = 1, Sum, Product, Subtract, Max, Min
-}
-
 table SnapshotDiffChunk {
   offset:int;
+  dataType:int;
+  mergeOp:int;
   data:[ubyte];
-  dataType: SnapshotDiffDataType = Raw;
-  mergeOp: SnapshotDiffMergeOp = Overwrite;
 }
 
 table SnapshotDiffPushRequest {

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -113,7 +113,9 @@ void SnapshotClient::pushSnapshotDiffs(
         std::vector<flatbuffers::Offset<SnapshotDiffChunk>> diffsFbVector;
         for (const auto& d : diffs) {
             auto dataOffset = mb.CreateVector<uint8_t>(d.data, d.size);
-            auto chunk = CreateSnapshotDiffChunk(mb, d.offset, dataOffset);
+
+            auto chunk = CreateSnapshotDiffChunk(
+              mb, d.offset, d.dataType, d.operation, dataOffset);
             diffsFbVector.push_back(chunk);
         }
 

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -131,6 +131,12 @@ SnapshotServer::recvPushSnapshotDiffs(const uint8_t* buffer, size_t bufferSize)
                         const auto* value =
                           reinterpret_cast<const int32_t*>(r->data()->data());
                         *(reinterpret_cast<int32_t*>(dest)) += *value;
+                        break;
+                    }
+                    default: {
+                        SPDLOG_ERROR("Unsupported sum data type : {}",
+                                     r->dataType());
+                        throw std::runtime_error("Unsupported sum data type");
                     }
                 }
             }

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -175,35 +175,6 @@ SnapshotServer::recvPushSnapshotDiffs(const uint8_t* buffer, size_t bufferSize)
                 throw std::runtime_error("Unsupported merge data type");
             }
         }
-
-        switch (r->mergeOp()) {
-            case (faabric::util::SnapshotMergeOperation::Overwrite): {
-                std::memcpy(dest, r->data()->data(), r->data()->size());
-                break;
-            }
-            case (faabric::util::SnapshotMergeOperation::Sum): {
-                switch (r->dataType()) {
-                    case (faabric::util::SnapshotDataType::Int): {
-                        const auto* value =
-                          reinterpret_cast<const int32_t*>(r->data()->data());
-
-                        // Add the value
-                        *(reinterpret_cast<int32_t*>(dest)) += *value;
-                        break;
-                    }
-                    default: {
-                        SPDLOG_ERROR("Unsupported sum data type : {}",
-                                     r->dataType());
-                        throw std::runtime_error("Unsupported sum data type");
-                    }
-                }
-                break;
-            }
-            default: {
-                SPDLOG_ERROR("Unsupported diff operation: {}", r->mergeOp());
-                throw std::runtime_error("Unsupported diff operation");
-            }
-        }
     }
 
     // Send response

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -135,6 +135,7 @@ SnapshotServer::recvPushSnapshotDiffs(const uint8_t* buffer, size_t bufferSize)
                           "Unsupported raw merge operation");
                     }
                 }
+                break;
             }
             case (faabric::util::SnapshotDataType::Int): {
                 const auto* value =

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -121,6 +121,61 @@ SnapshotServer::recvPushSnapshotDiffs(const uint8_t* buffer, size_t bufferSize)
     // Apply diffs to snapshot
     for (const auto* r : *r->chunks()) {
         uint8_t* dest = snap.data + r->offset();
+        switch (r->dataType()) {
+            case (faabric::util::SnapshotDataType::Raw): {
+                switch (r->mergeOp()) {
+                    case (faabric::util::SnapshotMergeOperation::Overwrite): {
+                        std::memcpy(dest, r->data()->data(), r->data()->size());
+                        break;
+                    }
+                    default: {
+                        SPDLOG_ERROR("Unsupported raw merge operation: {}",
+                                     r->mergeOp());
+                        throw std::runtime_error(
+                          "Unsupported raw merge operation");
+                    }
+                }
+            }
+            case (faabric::util::SnapshotDataType::Int): {
+                const auto* value =
+                  reinterpret_cast<const int32_t*>(r->data()->data());
+                auto* destValue = reinterpret_cast<int32_t*>(dest);
+                switch (r->mergeOp()) {
+                    case (faabric::util::SnapshotMergeOperation::Sum): {
+                        *destValue += *value;
+                        break;
+                    }
+                    case (faabric::util::SnapshotMergeOperation::Subtract): {
+                        *destValue -= *value;
+                        break;
+                    }
+                    case (faabric::util::SnapshotMergeOperation::Product): {
+                        *destValue *= *value;
+                        break;
+                    }
+                    case (faabric::util::SnapshotMergeOperation::Min): {
+                        *destValue = std::min(*destValue, *value);
+                        break;
+                    }
+                    case (faabric::util::SnapshotMergeOperation::Max): {
+                        *destValue = std::max(*destValue, *value);
+                        break;
+                    }
+                    default: {
+                        SPDLOG_ERROR("Unsupported int merge operation: {}",
+                                     r->mergeOp());
+                        throw std::runtime_error(
+                          "Unsupported int merge operation");
+                    }
+                }
+                break;
+            }
+            default: {
+                SPDLOG_ERROR("Unsupported data type: {}", r->dataType());
+                throw std::runtime_error("Unsupported merge data type");
+            }
+        }
+
         switch (r->mergeOp()) {
             case (faabric::util::SnapshotMergeOperation::Overwrite): {
                 std::memcpy(dest, r->data()->data(), r->data()->size());

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -78,7 +78,7 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
             bool isInMergeRegion =
               mergeIt != mergeRegions.end() &&
               offset >= mergeIt->second.offset &&
-              offset <= (mergeIt->second.offset + mergeIt->second.length);
+              offset < (mergeIt->second.offset + mergeIt->second.length);
 
             if (isDirtyByte && isInMergeRegion) {
                 SnapshotMergeRegion region = mergeIt->second;
@@ -152,9 +152,7 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
 
                 // Bump the loop variable to the end of this region (note that
                 // the loop itself will increment onto the next)
-                int nextOffset = region.offset + region.length;
-                int jump = nextOffset - offset;
-                b += jump;
+                b = (region.offset - pageOffset) + (region.length - 1);
 
                 // Move onto the next merge region
                 ++mergeIt;

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -4,6 +4,10 @@
 
 namespace faabric::util {
 
+SnapshotData::SnapshotData()
+  : merger(std::make_shared<SnapshotDiffMerger>())
+{}
+
 std::vector<SnapshotDiff> SnapshotData::getDirtyPages()
 {
     if (data == nullptr || size == 0) {
@@ -81,12 +85,29 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
     return diffs;
 }
 
+void SnapshotDiffMerger::applyDiff(size_t diffOffset,
+                                   const uint8_t* diffData,
+                                   size_t diffLen,
+                                   uint8_t* targetBase)
+{
+    uint8_t* dest = targetBase + diffOffset;
+    std::memcpy(dest, diffData, diffLen);
+};
+
 void SnapshotData::applyDiff(size_t diffOffset,
                              const uint8_t* diffData,
                              size_t diffLen)
 {
-    uint8_t* dest = data + diffOffset;
-    std::memcpy(dest, diffData, diffLen);
+    getMerger()->applyDiff(diffOffset, diffData, diffLen, data);
 }
 
+std::shared_ptr<SnapshotDiffMerger> SnapshotData::getMerger()
+{
+    return merger;
+}
+
+void SnapshotData::setMerger(std::shared_ptr<SnapshotDiffMerger> mergerIn)
+{
+    merger = mergerIn;
+}
 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -5,6 +5,10 @@
 
 namespace faabric::util {
 
+// TODO - this would be better as an instance variable on the SnapshotData
+// class, but it can't be copy-constructed.
+static std::mutex snapMx;
+
 std::vector<SnapshotDiff> SnapshotData::getDirtyPages()
 {
     if (data == nullptr || size == 0) {
@@ -191,7 +195,6 @@ void SnapshotData::addMergeRegion(uint32_t offset,
                                 .length = length,
                                 .dataType = dataType,
                                 .operation = operation };
-
     // Locking as this may be called in bursts by multiple threads
     faabric::util::UniqueLock lock(snapMx);
     mergeRegions[offset] = region;

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -31,18 +31,14 @@ std::vector<SnapshotDiff> SnapshotData::getDirtyPages()
 std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
                                                        size_t updatedSize)
 {
-    // Work out which pages have changed in the comparison
+    // Work out which pages have changed
     size_t nThisPages = getRequiredHostPages(size);
     std::vector<int> dirtyPageNumbers =
       getDirtyPageNumbers(updated, nThisPages);
 
-    // Sort merge regions in ascending offset order
-    std::sort(mergeRegions.begin(),
-              mergeRegions.end(),
-              [](const SnapshotMergeRegion& a, const SnapshotMergeRegion& b) {
-                  return a.offset < b.offset;
-              });
-    std::vector<SnapshotMergeRegion>::iterator mergeIt = mergeRegions.begin();
+    // Get iterator over merge regions
+    std::map<uint32_t, SnapshotMergeRegion>::iterator mergeIt =
+      mergeRegions.begin();
 
     // Get byte-wise diffs _within_ the dirty pages
     //
@@ -74,18 +70,82 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
             bool isDirtyByte = *(data + offset) != *(updated + offset);
 
             if (isDirtyByte && mergeIt != mergeRegions.end() &&
-                offset >= mergeIt->offset &&
-                offset <= (mergeIt->offset + mergeIt->length)) {
+                offset >= mergeIt->second.offset &&
+                offset <= (mergeIt->second.offset + mergeIt->second.length)) {
 
-                // Create a diff for the whole merge region
+                // Set up the diff
+                const uint8_t* updatedData = updated + mergeIt->second.offset;
+                const uint8_t* originalData = data + mergeIt->second.offset;
                 SnapshotDiff diff(
-                  mergeIt->offset, updated + mergeIt->offset, mergeIt->length);
-                diff.dataType = mergeIt->dataType;
-                diff.operation = mergeIt->operation;
+                  mergeIt->second.offset, updatedData, mergeIt->second.length);
+                diff.dataType = mergeIt->second.dataType;
+                diff.operation = mergeIt->second.operation;
+
+                // Modify diff data for certain operations
+                switch (mergeIt->second.dataType) {
+                    case (SnapshotDataType::Int): {
+                        const int* original =
+                          reinterpret_cast<const int*>(originalData);
+                        const int* updated =
+                          reinterpret_cast<const int*>(updatedData);
+
+                        switch (mergeIt->second.operation) {
+                            case (SnapshotMergeOperation::Sum): {
+                                // Sums must send the value to be _added_, and
+                                // not the final result
+                                int change = *updated - *original;
+                                std::memcpy(
+                                  (int*)updated, &change, sizeof(int32_t));
+                                break;
+                            }
+                            case (SnapshotMergeOperation::Subtract): {
+                                // Subtractions must send the value to be
+                                // subtracted, not the result
+                                int change = *original - *updated;
+                                std::memcpy(
+                                  (int*)updated, &change, sizeof(int32_t));
+                                break;
+                            }
+                            case (SnapshotMergeOperation::Product): {
+                                // Products must send the value to be
+                                // multiplied, not the result
+                                int change = *updated / *original;
+                                std::memcpy(
+                                  (int*)updated, &change, sizeof(int32_t));
+                                break;
+                            }
+                            case (SnapshotMergeOperation::Max):
+                            case (SnapshotMergeOperation::Min):
+                                // Min and max don't need to change
+                                break;
+                            default: {
+                                SPDLOG_ERROR(
+                                  "Unhandled integer merge operation: {}",
+                                  mergeIt->second.operation);
+                                throw std::runtime_error(
+                                  "Unhandled integer merge operation");
+                            }
+                        }
+                        break;
+                    }
+                    case (SnapshotDataType::Raw): {
+                        // Do nothing for raw data
+                        break;
+                    }
+                    default: {
+                        SPDLOG_ERROR("Merge region for unhandled data type: {}",
+                                     mergeIt->second.dataType);
+                        throw std::runtime_error(
+                          "Merge region for unhandled data type");
+                    }
+                }
+
+                // Add the diff to the list
                 diffs.emplace_back(diff);
 
                 // Bump the loop variable to the next byte after this region
-                int nextOffset = mergeIt->offset + mergeIt->length + 1;
+                int nextOffset =
+                  mergeIt->second.offset + mergeIt->second.length + 1;
                 int jump = nextOffset - offset;
                 b += jump;
 
@@ -126,19 +186,12 @@ void SnapshotData::addMergeRegion(uint32_t offset,
                                   SnapshotDataType dataType,
                                   SnapshotMergeOperation operation)
 {
+    // TODO - do we need locking here?
     SnapshotMergeRegion region{ .offset = offset,
                                 .length = length,
                                 .dataType = dataType,
                                 .operation = operation };
 
-    mergeRegions.emplace_back(region);
-}
-
-void SnapshotData::applyDiff(size_t diffOffset,
-                             const uint8_t* diffData,
-                             size_t diffLen)
-{
-    uint8_t* dest = data + diffOffset;
-    std::memcpy(dest, diffData, diffLen);
+    mergeRegions[offset] = region;
 }
 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -139,10 +139,6 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
 
                         break;
                     }
-                    case (SnapshotDataType::Raw): {
-                        // Do nothing for raw data
-                        break;
-                    }
                     default: {
                         SPDLOG_ERROR("Merge region for unhandled data type: {}",
                                      region.dataType);

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -1,3 +1,4 @@
+#include <faabric/util/locks.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/snapshot.h>
@@ -186,12 +187,13 @@ void SnapshotData::addMergeRegion(uint32_t offset,
                                   SnapshotDataType dataType,
                                   SnapshotMergeOperation operation)
 {
-    // TODO - do we need locking here?
     SnapshotMergeRegion region{ .offset = offset,
                                 .length = length,
                                 .dataType = dataType,
                                 .operation = operation };
 
+    // Locking as this may be called in bursts by multiple threads
+    faabric::util::UniqueLock lock(snapMx);
     mergeRegions[offset] = region;
 }
 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -154,8 +154,9 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
                 // Add the diff to the list
                 diffs.emplace_back(diff);
 
-                // Bump the loop variable to the next byte after this region
-                int nextOffset = region.offset + region.length + 1;
+                // Bump the loop variable to the end of this region (note that
+                // the loop itself will increment onto the next)
+                int nextOffset = region.offset + region.length;
                 int jump = nextOffset - offset;
                 b += jump;
 

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -3,6 +3,7 @@
 #include "faabric_utils.h"
 #include "fixtures.h"
 
+#include <faabric/util/bytes.h>
 #include <faabric/util/macros.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/snapshot.h>
@@ -145,12 +146,9 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot merge regions", "[util]")
         int finalValue = 150;
         int sumValue = 50;
 
-        originalData = std::vector(BYTES(&originalValue),
-                                   BYTES(&originalValue) + sizeof(int32_t));
-        updatedData =
-          std::vector(BYTES(&finalValue), BYTES(&finalValue) + sizeof(int32_t));
-        expectedData =
-          std::vector(BYTES(&sumValue), BYTES(&sumValue) + sizeof(int32_t));
+        originalData = faabric::util::valueToBytes<int>(originalValue);
+        updatedData = faabric::util::valueToBytes<int>(finalValue);
+        expectedData = faabric::util::valueToBytes<int>(sumValue);
 
         dataType = faabric::util::SnapshotDataType::Int;
         dataLength = sizeof(int32_t);
@@ -192,7 +190,7 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot merge regions", "[util]")
     REQUIRE(diff.size == dataLength);
 
     // Check actual and expected
-    std::vector<uint8_t> actualData(diff.data,diff.data + dataLength);
+    std::vector<uint8_t> actualData(diff.data, diff.data + dataLength);
     REQUIRE(actualData == expectedData);
 }
 }

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -1,0 +1,118 @@
+#include <catch.hpp>
+
+#include "faabric_utils.h"
+#include "fixtures.h"
+
+#include <faabric/util/memory.h>
+#include <faabric/util/snapshot.h>
+
+using namespace faabric::util;
+
+namespace tests {
+
+TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot merge regions", "[util]")
+{
+    std::string snapKey = "foobar123";
+    int snapPages = 5;
+
+    int originalValueA = 100;
+    int finalValueA = 150;
+    int sumValueA = 50;
+
+    int originalValueB = 300;
+    int finalValueB = 425;
+    int sumValueB = 125;
+
+    faabric::util::SnapshotData snap;
+    snap.size = snapPages * faabric::util::HOST_PAGE_SIZE;
+    snap.data = allocatePages(snapPages);
+
+    // Set up some integers in the snapshot
+    int intAOffset = HOST_PAGE_SIZE + (10 * sizeof(int32_t));
+    int intBOffset = (2 * HOST_PAGE_SIZE) + (20 * sizeof(int32_t));
+    int* intAOriginal = (int*)(snap.data + intAOffset);
+    int* intBOriginal = (int*)(snap.data + intBOffset);
+
+    // Set the original values
+    *intAOriginal = originalValueA;
+    *intBOriginal = originalValueB;
+
+    // Take the snapshot
+    reg.takeSnapshot(snapKey, snap, true);
+
+    // Map the snapshot to some memory
+    size_t sharedMemSize = snapPages * HOST_PAGE_SIZE;
+    uint8_t* sharedMem = allocatePages(snapPages);
+
+    reg.mapSnapshot(snapKey, sharedMem);
+
+    // Check mapping works
+    int* intA = (int*)(sharedMem + intAOffset);
+    int* intB = (int*)(sharedMem + intBOffset);
+
+    REQUIRE(*intA == originalValueA);
+    REQUIRE(*intB == originalValueB);
+
+    // Reset dirty tracking to get a clean start
+    faabric::util::resetDirtyTracking();
+
+    // Set up the merge regions
+    snap.addMergeRegion(intAOffset,
+                        sizeof(int),
+                        SnapshotDataType::Int,
+                        SnapshotMergeOperation::Sum);
+
+    snap.addMergeRegion(intBOffset,
+                        sizeof(int),
+                        SnapshotDataType::Int,
+                        SnapshotMergeOperation::Sum);
+
+    // Modify both values and some other data
+    *intA = finalValueA;
+    *intB = finalValueB;
+
+    std::vector<uint8_t> otherData(100, 5);
+    int otherOffset = (3 * HOST_PAGE_SIZE) + 5;
+    std::memcpy(sharedMem + otherOffset, otherData.data(), otherData.size());
+
+    // Get the snapshot diffs
+    std::vector<SnapshotDiff> actualDiffs =
+      snap.getChangeDiffs(sharedMem, sharedMemSize);
+
+    // Check original hasn't changed
+    REQUIRE(*intAOriginal == originalValueA);
+    REQUIRE(*intBOriginal == originalValueB);
+
+    // Check diffs themselves
+    REQUIRE(actualDiffs.size() == 3);
+
+    SnapshotDiff diffA = actualDiffs.at(0);
+    SnapshotDiff diffB = actualDiffs.at(1);
+    SnapshotDiff diffOther = actualDiffs.at(2);
+
+    REQUIRE(diffA.offset == intAOffset);
+    REQUIRE(diffB.offset == intBOffset);
+    REQUIRE(diffOther.offset == otherOffset);
+
+    REQUIRE(diffA.operation == SnapshotMergeOperation::Sum);
+    REQUIRE(diffB.operation == SnapshotMergeOperation::Sum);
+    REQUIRE(diffOther.operation == SnapshotMergeOperation::Overwrite);
+
+    REQUIRE(diffA.dataType == SnapshotDataType::Int);
+    REQUIRE(diffB.dataType == SnapshotDataType::Int);
+    REQUIRE(diffOther.dataType == SnapshotDataType::Raw);
+
+    REQUIRE(diffA.size == sizeof(int32_t));
+    REQUIRE(diffB.size == sizeof(int32_t));
+    REQUIRE(diffOther.size == otherData.size());
+
+    // Check that original values have been subtracted from final values for
+    // sums
+    REQUIRE(*(int*)diffA.data == sumValueA);
+    REQUIRE(*(int*)diffB.data == sumValueB);
+
+    std::vector<uint8_t> actualOtherData(diffOther.data,
+                                         diffOther.data + diffOther.size);
+    REQUIRE(actualOtherData == otherData);
+}
+}

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -56,13 +56,14 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot merge regions", "[util]")
     // Reset dirty tracking to get a clean start
     faabric::util::resetDirtyTracking();
 
-    // Set up the merge regions
-    snap.addMergeRegion(intAOffset,
+    // Set up the merge regions, deliberately do the one at higher offsets first
+    // to check the ordering
+    snap.addMergeRegion(intBOffset,
                         sizeof(int),
                         SnapshotDataType::Int,
                         SnapshotMergeOperation::Sum);
 
-    snap.addMergeRegion(intBOffset,
+    snap.addMergeRegion(intAOffset,
                         sizeof(int),
                         SnapshotDataType::Int,
                         SnapshotMergeOperation::Sum);

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -136,23 +136,69 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot merge regions", "[util]")
     std::vector<uint8_t> updatedData;
     std::vector<uint8_t> expectedData;
 
-    faabric::util::SnapshotDataType dataType;
-    faabric::util::SnapshotMergeOperation operation;
-    size_t dataLength;
+    faabric::util::SnapshotDataType dataType =
+      faabric::util::SnapshotDataType::Raw;
+    faabric::util::SnapshotMergeOperation operation =
+      faabric::util::SnapshotMergeOperation::Overwrite;
+    size_t dataLength = 0;
 
-    SECTION("Integer sum")
+    SECTION("Integer")
     {
-        int originalValue = 100;
-        int finalValue = 150;
-        int sumValue = 50;
-
-        originalData = faabric::util::valueToBytes<int>(originalValue);
-        updatedData = faabric::util::valueToBytes<int>(finalValue);
-        expectedData = faabric::util::valueToBytes<int>(sumValue);
+        int originalValue = 0;
+        int finalValue = 0;
+        int diffValue = 0;
 
         dataType = faabric::util::SnapshotDataType::Int;
         dataLength = sizeof(int32_t);
-        operation = faabric::util::SnapshotMergeOperation::Sum;
+
+        SECTION("Integer sum")
+        {
+            originalValue = 100;
+            finalValue = 150;
+            diffValue = 50;
+
+            operation = faabric::util::SnapshotMergeOperation::Sum;
+        }
+
+        SECTION("Integer subtract")
+        {
+            originalValue = 150;
+            finalValue = 100;
+            diffValue = 50;
+
+            operation = faabric::util::SnapshotMergeOperation::Subtract;
+        }
+
+        SECTION("Integer product")
+        {
+            originalValue = 3;
+            finalValue = 150;
+            diffValue = 50;
+
+            operation = faabric::util::SnapshotMergeOperation::Product;
+        }
+
+        SECTION("Integer max")
+        {
+            originalValue = 10;
+            finalValue = 200;
+            diffValue = 200;
+
+            operation = faabric::util::SnapshotMergeOperation::Max;
+        }
+
+        SECTION("Integer min")
+        {
+            originalValue = 30;
+            finalValue = 10;
+            diffValue = 10;
+
+            operation = faabric::util::SnapshotMergeOperation::Max;
+        }
+
+        originalData = faabric::util::valueToBytes<int>(originalValue);
+        updatedData = faabric::util::valueToBytes<int>(finalValue);
+        expectedData = faabric::util::valueToBytes<int>(diffValue);
     }
 
     // Write the original data into place


### PR DESCRIPTION
The default merge strategy for snapshot diffs is to overwrite the master with the diffs. This works if each distributed function is writing to different offsets (for example, if each function is writing to a different index in an array), but if they are writing to the _same_ offset, the merging will lose information by overwriting each time.

This PR adds merge operations for summation, subtraction, multiplication, min and max, but this list could be extended in future, primarily focused on in-place reductions.

Applications can set these merge operations at byte-level granularity, e.g. specifying that a 4-byte region at offset `X` should be summed as an integer when merging snapshots.

At the moment I've only included integer operations, as these are all that's needed for the current use-case, but again, this could be extended in future.