### PR TITLE
Use `NEVER_ALONE` for chained MPI calls

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -208,7 +208,10 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
     std::vector<std::string> executedAt;
     if (size > 1) {
         // Send the init messages (note that message i corresponds to rank i+1)
-        faabric::util::SchedulingDecision decision = sch.callFunctions(req);
+        // By default, we use the NEVER_ALONE policy for MPI executions to
+        // minimise cross-host messaging
+        faabric::util::SchedulingDecision decision = sch.callFunctions(
+          req, faabric::util::SchedulingTopologyHint::NEVER_ALONE);
         executedAt = decision.hosts;
     }
     assert(executedAt.size() == size - 1);

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -202,59 +202,6 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     thisWorld.destroy();
 }
 
-/*
-TEST_CASE_METHOD(RemoteMpiTestFixture, "Test barrier across hosts", "[mpi]")
-{
-    // Register two ranks (one on each host)
-    setWorldSizes(4, 2, 2);
-    int rankA = 0;
-    int rankA2 = 1;
-    int rankB = 2;
-    int rankB2 = 3;
-    std::vector<int> sendData = { 0, 1, 2 };
-    std::vector<int> recvData = { -1, -1, -1 };
-
-    // Init worlds
-    MpiWorld& thisWorld = getMpiWorldRegistry().createWorld(msg, worldId);
-    faabric::util::setMockMode(false);
-
-    thisWorld.broadcastHostsToRanks();
-
-    std::thread otherWorldThread([this, rankA, rankB, rankB2, &sendData,
-&recvData] { otherWorld.initialiseFromMsg(msg);
-
-        otherWorld.send(
-          rankB, rankA, BYTES(sendData.data()), MPI_INT, sendData.size());
-
-        // Barrier on all ranks
-        otherWorld.barrier(rankB);
-        otherWorld.barrier(rankB2);
-        assert(sendData == recvData);
-        otherWorld.destroy();
-    });
-
-    // Receive the message for the given rank
-    thisWorld.recv(rankB,
-                   rankA,
-                   BYTES(recvData.data()),
-                   MPI_INT,
-                   recvData.size(),
-                   MPI_STATUS_IGNORE);
-    REQUIRE(recvData == sendData);
-
-    // Call barrier to synchronise remote host
-    thisWorld.barrier(rankA);
-    thisWorld.barrier(rankA2);
-
-    // Clean up
-    if (otherWorldThread.joinable()) {
-        otherWorldThread.join();
-    }
-
-    thisWorld.destroy();
-}
-*/
-
 TEST_CASE_METHOD(RemoteMpiTestFixture,
                  "Test sending many messages across host",
                  "[mpi]")

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -349,7 +349,6 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
                            BYTES(actual.data()),
                            MPI_INT,
                            nPerRank);
-        // assert(actual == std::vector<int>({ 4, 5, 6, 7 }));
         assert(actual == expected.at(2));
 
         otherWorld.scatter(otherHostRankB,
@@ -360,7 +359,6 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
                            BYTES(actual.data()),
                            MPI_INT,
                            nPerRank);
-        // assert(actual == std::vector<int>({ 12, 13, 14, 15 }));
         assert(actual == expected.at(1));
 
         testLatch->wait();


### PR DESCRIPTION
In this PR I set MPI functions to use the `NEVER_ALONE` scheduling topology hint by default.

Preliminary results show that this policy reduces the number of cross-host messages by 20% on our baseline experiment.

I have to update some tests in the `test_remote_mpi_worlds.cpp` file as they assumed a specific scheduling behaviour.