### PR TITLE
Fixes for MPI message graph

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -184,6 +184,10 @@ class MpiWorld
 
     std::vector<bool> getInitedUMB();
 
+    /* Profiling */
+
+    void setMsgForRank(faabric::Message& msg);
+
   private:
     int id = -1;
     int size = -1;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -300,7 +300,6 @@ void MpiWorld::initialiseFromMsg(faabric::Message& msg)
     user = msg.user();
     function = msg.function();
     size = msg.mpiworldsize();
-    thisRankMsg = &msg;
 
     // Block until we receive
     faabric::MpiHostsToRanksMessage hostRankMsg = recvMpiHostRankMsg();
@@ -322,6 +321,11 @@ void MpiWorld::initialiseFromMsg(faabric::Message& msg)
 
     // Initialise the memory queues for message reception
     initLocalQueues();
+}
+
+void MpiWorld::setMsgForRank(faabric::Message& msg)
+{
+    thisRankMsg = &msg;
 }
 
 std::string MpiWorld::getHostForRank(int rank)

--- a/src/scheduler/MpiWorldRegistry.cpp
+++ b/src/scheduler/MpiWorldRegistry.cpp
@@ -51,7 +51,11 @@ MpiWorld& MpiWorldRegistry::getOrInitialiseWorld(faabric::Message& msg)
 
     {
         faabric::util::SharedLock lock(registryMutex);
-        return worldMap[worldId];
+        MpiWorld& world = worldMap[worldId];
+        if (msg.recordexecgraph()) {
+            world.setMsgForRank(msg);
+        }
+        return world;
     }
 }
 

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -218,9 +218,11 @@ std::string messageToJson(const faabric::Message& msg)
             }
 
             std::string out = ss.str();
-            d.AddMember("int_exec_graph_detail",
-                        Value(out.c_str(), out.size()).Move(),
-                        a);
+
+            // Need to create a value (instead of move) as the string's scope
+            // is smaller than the document's one
+            Value value = Value(out.c_str(), out.size(), a);
+            d.AddMember("int_exec_graph_detail", value, a);
         }
     }
 


### PR DESCRIPTION
In this PR I fix two bugs I encountered while testing the MPI message graph.

First, the way we cached the message that initialised a rank meant that only messages creating a new world (or initialising it in a different host) would get the updated details. Note that the other ranks would inherit a message with the right flags, but would never update it locally. I add a regression test to check that non-master ranks also populate the message details.

Second, I was eventually running into a RapidJSON memory corruption when requesting the result from `redis`. There was a problem with the scope of the variables used, which I also fix.