### PR TITLE
Compare pointers rather than ids in Scheduler::notifyExecutorShutdown

### DIFF
--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -172,7 +172,7 @@ void Scheduler::notifyExecutorShutdown(Executor* exec,
     int execIdx = -1;
     std::vector<std::shared_ptr<Executor>>& thisExecutors = executors[funcStr];
     for (int i = 0; i < thisExecutors.size(); i++) {
-        if (thisExecutors.at(i)->id == exec->id) {
+        if (thisExecutors.at(i).get() == exec) {
             execIdx = i;
             break;
         }


### PR DESCRIPTION
This fixes a rare "race" condition I encountered when the gid counter overflows due to many messages flowing through the system, and two executors collide with the same id. With this fix the executor IDs are not used for comparing them anymore, just for debug printing where the collisions don't matter for the correctness of the runtime (though the gids should probably be 64-bit integers and include some sort of configurable machine id, it doesn't take that long to overflow 32-bit counters - especially as one gid counter is shared to generate IDs for all kinds of objects, including messages).

The pointers are guaranteed to be the same because they're both generated from the same shared_ptr pointee address, adjusted for the position of the Executor* vtable.