### PR TITLE
Enable/disable scheduling topology hints through an env. variable

### DIFF
--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -28,7 +28,7 @@ class SystemConfig
     // Scheduling
     int noScheduler;
     int overrideCpuCount;
-    std::string useTopologyHints;
+    std::string noTopologyHints;
 
     // Worker-related timeouts
     int globalMessageTimeout;

--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -28,6 +28,7 @@ class SystemConfig
     // Scheduling
     int noScheduler;
     int overrideCpuCount;
+    std::string useTopologyHints;
 
     // Worker-related timeouts
     int globalMessageTimeout;

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -284,7 +284,10 @@ faabric::util::SchedulingDecision Scheduler::makeSchedulingDecision(
     std::string funcStr = faabric::util::funcToString(firstMsg, false);
 
     // If topology hints are disabled, unset the provided topology hint
-    if (conf.useTopologyHints == "off") {
+    if (conf.noTopologyHints == "on" &&
+        topologyHint != faabric::util::SchedulingTopologyHint::NORMAL) {
+        SPDLOG_WARN("Ignoring topology hint passed to scheduler as hints are "
+                    "disabled in the config");
         topologyHint = faabric::util::SchedulingTopologyHint::NORMAL;
     }
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -283,6 +283,11 @@ faabric::util::SchedulingDecision Scheduler::makeSchedulingDecision(
     faabric::Message& firstMsg = req->mutable_messages()->at(0);
     std::string funcStr = faabric::util::funcToString(firstMsg, false);
 
+    // If topology hints are disabled, unset the provided topology hint
+    if (conf.useTopologyHints == "off") {
+        topologyHint = faabric::util::SchedulingTopologyHint::NORMAL;
+    }
+
     std::vector<std::string> hosts;
     if (topologyHint == faabric::util::SchedulingTopologyHint::FORCE_LOCAL) {
         // We're forced to execute locally here so we do all the messages

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -34,6 +34,7 @@ void SystemConfig::initialise()
     // Scheduling
     noScheduler = this->getSystemConfIntParam("NO_SCHEDULER", "0");
     overrideCpuCount = this->getSystemConfIntParam("OVERRIDE_CPU_COUNT", "0");
+    useTopologyHints = getEnvVar("USE_TOPOLOGY_HINTS", "off");
 
     // Worker-related timeouts (all in seconds)
     globalMessageTimeout =
@@ -100,6 +101,7 @@ void SystemConfig::print()
     SPDLOG_INFO("--- Scheduling ---");
     SPDLOG_INFO("NO_SCHEDULER               {}", noScheduler);
     SPDLOG_INFO("OVERRIDE_CPU_COUNT         {}", overrideCpuCount);
+    SPDLOG_INFO("USE_TOPOLOGY_HINTS         {}", useTopologyHints);
 
     SPDLOG_INFO("--- Timeouts ---");
     SPDLOG_INFO("GLOBAL_MESSAGE_TIMEOUT     {}", globalMessageTimeout);

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -34,7 +34,7 @@ void SystemConfig::initialise()
     // Scheduling
     noScheduler = this->getSystemConfIntParam("NO_SCHEDULER", "0");
     overrideCpuCount = this->getSystemConfIntParam("OVERRIDE_CPU_COUNT", "0");
-    useTopologyHints = getEnvVar("USE_TOPOLOGY_HINTS", "off");
+    useTopologyHints = getEnvVar("USE_TOPOLOGY_HINTS", "on");
 
     // Worker-related timeouts (all in seconds)
     globalMessageTimeout =

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -34,7 +34,7 @@ void SystemConfig::initialise()
     // Scheduling
     noScheduler = this->getSystemConfIntParam("NO_SCHEDULER", "0");
     overrideCpuCount = this->getSystemConfIntParam("OVERRIDE_CPU_COUNT", "0");
-    useTopologyHints = getEnvVar("USE_TOPOLOGY_HINTS", "on");
+    noTopologyHints = getEnvVar("NO_TOPOLOGY_HINTS", "off");
 
     // Worker-related timeouts (all in seconds)
     globalMessageTimeout =
@@ -101,7 +101,7 @@ void SystemConfig::print()
     SPDLOG_INFO("--- Scheduling ---");
     SPDLOG_INFO("NO_SCHEDULER               {}", noScheduler);
     SPDLOG_INFO("OVERRIDE_CPU_COUNT         {}", overrideCpuCount);
-    SPDLOG_INFO("USE_TOPOLOGY_HINTS         {}", useTopologyHints);
+    SPDLOG_INFO("NO_TOPOLOGY_HINTS         {}", noTopologyHints);
 
     SPDLOG_INFO("--- Timeouts ---");
     SPDLOG_INFO("GLOBAL_MESSAGE_TIMEOUT     {}", globalMessageTimeout);

--- a/tests/test/scheduler/test_scheduling_decisions.cpp
+++ b/tests/test/scheduler/test_scheduling_decisions.cpp
@@ -187,6 +187,37 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 }
 
 TEST_CASE_METHOD(SchedulingDecisionTestFixture,
+                 "Test scheduling hints can be disabled through the config",
+                 "[scheduler]")
+{
+    SchedulingConfig config = {
+        .hosts = { masterHost, "hostA" },
+        .slots = { 1, 1 },
+        .numReqs = 2,
+        .topologyHint = faabric::util::SchedulingTopologyHint::FORCE_LOCAL,
+        .expectedHosts = { masterHost, "hostA" },
+    };
+
+    auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
+    auto& faabricConf = faabric::util::getSystemConfig();
+
+    SECTION("Config. variable set")
+    {
+        faabricConf.noTopologyHints = "on";
+        config.expectedHosts = { masterHost, "hostA" };
+    }
+
+    SECTION("Config. variable not set")
+    {
+        config.expectedHosts = { masterHost, masterHost };
+    }
+
+    testActualSchedulingDecision(req, config);
+
+    faabricConf.reset();
+}
+
+TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "Test master running out of resources",
                  "[scheduler]")
 {

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Test default system config initialisation", "[util]")
 
     REQUIRE(conf.noScheduler == 0);
     REQUIRE(conf.overrideCpuCount == 0);
-    REQUIRE(conf.useTopologyHints == "off");
+    REQUIRE(conf.useTopologyHints == "on");
 
     REQUIRE(conf.globalMessageTimeout == 60000);
     REQUIRE(conf.boundTimeout == 30000);
@@ -45,7 +45,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     std::string noScheduler = setEnvVar("NO_SCHEDULER", "1");
     std::string overrideCpuCount = setEnvVar("OVERRIDE_CPU_COUNT", "4");
-    std::string useTopologyHints = setEnvVar("USE_TOPOLOGY_HINTS", "on");
+    std::string useTopologyHints = setEnvVar("USE_TOPOLOGY_HINTS", "off");
 
     std::string globalTimeout = setEnvVar("GLOBAL_MESSAGE_TIMEOUT", "9876");
     std::string boundTimeout = setEnvVar("BOUND_TIMEOUT", "6666");
@@ -72,7 +72,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     REQUIRE(conf.noScheduler == 1);
     REQUIRE(conf.overrideCpuCount == 4);
-    REQUIRE(conf.useTopologyHints == "on");
+    REQUIRE(conf.useTopologyHints == "off");
 
     REQUIRE(conf.globalMessageTimeout == 9876);
     REQUIRE(conf.boundTimeout == 6666);

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -22,6 +22,7 @@ TEST_CASE("Test default system config initialisation", "[util]")
 
     REQUIRE(conf.noScheduler == 0);
     REQUIRE(conf.overrideCpuCount == 0);
+    REQUIRE(conf.useTopologyHints == "off");
 
     REQUIRE(conf.globalMessageTimeout == 60000);
     REQUIRE(conf.boundTimeout == 30000);
@@ -44,6 +45,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     std::string noScheduler = setEnvVar("NO_SCHEDULER", "1");
     std::string overrideCpuCount = setEnvVar("OVERRIDE_CPU_COUNT", "4");
+    std::string useTopologyHints = setEnvVar("USE_TOPOLOGY_HINTS", "on");
 
     std::string globalTimeout = setEnvVar("GLOBAL_MESSAGE_TIMEOUT", "9876");
     std::string boundTimeout = setEnvVar("BOUND_TIMEOUT", "6666");
@@ -70,6 +72,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     REQUIRE(conf.noScheduler == 1);
     REQUIRE(conf.overrideCpuCount == 4);
+    REQUIRE(conf.useTopologyHints == "on");
 
     REQUIRE(conf.globalMessageTimeout == 9876);
     REQUIRE(conf.boundTimeout == 6666);
@@ -95,6 +98,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     setEnvVar("NO_SCHEDULER", noScheduler);
     setEnvVar("OVERRIDE_CPU_COUNT", overrideCpuCount);
+    setEnvVar("USE_TOPOLOGY_HINTS", useTopologyHints);
 
     setEnvVar("GLOBAL_MESSAGE_TIMEOUT", globalTimeout);
     setEnvVar("BOUND_TIMEOUT", boundTimeout);

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Test default system config initialisation", "[util]")
 
     REQUIRE(conf.noScheduler == 0);
     REQUIRE(conf.overrideCpuCount == 0);
-    REQUIRE(conf.useTopologyHints == "on");
+    REQUIRE(conf.noTopologyHints == "off");
 
     REQUIRE(conf.globalMessageTimeout == 60000);
     REQUIRE(conf.boundTimeout == 30000);
@@ -45,7 +45,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     std::string noScheduler = setEnvVar("NO_SCHEDULER", "1");
     std::string overrideCpuCount = setEnvVar("OVERRIDE_CPU_COUNT", "4");
-    std::string useTopologyHints = setEnvVar("USE_TOPOLOGY_HINTS", "off");
+    std::string noTopologyHints = setEnvVar("NO_TOPOLOGY_HINTS", "on");
 
     std::string globalTimeout = setEnvVar("GLOBAL_MESSAGE_TIMEOUT", "9876");
     std::string boundTimeout = setEnvVar("BOUND_TIMEOUT", "6666");
@@ -72,7 +72,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     REQUIRE(conf.noScheduler == 1);
     REQUIRE(conf.overrideCpuCount == 4);
-    REQUIRE(conf.useTopologyHints == "off");
+    REQUIRE(conf.noTopologyHints == "on");
 
     REQUIRE(conf.globalMessageTimeout == 9876);
     REQUIRE(conf.boundTimeout == 6666);
@@ -98,7 +98,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
 
     setEnvVar("NO_SCHEDULER", noScheduler);
     setEnvVar("OVERRIDE_CPU_COUNT", overrideCpuCount);
-    setEnvVar("USE_TOPOLOGY_HINTS", useTopologyHints);
+    setEnvVar("USE_TOPOLOGY_HINTS", noTopologyHints);
 
     setEnvVar("GLOBAL_MESSAGE_TIMEOUT", globalTimeout);
     setEnvVar("BOUND_TIMEOUT", boundTimeout);


### PR DESCRIPTION
With this PR scheduling topology hints may be disabled by setting the environment variable: `NO_TOPOLOGY_HINTS=on` in faam's worker.