### PR TITLE
Add ignored snapshot regions

### DIFF
--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -17,6 +17,7 @@ enum SnapshotDataType
 enum SnapshotMergeOperation
 {
     Overwrite,
+    Ignore,
     Sum,
     Product,
     Subtract,


### PR DESCRIPTION
This lets applications define regions of snapshots that should _not_ be diffed and merged. This is useful for regions of memory that we know hold thread stacks, which may have changed, but don't need to be merged across hosts.