### PR TITLE
Locality Aware Broadcast

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -20,6 +20,15 @@
 #define MPI_MSGTYPE_COUNT_PREFIX "mpi-msgtype-torank"
 
 namespace faabric::scheduler {
+
+// -----------------------------------
+// Mocking
+// -----------------------------------
+std::vector<faabric::MpiHostsToRanksMessage> getMpiHostsToRanksMessages();
+
+std::vector<std::shared_ptr<faabric::MPIMessage>> getMpiMockedMessages(
+  int sendRank);
+
 typedef faabric::util::Queue<std::shared_ptr<faabric::MPIMessage>>
   InMemoryMpiQueue;
 
@@ -76,7 +85,7 @@ class MpiWorld
               faabric::MPIMessage::MPIMessageType messageType =
                 faabric::MPIMessage::NORMAL);
 
-    void broadcast(int sendRank,
+    void broadcast(int rootRank,
                    int thisRank,
                    uint8_t* buffer,
                    faabric_datatype_t* dataType,

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -24,6 +24,8 @@ namespace faabric::scheduler {
 // -----------------------------------
 // Mocking
 // -----------------------------------
+// MPITOPTP - mocking at the MPI level won't be needed when using the PTP broker
+// as the broker already has mocking capabilities
 std::vector<faabric::MpiHostsToRanksMessage> getMpiHostsToRanksMessages();
 
 std::vector<std::shared_ptr<faabric::MPIMessage>> getMpiMockedMessages(
@@ -226,14 +228,11 @@ class MpiWorld
     int getIndexForRanks(int sendRank, int recvRank);
     std::vector<int> getRanksForHost(const std::string& host);
 
-    // Track ranks that are local to this world, and master ranks
+    // Track ranks that are local to this world, and local/remote leaders
+    int localLeader;
     std::vector<int> localRanks;
-    std::vector<int> getLocalRanks();
-    int localMaster;
-    int getLocalMaster();
-    int getMasterForHost(const std::string& host);
-    std::vector<int> remoteMasters;
-    std::vector<int> getRemoteMasters();
+    std::vector<int> remoteLeaders;
+    void initLocalRemoteLeaders();
 
     // In-memory queues for local messaging
     std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueues;

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -77,7 +77,8 @@ class MpiWorld
                 faabric::MPIMessage::NORMAL);
 
     void broadcast(int sendRank,
-                   const uint8_t* buffer,
+                   int thisRank,
+                   uint8_t* buffer,
                    faabric_datatype_t* dataType,
                    int count,
                    faabric::MPIMessage::MPIMessageType messageType =
@@ -214,6 +215,16 @@ class MpiWorld
     // Track at which host each rank lives
     std::vector<std::string> rankHosts;
     int getIndexForRanks(int sendRank, int recvRank);
+    std::vector<int> getRanksForHost(const std::string& host);
+
+    // Track ranks that are local to this world, and master ranks
+    std::vector<int> localRanks;
+    std::vector<int> getLocalRanks();
+    int localMaster;
+    int getLocalMaster();
+    int getMasterForHost(const std::string& host);
+    std::vector<int> remoteMasters;
+    std::vector<int> getRemoteMasters();
 
     // In-memory queues for local messaging
     std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueues;

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -229,6 +229,7 @@ class MpiWorld
     std::vector<int> getRanksForHost(const std::string& host);
 
     // Track ranks that are local to this world, and local/remote leaders
+    // MPITOPTP - this information exists in the broker
     int localLeader;
     std::vector<int> localRanks;
     std::vector<int> remoteLeaders;

--- a/src/mpi_native/mpi_native.cpp
+++ b/src/mpi_native/mpi_native.cpp
@@ -212,7 +212,7 @@ int MPI_Bcast(void* buffer,
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
 
     int rank = executingContext.getRank();
-    SPDLOG_DEBUG(fmt::format("MPI_Bcast {} -> all", rank));
+    SPDLOG_DEBUG("MPI_Bcast {} -> all", rank);
     world.broadcast(root,
                     rank,
                     (uint8_t*)buffer,

--- a/src/mpi_native/mpi_native.cpp
+++ b/src/mpi_native/mpi_native.cpp
@@ -212,20 +212,14 @@ int MPI_Bcast(void* buffer,
     faabric::scheduler::MpiWorld& world = getExecutingWorld();
 
     int rank = executingContext.getRank();
-    if (rank == root) {
-        SPDLOG_DEBUG(fmt::format("MPI_Bcast {} -> all", rank));
-        world.broadcast(
-          rank, (uint8_t*)buffer, datatype, count, faabric::MPIMessage::NORMAL);
-    } else {
-        SPDLOG_DEBUG(fmt::format("MPI_Bcast {} <- {}", rank, root));
-        world.recv(root,
-                   rank,
-                   (uint8_t*)buffer,
-                   datatype,
-                   count,
-                   nullptr,
-                   faabric::MPIMessage::NORMAL);
-    }
+    SPDLOG_DEBUG(fmt::format("MPI_Bcast {} -> all", rank));
+    world.broadcast(root,
+                    rank,
+                    (uint8_t*)buffer,
+                    datatype,
+                    count,
+                    faabric::MPIMessage::BROADCAST);
+
     return MPI_SUCCESS;
 }
 

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -74,6 +74,7 @@ message MPIMessage {
         ALLREDUCE = 8;
         ALLTOALL = 9;
         SENDRECV = 10;
+        BROADCAST = 11;
     };
 
     MPIMessageType messageType = 1;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -783,13 +783,12 @@ void MpiWorld::broadcast(int sendRank,
               sendRank, remoteRecvRank, buffer, dataType, count, messageType);
         }
     } else if (thisRank == localMaster) {
-        // If we are the local master, but the broadcast originated in this
-        // host, we just receive
+        // If we are the local master, first we receive the message sent by
+        // the originator of the broadcast
         recv(sendRank, thisRank, buffer, dataType, count, nullptr, messageType);
 
-        // If we are the local master, and the broadcast originated in a
-        // remote host, we wait for a message from the root, and distribute
-        // to all our local ranks
+        // If the broadcast originated locally, we are done. If not, we now
+        // distribute to all our local ranks
         if (getHostForRank(sendRank) != thisHost) {
             for (const int localRecvRank : localRanks) {
                 send(thisRank,
@@ -801,9 +800,9 @@ void MpiWorld::broadcast(int sendRank,
             }
         }
     } else {
-        // If we are not a local master, we receive from either our local master
-        // if the broadcast originated in a remote host, or the broadcast
-        // originator itself
+        // If we are neither the originator nor a local master, we receive from
+        // either our local master if the broadcast originated in a remote host,
+        // or the broadcast originator itself if we are on the same host
         int sendingRank =
           getHostForRank(sendRank) == thisHost ? sendRank : localMaster;
 

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -486,8 +486,14 @@ TEST_CASE_METHOD(MpiTestFixture, "Test collective messaging locally", "[mpi]")
     {
         // Broadcast a message from the root
         std::vector<int> messageData = { 0, 1, 2 };
-        world.broadcast(
-          root, BYTES(messageData.data()), MPI_INT, messageData.size());
+
+        // First call from the root, which just sends
+        world.broadcast(root,
+                        root,
+                        BYTES(messageData.data()),
+                        MPI_INT,
+                        messageData.size(),
+                        faabric::MPIMessage::BROADCAST);
 
         // Recv on all non-root ranks
         for (int rank = 0; rank < worldSize; rank++) {
@@ -495,7 +501,12 @@ TEST_CASE_METHOD(MpiTestFixture, "Test collective messaging locally", "[mpi]")
                 continue;
             }
             std::vector<int> actual(3, -1);
-            world.recv(root, rank, BYTES(actual.data()), MPI_INT, 3, nullptr);
+            world.broadcast(root,
+                            rank,
+                            BYTES(actual.data()),
+                            MPI_INT,
+                            3,
+                            faabric::MPIMessage::BROADCAST);
             REQUIRE(actual == messageData);
         }
     }

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -918,4 +918,109 @@ TEST_CASE_METHOD(RemoteMpiTestFixture, "Test UMB creation", "[mpi]")
 
     thisWorld.destroy();
 }
+
+std::set<int> getReceiversFromMessages(
+  std::vector<std::shared_ptr<faabric::MPIMessage>> msgs)
+{
+    std::set<int> retSet;
+    for (const auto& msg : msgs) {
+        retSet.insert(msg->destination());
+    }
+
+    return retSet;
+}
+
+TEST_CASE_METHOD(RemoteMpiTestFixture,
+                 "Test number of messages sent during broadcast",
+                 "[mpi]")
+{
+    // Register three ranks
+    setWorldSizes(4, 2, 2);
+
+    // Init worlds
+    MpiWorld& thisWorld = getMpiWorldRegistry().createWorld(msg, worldId);
+    faabric::util::setMockMode(true);
+    thisWorld.broadcastHostsToRanks();
+    REQUIRE(getMpiHostsToRanksMessages().size() == 1);
+    otherWorld.initialiseFromMsg(msg);
+
+    // Call broadcast and check sent messages
+    std::set<int> expectedRecvRanks;
+    int expectedNumMsg;
+    int sendRank;
+    int rootRank;
+
+    SECTION("Check from root rank (local), and root is local master")
+    {
+        rootRank = 0;
+        sendRank = rootRank;
+        expectedNumMsg = 2;
+        expectedRecvRanks = { 1, 2 };
+    }
+
+    SECTION("Check from root rank (local), and root is non-local master")
+    {
+        rootRank = 1;
+        sendRank = rootRank;
+        expectedNumMsg = 2;
+        expectedRecvRanks = { 0, 2 };
+    }
+
+    SECTION("Check from local non-root rank, and non-root is local master")
+    {
+        rootRank = 1;
+        sendRank = 0;
+        expectedNumMsg = 0;
+        expectedRecvRanks = {};
+    }
+
+    SECTION("Check from local non-root rank, and non-root is non-local-master")
+    {
+        rootRank = 0;
+        sendRank = 1;
+        expectedNumMsg = 0;
+        expectedRecvRanks = {};
+    }
+
+    SECTION("Check from remote rank, and remote rank is local master")
+    {
+        rootRank = 0;
+        sendRank = 2;
+        expectedNumMsg = 1;
+        expectedRecvRanks = { 3 };
+    }
+
+    SECTION("Check from remote rank, and remote rank is not local master")
+    {
+        rootRank = 0;
+        sendRank = 3;
+        expectedNumMsg = 0;
+        expectedRecvRanks = {};
+    }
+
+    // Check for root
+    std::vector<int> messageData = { 0, 1, 2 };
+    if (sendRank < 2) {
+        thisWorld.broadcast(rootRank,
+                            sendRank,
+                            BYTES(messageData.data()),
+                            MPI_INT,
+                            messageData.size(),
+                            faabric::MPIMessage::BROADCAST);
+    } else {
+        otherWorld.broadcast(rootRank,
+                             sendRank,
+                             BYTES(messageData.data()),
+                             MPI_INT,
+                             messageData.size(),
+                             faabric::MPIMessage::BROADCAST);
+    }
+    auto msgs = getMpiMockedMessages(sendRank);
+    REQUIRE(msgs.size() == expectedNumMsg);
+    REQUIRE(getReceiversFromMessages(msgs) == expectedRecvRanks);
+
+    faabric::util::setMockMode(false);
+    otherWorld.destroy();
+    thisWorld.destroy();
+}
 }


### PR DESCRIPTION
In this PR I change the broadcast algorithm in MPI to reduce the number of cross-host messages sent. With the new implementation, the number of cross-host messages grows linearly with the number of hosts, and not with the number of ranks.

In the process I also change some minor issues with the broadcast implementation:
1. The external API was not symmetric to reduce (and to the other collective communication primitves): faabric expected _all_ ranks to call `reduce` but only the root rank to call `broadcast` (all other ranks would call `recv`), see [here](https://github.com/faasm/faasm/blob/d49d9749b7c23919b77d8cabda985c24ea845778/src/wavm/mpi.cpp#L679) for the implementation in faasm. Now all ranks call reduce, and the behaviour depends on the caller's rank.
2. There was no `MPIMessage::BROADCAST` in the protobuf object, so `MPI_Bcast` messages were labeled as `NORMAL` messages.
3. I change the nomenclature in the method to use `rootRank` for the rank which originates the broadcast.

Regarding the algorithm itself, I introduce the notion of `localMaster`s in the MPI world. A local master is a selected leader for all MPI ranks living in a particular host. Then:
* The node performing a broadcast will message (1) all its local ranks, and (2) all the remote masters. 
* A remote master will (1) listen for the message from the root, and (2) message all its local ranks.
* A non-master rank will listen from a message from either (1) the root or (2) its local master, depending on wether the root and itself are colocated or not.

For the moment local masters are the lowest rank in each host. Even though the load in local masters will now slightly increase, we are drastically reducing the load in rank 0 (which was always elected as the master, and therefore was doing a bunch of cross-host messaging). 

To ease with testing I enhance the mocking tools in the MpiWorld.

Also note that this PR is rebased on top of #187 for faster GHA tests, so I'd recommend reviewing #187 first.