### PR TITLE
Snapshot diff merging fixes

### DIFF
--- a/include/faabric/util/memory.h
+++ b/include/faabric/util/memory.h
@@ -38,4 +38,7 @@ AlignedChunk getPageAlignedChunk(long offset, long length);
 void resetDirtyTracking();
 
 std::vector<int> getDirtyPageNumbers(const uint8_t* ptr, int nPages);
+
+std::vector<std::pair<uint32_t, uint32_t>> getDirtyRegions(const uint8_t* ptr,
+                                                           int nPages);
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -64,7 +64,8 @@ class SnapshotMergeRegion
 
     void addDiffs(std::vector<SnapshotDiff>& diffs,
                   const uint8_t* original,
-                  const uint8_t* updated);
+                  const uint8_t* updated,
+                  size_t updatedSize);
 };
 
 class SnapshotData

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -65,7 +65,8 @@ class SnapshotMergeRegion
     void addDiffs(std::vector<SnapshotDiff>& diffs,
                   const uint8_t* original,
                   const uint8_t* updated,
-                  size_t updatedSize);
+                  uint32_t dirtyRegionStart,
+                  uint32_t dirtyRegionEnd);
 };
 
 class SnapshotData

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -64,6 +64,7 @@ class SnapshotMergeRegion
 
     void addDiffs(std::vector<SnapshotDiff>& diffs,
                   const uint8_t* original,
+                  uint32_t originalSize,
                   const uint8_t* updated,
                   uint32_t dirtyRegionStart,
                   uint32_t dirtyRegionEnd);

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -216,25 +216,18 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
                 case (SnapshotMergeOperation::Sum): {
                     // Sums must send the value to be _added_, and
                     // not the final result
-                    SPDLOG_TRACE("Sum merge {} -= {}", updatedInt, originalInt);
                     updatedInt -= originalInt;
                     break;
                 }
                 case (SnapshotMergeOperation::Subtract): {
                     // Subtractions must send the value to be
                     // subtracted, not the result
-                    SPDLOG_TRACE("Subtract merge {} = {} - {}",
-                                 updatedInt,
-                                 originalInt,
-                                 updatedInt);
                     updatedInt = originalInt - updatedInt;
                     break;
                 }
                 case (SnapshotMergeOperation::Product): {
                     // Products must send the value to be
                     // multiplied, not the result
-                    SPDLOG_TRACE(
-                      "Product merge {} /= {}", updatedInt, originalInt);
                     updatedInt /= originalInt;
                     break;
                 }

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -60,6 +60,8 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
     std::vector<int> dirtyPageNumbers =
       getDirtyPageNumbers(updated, nThisPages);
 
+    // TODO - flip this, go merge region by merge region
+
     // Iterate through each dirty page, work out if there's an overlapping merge
     // region, tell that region to add their diffs to the list
     std::map<uint32_t, SnapshotMergeRegion>::iterator mergeIt =
@@ -91,8 +93,6 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
 
         // For each merge region that overlaps this dirty page, get it to add
         // its diffs, and move onto the next one
-        // TODO - make this more efficient by passing in dirty pages to merge
-        // regions so that they avoid unnecessary work if they're large.
         while (mergeIt != mergeRegions.end() &&
                (mergeIt->second.offset >= pageStart &&
                 mergeIt->second.offset < pageEnd)) {
@@ -111,7 +111,9 @@ std::vector<SnapshotDiff> SnapshotData::getChangeDiffs(const uint8_t* updated,
                 original = nullptr;
             }
 
-            mergeIt->second.addDiffs(diffs, original, updated);
+            // TODO iterate through just the dirty pages that are relevant for
+            // this diff, get it to add its diffs for each one.
+            mergeIt->second.addDiffs(diffs, original, updated, updatedSize);
             mergeIt++;
         }
     }
@@ -210,7 +212,8 @@ std::string snapshotMergeOpStr(SnapshotMergeOperation op)
 
 void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
                                    const uint8_t* original,
-                                   const uint8_t* updated)
+                                   const uint8_t* updated,
+                                   size_t updatedSize)
 {
     SPDLOG_TRACE("Checking for {} {} merge region at {}-{}",
                  snapshotDataTypeStr(dataType),
@@ -237,34 +240,31 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
                 return;
             }
 
-            // Add the diff
-            diffs.emplace_back(
-              dataType, operation, offset, updatedValue, length);
-
-            SPDLOG_TRACE("Adding {} {} diff at {}-{}",
-                         snapshotDataTypeStr(dataType),
-                         snapshotMergeOpStr(operation),
-                         offset,
-                         offset + length);
-
             // Potentially modify the original in place depending on the
             // operation
             switch (operation) {
                 case (SnapshotMergeOperation::Sum): {
                     // Sums must send the value to be _added_, and
                     // not the final result
+                    SPDLOG_TRACE("Sum merge {} -= {}", updatedInt, originalInt);
                     updatedInt -= originalInt;
                     break;
                 }
                 case (SnapshotMergeOperation::Subtract): {
                     // Subtractions must send the value to be
                     // subtracted, not the result
+                    SPDLOG_TRACE("Subtract merge {} = {} - {}",
+                                 updatedInt,
+                                 originalInt,
+                                 updatedInt);
                     updatedInt = originalInt - updatedInt;
                     break;
                 }
                 case (SnapshotMergeOperation::Product): {
                     // Products must send the value to be
                     // multiplied, not the result
+                    SPDLOG_TRACE(
+                      "Product merge {} /= {}", updatedInt, originalInt);
                     updatedInt /= originalInt;
                     break;
                 }
@@ -285,16 +285,32 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
             std::memcpy(
               (uint8_t*)updatedValue, BYTES(&updatedInt), sizeof(int32_t));
 
+            // Add the diff
+            diffs.emplace_back(
+              dataType, operation, offset, updatedValue, length);
+
+            SPDLOG_TRACE("Adding {} {} diff at {}-{} ({})",
+                         snapshotDataTypeStr(dataType),
+                         snapshotMergeOpStr(operation),
+                         offset,
+                         offset + length,
+                         updatedInt);
+
             break;
         }
         case (SnapshotDataType::Raw): {
             switch (operation) {
                 case (SnapshotMergeOperation::Overwrite): {
+                    size_t overwriteLength = length;
+                    if (length == 0) {
+                        overwriteLength = updatedSize;
+                    }
+
                     // Add subsections of diffs only for the bytes that
                     // have changed
                     bool diffInProgress = false;
                     int diffStart = 0;
-                    for (int b = offset; b <= offset + length; b++) {
+                    for (int b = offset; b <= offset + overwriteLength; b++) {
                         bool isDirtyByte = false;
 
                         if (original == nullptr) {
@@ -303,7 +319,6 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
                             isDirtyByte = *(original + b) != *(updated + b);
                         }
 
-                        SPDLOG_TRACE("BYTE {} dirty {}", b, isDirtyByte);
                         if (isDirtyByte && !diffInProgress) {
                             // Diff starts here if it's different and diff
                             // not in progress
@@ -331,7 +346,8 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
                     // If we've reached the end of this region with a diff
                     // in progress, we need to close it off
                     if (diffInProgress) {
-                        int finalDiffLength = (offset + length) - diffStart + 1;
+                        int finalDiffLength =
+                          (offset + overwriteLength) - diffStart + 1;
                         SPDLOG_TRACE(
                           "Adding {} {} diff at {}-{} (end of region)",
                           snapshotDataTypeStr(dataType),

--- a/tests/test/snapshot/test_snapshot_diffs.cpp
+++ b/tests/test/snapshot/test_snapshot_diffs.cpp
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
     // NOTE - deliberately add merge regions out of order
     // Diff starting in merge region and overlapping the end
     std::vector<uint8_t> dataC = { 7, 6, 5, 4, 3, 2, 1 };
-    std::vector<uint8_t> expectedDataC = { 7, 6, 5, 4, 3 };
+    std::vector<uint8_t> expectedDataC = { 7, 6, 5, 4 };
     int offsetC = 2 * HOST_PAGE_SIZE;
     std::memcpy(sharedMem + offsetC, dataC.data(), dataC.size());
 
@@ -104,7 +104,7 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
 
     // Merge region within a change
     std::vector<uint8_t> dataD = { 1, 1, 2, 2, 3, 3, 4 };
-    std::vector<uint8_t> expectedDataD = { 2, 2, 3, 3 };
+    std::vector<uint8_t> expectedDataD = { 2, 2, 3 };
     int offsetD = 3 * HOST_PAGE_SIZE - dataD.size();
     std::memcpy(sharedMem + offsetD, dataD.data(), dataD.size());
 
@@ -119,7 +119,7 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
     // add a merge region larger than it. Anything outside the original snapshot
     // should be marked as changed.
     std::vector<uint8_t> dataExtra = { 2, 2, 2 };
-    std::vector<uint8_t> expectedDataExtra = { 0, 0, 2, 2, 2, 0, 0, 0 };
+    std::vector<uint8_t> expectedDataExtra = { 0, 0, 2, 2, 2, 0, 0 };
     int extraOffset = snapSize + HOST_PAGE_SIZE + 10;
     std::memcpy(sharedMem + extraOffset, dataExtra.data(), dataExtra.size());
 


### PR DESCRIPTION
These changes were part of the effort to get pthreads working in Faasm again. The original issue was an off-by-one error in the diff detection loop, but to make diagnosis simpler I refactored the diff detection logic. 

Changes:

- Move logic around working out dirty region offsets into new `getDirtyRegions` function. This is preferable to the old `getDirtyPages` which would return a list of page numbers that the diffing function eventually converted into regions. This logic is now isolated and tested separately.
- Refactored diff detection loop to push all remaining logic down into the `MergeRegion` class (now all the grimness is held in once place 😄)
- Allow `Overwrite` merge regions to specify `length=0`, which means they will extend to the end of the memory. This is necessary to merge back changes from memory allocated outside the original snapshot size.