### PR TITLE
Not use emplace for editing vector elements

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -180,8 +180,6 @@ class MpiWorld
 
     double getWTime();
 
-    // ---------- Testing only methods ----------
-
     std::vector<bool> getInitedRemoteMpiEndpoints();
 
     std::vector<bool> getInitedUMB();

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -180,6 +180,12 @@ class MpiWorld
 
     double getWTime();
 
+    // ---------- Testing only methods ----------
+
+    std::vector<bool> getInitedRemoteMpiEndpoints();
+
+    std::vector<bool> getInitedUMB();
+
   private:
     int id = -1;
     int size = -1;

--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -33,7 +33,7 @@ class MessageEndpoint
     MessageEndpoint(const std::string& hostIn, int portIn, int timeoutMsIn);
 
     // Delete assignment and copy-constructor as we need to be very careful with
-    // socping and same-thread instantiation
+    // scoping and same-thread instantiation
     MessageEndpoint& operator=(const MessageEndpoint&) = delete;
 
     MessageEndpoint(const MessageEndpoint& ctx) = delete;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -110,10 +110,9 @@ void MpiWorld::initRemoteMpiEndpoint(int localRank, int remoteRank)
     std::pair<int, int> sendRecvPorts = getPortForRanks(localRank, remoteRank);
 
     // Create MPI message endpoint
-    mpiMessageEndpoints.emplace(
-      mpiMessageEndpoints.begin() + index,
+    mpiMessageEndpoints.at(index) =
       std::make_unique<faabric::transport::MpiMessageEndpoint>(
-        otherHost, sendRecvPorts.first, sendRecvPorts.second));
+        otherHost, sendRecvPorts.first, sendRecvPorts.second);
 }
 
 void MpiWorld::sendRemoteMpiMessage(
@@ -164,9 +163,8 @@ MpiWorld::getUnackedMessageBuffer(int sendRank, int recvRank)
     assert(index >= 0 && index < size * size);
 
     if (unackedMessageBuffers[index] == nullptr) {
-        unackedMessageBuffers.emplace(
-          unackedMessageBuffers.begin() + index,
-          std::make_shared<faabric::scheduler::MpiMessageBuffer>());
+        unackedMessageBuffers.at(index) =
+          std::make_shared<faabric::scheduler::MpiMessageBuffer>();
     }
 
     return unackedMessageBuffers[index];

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -1377,14 +1377,8 @@ double MpiWorld::getWTime()
     return t / 1000.0;
 }
 
-// This method is only used for testing
 std::vector<bool> MpiWorld::getInitedRemoteMpiEndpoints()
 {
-    if (!faabric::util::isTestMode()) {
-        SPDLOG_ERROR("Called method for testing outside test mode");
-        throw std::runtime_error("This method can only be called in testing");
-    }
-
     std::vector<bool> retVec(mpiMessageEndpoints.size());
     for (int i = 0; i < mpiMessageEndpoints.size(); i++) {
         retVec.at(i) = mpiMessageEndpoints.at(i) != nullptr;
@@ -1393,14 +1387,8 @@ std::vector<bool> MpiWorld::getInitedRemoteMpiEndpoints()
     return retVec;
 }
 
-// This method is only used for testing
 std::vector<bool> MpiWorld::getInitedUMB()
 {
-    if (!faabric::util::isTestMode()) {
-        SPDLOG_ERROR("Called method for testing outside test mode");
-        throw std::runtime_error("This method can only be called in testing");
-    }
-
     std::vector<bool> retVec(unackedMessageBuffers.size());
     for (int i = 0; i < unackedMessageBuffers.size(); i++) {
         retVec.at(i) = unackedMessageBuffers.at(i) != nullptr;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -1377,6 +1377,38 @@ double MpiWorld::getWTime()
     return t / 1000.0;
 }
 
+// This method is only used for testing
+std::vector<bool> MpiWorld::getInitedRemoteMpiEndpoints()
+{
+    if (!faabric::util::isTestMode()) {
+        SPDLOG_ERROR("Called method for testing outside test mode");
+        throw std::runtime_error("This method can only be called in testing");
+    }
+
+    std::vector<bool> retVec(mpiMessageEndpoints.size());
+    for (int i = 0; i < mpiMessageEndpoints.size(); i++) {
+        retVec.at(i) = mpiMessageEndpoints.at(i) != nullptr;
+    }
+
+    return retVec;
+}
+
+// This method is only used for testing
+std::vector<bool> MpiWorld::getInitedUMB()
+{
+    if (!faabric::util::isTestMode()) {
+        SPDLOG_ERROR("Called method for testing outside test mode");
+        throw std::runtime_error("This method can only be called in testing");
+    }
+
+    std::vector<bool> retVec(unackedMessageBuffers.size());
+    for (int i = 0; i < unackedMessageBuffers.size(); i++) {
+        retVec.at(i) = unackedMessageBuffers.at(i) != nullptr;
+    }
+
+    return retVec;
+}
+
 std::string MpiWorld::getUser()
 {
     return user;


### PR DESCRIPTION
Pretty simple, silly, yet nasty bug with the MPI implementation.

In two different `std::vector`s (which we previously filled by `emplace_back`-ing `nullptr`s, we used `emplace(<offset>, <thing to be moved>)` to **modify** the element at offset `<offset>`.

Turns out that this is **not** how `emplace` works. Citing [cppreference](https://en.cppreference.com/w/cpp/container/vector/emplace):
> Inserts a new element into the container directly before pos.

Thus, our vector elements were moved all around the place in a non-deterministic manner. The fact that this worked sometimes is because:
* We lazy-initialise these vectors. If the element is not initialised, we create a new one. Thus, every time we created a new element at the right index, and used it (just once). This only happened a limited number of times.
* Given that the rank distribution we test with is always lower-half host 1, upper-half host 2, and the vectors are sparse by nature, overwrites were occasional.

This would have worsen dramatically with more aggressive testing or different rank-host distributions. I checked, and this does not happen anywhere else in the codebase. 

Should have read the reference better before hand.