### PR TITLE
Add a crash handler that prints backtraces to FaabricMain users

### DIFF
--- a/include/faabric/runner/FaabricMain.h
+++ b/include/faabric/runner/FaabricMain.h
@@ -26,6 +26,8 @@ class FaabricMain
     void shutdown();
 
   private:
+    void setupCrashHandler();
+
     faabric::state::StateServer stateServer;
     faabric::scheduler::FunctionCallServer functionServer;
     faabric::snapshot::SnapshotServer snapshotServer;

--- a/src/runner/FaabricMain.cpp
+++ b/src/runner/FaabricMain.cpp
@@ -4,6 +4,13 @@
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 
+#include <array>
+#include <execinfo.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
 #if (FAASM_SGX)
 namespace sgx {
 extern void checkSgxSetup();
@@ -18,8 +25,50 @@ FaabricMain::FaabricMain(
     faabric::scheduler::setExecutorFactory(execFactory);
 }
 
+namespace {
+const std::string_view ABORT_MSG = "Caught stack backtrace:\n";
+constexpr int TEST_SIGNAL = 12341234;
+
+// must be async-signal-safe - don't call allocating functions
+void crashHandler(int sig) noexcept
+{
+    std::array<void*, 32> stackPtrs;
+    size_t filledStacks = backtrace(stackPtrs.data(), stackPtrs.size());
+    if (sig != TEST_SIGNAL) {
+        write(STDERR_FILENO, ABORT_MSG.data(), ABORT_MSG.size());
+    }
+    backtrace_symbols_fd(stackPtrs.data(),
+                         std::min(filledStacks, stackPtrs.size()),
+                         STDERR_FILENO);
+    if (sig != TEST_SIGNAL) {
+        signal(sig, SIG_DFL);
+        raise(sig);
+        exit(1);
+    }
+    return;
+}
+}
+
+void FaabricMain::setupCrashHandler()
+{
+    fputs("Testing crash handler backtrace:\n", stderr);
+    fflush(stderr);
+    crashHandler(TEST_SIGNAL);
+    SPDLOG_INFO("Installing crash handler");
+    for (auto signo : { SIGSEGV, SIGABRT, SIGILL, SIGFPE }) {
+        if (signal(signo, &crashHandler) == SIG_ERR) {
+            SPDLOG_WARN("Couldn't install handler for signal {}", signo);
+        } else {
+            SPDLOG_INFO("Installed handler for signal {}", signo);
+        }
+    }
+}
+
 void FaabricMain::startBackground()
 {
+    // Crash handler
+    setupCrashHandler();
+
     // Start basics
     startRunner();
 


### PR DESCRIPTION
On aborts, segfaults, and similar hard faults this patch allows the programs to print a backtrace of where the crash happened before exiting. For the stacktraces to be readable, the corresponding PR in faasm needs to be merged.