### PR TITLE
Re-use conan cache for built dependencies

### DIFF
--- a/.github/workflows/sanitisers.yml
+++ b/.github/workflows/sanitisers.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   conan-cache:
     if: github.event.pull_request.draft == false
@@ -37,12 +41,10 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: Hash ExternalProjects
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
@@ -84,12 +86,10 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: Hash ExternalProjects
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
@@ -136,12 +136,10 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: Hash ExternalProjects
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
@@ -189,12 +187,10 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: Hash ExternalProjects
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
@@ -242,12 +238,10 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: Hash ExternalProjects
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Check C/C++ formatting changes"
         run: git diff --exit-code
 
-  tests:
+  conan-cache:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
@@ -61,6 +61,71 @@ jobs:
       # --- Set-up ---
       - name: "Ping redis"
         run: redis-cli -h redis ping
+      # --- Cache based on Conan version and ExternalProjects cmake source
+      - name: Get Conan version
+        id: get-conan-version
+        run: |
+          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
+        shell: bash
+      - name: Hash ExternalProjects
+        id: hash-external
+        run: |
+          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
+        shell: bash
+      - uses: actions/cache@v2
+        with:
+          path: '~/.conan'
+          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            ${{ runner.os }}-
+      # --- Build dependencies
+      - name: "Build dependencies to be shared by all sanitiser runs"
+        run: inv dev.cmake -b Debug
+
+  tests:
+    if: github.event.pull_request.draft == false
+    needs: [conan-cache]
+    runs-on: ubuntu-latest
+    env:
+      HOST_TYPE: ci
+      REDIS_QUEUE_HOST: redis
+      REDIS_STATE_HOST: redis
+    container:
+      image: faasm/faabric:0.2.2
+    defaults:
+      run:
+        working-directory: /code/faabric
+    services:
+      redis:
+        image: redis
+    steps:
+      # --- Code update ---
+      - name: "Fetch ref"
+        run: git fetch origin ${GITHUB_REF}:ci-branch
+      - name: "Check out branch"
+        run: git checkout --force ci-branch
+      # --- Set-up ---
+      - name: "Ping redis"
+        run: redis-cli -h redis ping
+      # --- Cache based on Conan version and ExternalProjects cmake source
+      - name: Get Conan version
+        id: get-conan-version
+        run: |
+          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
+        shell: bash
+      - name: Hash ExternalProjects
+        id: hash-external
+        run: |
+          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
+        shell: bash
+      - uses: actions/cache@v2
+        with:
+          path: '~/.conan'
+          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            ${{ runner.os }}-
       # --- Tests build - need a debug build for actually running tests ---
       - name: "Run cmake for tests"
         run: inv dev.cmake --build=Debug
@@ -86,6 +151,7 @@ jobs:
 
   examples:
     if: github.event.pull_request.draft == false
+    needs: [conan-cache]
     runs-on: ubuntu-latest
     env:
       HOST_TYPE: ci
@@ -105,6 +171,24 @@ jobs:
         run: git fetch origin ${GITHUB_REF}:ci-branch
       - name: "Check out branch"
         run: git checkout --force ci-branch
+      # --- Cache based on Conan version and ExternalProjects cmake source
+      - name: Get Conan version
+        id: get-conan-version
+        run: |
+          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
+        shell: bash
+      - name: Hash ExternalProjects
+        id: hash-external
+        run: |
+          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
+        shell: bash
+      - uses: actions/cache@v2
+        with:
+          path: '~/.conan'
+          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            ${{ runner.os }}-
       # --- Examples ---
       - name: "Run cmake shared"
         run: inv dev.cmake --shared --build=Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,31 @@ jobs:
       # --- Code update ---
       - name: "Check out code"
         uses: actions/checkout@v2
+        # --- Cache based on Conan version and ExternalProjects cmake source
+      - name: Get Conan version
+        id: get-conan-version
+        run: |
+          docker-compose run --rm cli conan --version 2>/tmp/conan-ver-log | tee /tmp/conan-ver
+          grep 'Conan version' /tmp/conan-ver || exit 1
+          echo "::set-output name=conan-version::$(grep 'Conan version' /tmp/conan-ver | tr -d '[:alpha:] ')"
+        shell: bash
+        env:
+          CONAN_CACHE_MOUNT_SOURCE: ~/.conan/
+      - name: Get Conan Version - Show Log
+        if: always()
+        run: cat /tmp/conan-ver-log
+      - name: Hash ExternalProjects
+        id: hash-external
+        run: |
+          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
+        shell: bash
+      - uses: actions/cache@v2
+        with:
+          path: '~/.conan'
+          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            ${{ runner.os }}-
       # --- Build and test ---
       - name: "Build distributed tests"
         run: ./dist-test/build.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,55 +37,8 @@ jobs:
       - name: "Check C/C++ formatting changes"
         run: git diff --exit-code
 
-  conan-cache:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    env:
-      HOST_TYPE: ci
-      REDIS_QUEUE_HOST: redis
-      REDIS_STATE_HOST: redis
-    container:
-      image: faasm/faabric:0.2.2
-    defaults:
-      run:
-        working-directory: /code/faabric
-    services:
-      redis:
-        image: redis
-    steps:
-      # --- Code update ---
-      - name: "Fetch ref"
-        run: git fetch origin ${GITHUB_REF}:ci-branch
-      - name: "Check out branch"
-        run: git checkout --force ci-branch
-      # --- Set-up ---
-      - name: "Ping redis"
-        run: redis-cli -h redis ping
-      # --- Cache based on Conan version and ExternalProjects cmake source
-      - name: Get Conan version
-        id: get-conan-version
-        run: |
-          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
-      - name: Hash ExternalProjects
-        id: hash-external
-        run: |
-          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
-      - uses: actions/cache@v2
-        with:
-          path: '~/.conan'
-          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
-            ${{ runner.os }}-
-      # --- Build dependencies
-      - name: "Build dependencies to be shared by all sanitiser runs"
-        run: inv dev.cmake -b Debug
-
   tests:
     if: github.event.pull_request.draft == false
-    needs: [conan-cache]
     runs-on: ubuntu-latest
     env:
       HOST_TYPE: ci
@@ -151,7 +104,6 @@ jobs:
 
   examples:
     if: github.event.pull_request.draft == false
-    needs: [conan-cache]
     runs-on: ubuntu-latest
     env:
       HOST_TYPE: ci
@@ -185,8 +137,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
-          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}-release
           restore-keys: |
+            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
             ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
             ${{ runner.os }}-
       # --- Examples ---

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
         shell: bash
-      - name: Hash ExternalProjects
+      - name: "Hash ExternalProjects"
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
@@ -97,19 +97,20 @@ jobs:
       - name: "Check out code"
         uses: actions/checkout@v2
         # --- Cache based on Conan version and ExternalProjects cmake source
-      - name: Get Conan version
+      - name: "Get Conan version"
         id: get-conan-version
         run: |
           docker-compose run --rm cli conan --version 2>/tmp/conan-ver-log | tee /tmp/conan-ver
           grep 'Conan version' /tmp/conan-ver || exit 1
+          sudo chown -R $(id -u):$(id -g) ~/.conan
           echo "::set-output name=conan-version::$(grep 'Conan version' /tmp/conan-ver | tr -d '[:alpha:] ')"
         shell: bash
         env:
           CONAN_CACHE_MOUNT_SOURCE: ~/.conan/
-      - name: Get Conan Version - Show Log
+      - name: "Get Conan Version - Show Log"
         if: always()
         run: cat /tmp/conan-ver-log
-      - name: Hash ExternalProjects
+      - name: "Hash ExternalProjects"
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
@@ -149,12 +150,12 @@ jobs:
       - name: "Check out branch"
         run: git checkout --force ci-branch
       # --- Cache based on Conan version and ExternalProjects cmake source
-      - name: Get Conan version
+      - name: "Get Conan version"
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
         shell: bash
-      - name: Hash ExternalProjects
+      - name: "Hash ExternalProjects"
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   formatting:
     if: github.event.pull_request.draft == false
@@ -66,12 +70,10 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: "Hash ExternalProjects"
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
@@ -104,7 +106,6 @@ jobs:
           grep 'Conan version' /tmp/conan-ver || exit 1
           sudo chown -R $(id -u):$(id -g) ~/.conan
           echo "::set-output name=conan-version::$(grep 'Conan version' /tmp/conan-ver | tr -d '[:alpha:] ')"
-        shell: bash
         env:
           CONAN_CACHE_MOUNT_SOURCE: ~/.conan/
       - name: "Get Conan Version - Show Log"
@@ -114,7 +115,6 @@ jobs:
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
@@ -154,20 +154,18 @@ jobs:
         id: get-conan-version
         run: |
           echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
-        shell: bash
       - name: "Hash ExternalProjects"
         id: hash-external
         run: |
           echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
-        shell: bash
       - uses: actions/cache@v2
         with:
           path: '~/.conan'
-          key: ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}-release
+          key: release-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
           restore-keys: |
-            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
-            ${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
-            ${{ runner.os }}-
+            release-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+            release-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            release-${{ runner.os }}-
       # --- Examples ---
       - name: "Run cmake shared"
         run: inv dev.cmake --shared --build=Release

--- a/dist-test/build.sh
+++ b/dist-test/build.sh
@@ -5,6 +5,10 @@ set -e
 export PROJ_ROOT=$(dirname $(dirname $(readlink -f $0)))
 pushd ${PROJ_ROOT} >> /dev/null
 
+export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
+# Ensure the cache directory exists before starting the containers
+mkdir -p ${CONAN_CACHE_MOUNT_SOURCE}
+
 # Run the build
 docker-compose \
     run \

--- a/dist-test/run.sh
+++ b/dist-test/run.sh
@@ -3,6 +3,7 @@
 export PROJ_ROOT=$(dirname $(dirname $(readlink -f $0)))
 pushd ${PROJ_ROOT} >> /dev/null
 
+export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
 RETURN_VAL=0
 
 # Run the test server in the background

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /usr/bin/docker:/usr/bin/docker
       - ./:/code/faabric
       - ./build:/build/faabric
-      - ./conan-cache/:/root/.conan
+      - ${CONAN_CACHE_MOUNT_SOURCE:-./conan-cache/}:/root/.conan
     working_dir: /code/faabric
     stdin_open: true
     tty: true

--- a/thread-sanitizer-ignorelist.txt
+++ b/thread-sanitizer-ignorelist.txt
@@ -11,3 +11,6 @@ signal:*
 
 # TODO: Remove: There's something weird going on with MPI code I don't understand
 race:faabric::scheduler::MpiWorld::*
+
+# Known Bug num. 1 in #189
+race:faabric::transport::PointToPointGroup::*


### PR DESCRIPTION
I cherry pick this change from #182, and faasm/faasm#542.

Upon cache hit the tests workflow file runs in under 7'.