### PR TITLE
Fix issue with hanging shutdown when not started

### DIFF
--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -86,5 +86,7 @@ class MessageEndpointServer
 
     std::shared_ptr<faabric::util::Latch> requestLatch;
     std::shared_ptr<faabric::util::Latch> shutdownLatch;
+
+    bool started = false;
 };
 }


### PR DESCRIPTION
Previously the message endpoint server would hang if something called `stop`, without calling `start`. 