### PR TITLE
Add crash handler to tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ function(faabric_lib lib_name lib_deps)
         target_compile_options(${lib_name} PRIVATE "-fPIC")
         target_compile_options(${lib_name}_obj PRIVATE "-fPIC")
     endif()
+
+    # Ensure library generates readable stack traces
+    target_compile_options(${lib_name} PUBLIC -fno-omit-frame-pointer)
+    target_link_options(${lib_name} PUBLIC -Wl,--export-dynamic)
 endfunction()
 
 add_subdirectory(src/endpoint)

--- a/include/faabric/runner/FaabricMain.h
+++ b/include/faabric/runner/FaabricMain.h
@@ -26,8 +26,6 @@ class FaabricMain
     void shutdown();
 
   private:
-    void setupCrashHandler();
-
     faabric::state::StateServer stateServer;
     faabric::scheduler::FunctionCallServer functionServer;
     faabric::snapshot::SnapshotServer snapshotServer;

--- a/include/faabric/util/crash.h
+++ b/include/faabric/util/crash.h
@@ -1,0 +1,6 @@
+
+namespace faabric::util {
+
+void setUpCrashHandler();
+
+}

--- a/src/runner/FaabricMain.cpp
+++ b/src/runner/FaabricMain.cpp
@@ -2,6 +2,7 @@
 #include <faabric/scheduler/ExecutorFactory.h>
 #include <faabric/scheduler/FunctionCallServer.h>
 #include <faabric/util/config.h>
+#include <faabric/util/crash.h>
 #include <faabric/util/logging.h>
 
 #include <array>
@@ -25,49 +26,10 @@ FaabricMain::FaabricMain(
     faabric::scheduler::setExecutorFactory(execFactory);
 }
 
-namespace {
-const std::string_view ABORT_MSG = "Caught stack backtrace:\n";
-constexpr int TEST_SIGNAL = 12341234;
-
-// must be async-signal-safe - don't call allocating functions
-void crashHandler(int sig) noexcept
-{
-    std::array<void*, 32> stackPtrs;
-    size_t filledStacks = backtrace(stackPtrs.data(), stackPtrs.size());
-    if (sig != TEST_SIGNAL) {
-        write(STDERR_FILENO, ABORT_MSG.data(), ABORT_MSG.size());
-    }
-    backtrace_symbols_fd(stackPtrs.data(),
-                         std::min(filledStacks, stackPtrs.size()),
-                         STDERR_FILENO);
-    if (sig != TEST_SIGNAL) {
-        signal(sig, SIG_DFL);
-        raise(sig);
-        exit(1);
-    }
-    return;
-}
-}
-
-void FaabricMain::setupCrashHandler()
-{
-    fputs("Testing crash handler backtrace:\n", stderr);
-    fflush(stderr);
-    crashHandler(TEST_SIGNAL);
-    SPDLOG_INFO("Installing crash handler");
-    for (auto signo : { SIGSEGV, SIGABRT, SIGILL, SIGFPE }) {
-        if (signal(signo, &crashHandler) == SIG_ERR) {
-            SPDLOG_WARN("Couldn't install handler for signal {}", signo);
-        } else {
-            SPDLOG_INFO("Installed handler for signal {}", signo);
-        }
-    }
-}
-
 void FaabricMain::startBackground()
 {
     // Crash handler
-    setupCrashHandler();
+    faabric::util::setUpCrashHandler();
 
     // Start basics
     startRunner();

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIB_FILES
         bytes.cpp
         config.cpp
         clock.cpp
+        crash.cpp
         delta.cpp
         environment.cpp
         files.cpp

--- a/src/util/crash.cpp
+++ b/src/util/crash.cpp
@@ -1,0 +1,50 @@
+#include <faabric/util/crash.h>
+#include <faabric/util/logging.h>
+
+#include <execinfo.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <unistd.h>
+
+const std::string_view ABORT_MSG = "Caught stack backtrace:\n";
+constexpr int TEST_SIGNAL = 12341234;
+
+// Must be async-signal-safe - don't call allocating functions
+void crashHandler(int sig) noexcept
+{
+    std::array<void*, 32> stackPtrs;
+    size_t filledStacks = backtrace(stackPtrs.data(), stackPtrs.size());
+    if (sig != TEST_SIGNAL) {
+        write(STDERR_FILENO, ABORT_MSG.data(), ABORT_MSG.size());
+    }
+    backtrace_symbols_fd(stackPtrs.data(),
+                         std::min(filledStacks, stackPtrs.size()),
+                         STDERR_FILENO);
+    if (sig != TEST_SIGNAL) {
+        signal(sig, SIG_DFL);
+        raise(sig);
+        exit(1);
+    }
+    return;
+}
+
+namespace faabric::util {
+
+void setUpCrashHandler()
+{
+    fputs("Testing crash handler backtrace:\n", stderr);
+    fflush(stderr);
+    crashHandler(TEST_SIGNAL);
+    SPDLOG_INFO("Installing crash handler");
+    for (auto signo : { SIGSEGV, SIGABRT, SIGILL, SIGFPE }) {
+        if (signal(signo, &crashHandler) == SIG_ERR) {
+            SPDLOG_WARN("Couldn't install handler for signal {}", signo);
+        } else {
+            SPDLOG_INFO("Installed handler for signal {}", signo);
+        }
+    }
+}
+
+}

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -5,6 +5,7 @@
 #include "faabric_utils.h"
 
 #include <faabric/transport/context.h>
+#include <faabric/util/crash.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/testing.h>
 
@@ -12,6 +13,8 @@ FAABRIC_CATCH_LOGGER
 
 int main(int argc, char* argv[])
 {
+    faabric::util::setUpCrashHandler();
+
     faabric::transport::initGlobalMessageContext();
     faabric::util::setTestMode(true);
     faabric::util::initLogging();

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -13,6 +13,9 @@ set(LIB_FILES
 
 add_library(faabric_test_utils "${LIB_FILES}")
 
+target_compile_options(faabric_test_utils PUBLIC -fno-omit-frame-pointer)
+target_link_options(faabric_test_utils PUBLIC -Wl,--export-dynamic)
+
 add_dependencies(faabric_test_utils catch_ext)
 target_include_directories(faabric_test_utils PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 


### PR DESCRIPTION
Adds stack traces to errors in tests (same motivation as https://github.com/faasm/faabric/pull/145).

Moved crash handler to utils to allow sharing.