### PR TITLE
Fix race condition in scheduler reset

### DIFF
--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -61,14 +61,15 @@ void Executor::finish()
 
     // Shut down thread pools and wait
     for (int i = 0; i < threadPoolThreads.size(); i++) {
-        if (threadPoolThreads.at(i) == nullptr) {
-            continue;
-        }
-
         // Send a kill message
         SPDLOG_TRACE("Executor {} killing thread pool {}", id, i);
         threadTaskQueues[i].enqueue(
           ExecutorTask(POOL_SHUTDOWN, nullptr, nullptr, false, false));
+
+        // If already killed, move to the next thread
+        if (threadPoolThreads.at(i) == nullptr) {
+            continue;
+        }
 
         // Await the thread
         if (threadPoolThreads.at(i)->joinable()) {

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -334,15 +334,16 @@ TEST_CASE_METHOD(TestExecutorFixture,
                  "Test executing function repeatedly and flushing",
                  "[executor]")
 {
-    std::shared_ptr<BatchExecuteRequest> req =
-      faabric::util::batchExecFactory("dummy", "simple", 1);
-    uint32_t msgId = req->messages().at(0).id();
-    std::vector<std::string> actualHosts;
+    // Set the bound timeout to something short so the test runs fast
+    conf.boundTimeout = 100;
 
     int numRepeats = 20;
     for (int i = 0; i < numRepeats; i++) {
-        std::vector<std::string> actualHosts =
-          executeWithTestExecutor(req, false);
+        std::shared_ptr<BatchExecuteRequest> req =
+          faabric::util::batchExecFactory("dummy", "simple", 1);
+        uint32_t msgId = req->messages().at(0).id();
+
+        executeWithTestExecutor(req, false);
         faabric::Message result =
           sch.getFunctionResult(msgId, SHORT_TEST_TIMEOUT_MS);
         std::string expected =

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -331,6 +331,34 @@ TEST_CASE_METHOD(TestExecutorFixture,
 }
 
 TEST_CASE_METHOD(TestExecutorFixture,
+                 "Test executing function repeatedly and flushing",
+                 "[executor]")
+{
+    std::shared_ptr<BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("dummy", "simple", 1);
+    uint32_t msgId = req->messages().at(0).id();
+    std::vector<std::string> actualHosts;
+
+    int numRepeats = 20;
+    for (int i = 0; i < numRepeats; i++) {
+        std::vector<std::string> actualHosts =
+          executeWithTestExecutor(req, false);
+        faabric::Message result =
+          sch.getFunctionResult(msgId, SHORT_TEST_TIMEOUT_MS);
+        std::string expected =
+          fmt::format("Simple function {} executed", msgId);
+        REQUIRE(result.outputdata() == expected);
+
+        // We sleep for the same timeout threads have, to force a race condition
+        // between the scheduler's flush and the thread's own cleanup timeout
+        SLEEP_MS(conf.boundTimeout);
+
+        // Flush
+        sch.flushLocally();
+    }
+}
+
+TEST_CASE_METHOD(TestExecutorFixture,
                  "Test executing chained functions",
                  "[executor]")
 {


### PR DESCRIPTION
In this PR I fix a race condition when resetting executors that made the flushing tests in faasm segfault sporadically.

The race condition happened between:
* The main thread calling `Scheduler::reset()` then `Executor::finish` and, for each thread in `threadPoolThreads`: (1) check not null, (2) enqueue shutdown task, (3) join.
* The thread pool thread that: (i) times out dequeueing between (1) and (2), (ii) breaks out the main executor loop setting `selfShutdown = true` and assigning itself to `null`; all of this before (3).

The consequence was that we tried to join a `nullptr` in (3) and segfault.

The proposed solution changes the order in the `Executor::finish` loop to: (1) enqueue shutdown task, (2) check if thread is `null`, (3) if not join the thread. This way, when we start killing the thread pool, the thread either: (1) is still blocked dequeuing, thus adding the `POOL_SHUTDOWN` task will have the desired effect when it wakes up, or (2) has already timed-out, and will self-destroy itself, and will be pointing to `null` when we check for it.

I think the chances that the thread _has_ timed out when we enqueue _but_ it is not `null` when we check _and_ is `null` when we join are very remote as there's only one instruction between timing out and setting oneself to null, and I haven't been able to re-create it.

Note that the tasks queues are cleared at the end of `Executor::finish` so it is not really a problem having non-empty queues with `POOL_SHUTDOWN` tasks.

I also include a test that makes the current `master` branch crash with less than 20 tries (less than 10 in fact the 20 times I tried locally), but passes now.