### PR TITLE
Locality Aware Reduce

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -151,8 +151,8 @@ class MpiWorld
                    faabric_datatype_t* recvType,
                    int recvCount);
 
-    void reduce(int sendRank,
-                int recvRank,
+    void reduce(int thisRank,
+                int rootRank,
                 uint8_t* sendBuffer,
                 uint8_t* recvBuffer,
                 faabric_datatype_t* datatype,

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -151,8 +151,8 @@ class MpiWorld
                    faabric_datatype_t* recvType,
                    int recvCount);
 
-    void reduce(int thisRank,
-                int rootRank,
+    void reduce(int sendRank,
+                int recvRank,
                 uint8_t* sendBuffer,
                 uint8_t* recvBuffer,
                 faabric_datatype_t* datatype,

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -1120,8 +1120,11 @@ void MpiWorld::reduce(int thisRank,
                      nullptr,
                      faabric::MPIMessage::REDUCE);
 
+                // Note that we accumulate the reuce operation on the send
+                // buffer, not the receive one, as we later need to send all
+                // the reduced data (including ours) to the root rank
                 op_reduce(
-                  operation, datatype, count, rankData.get(), recvBuffer);
+                  operation, datatype, count, rankData.get(), sendBuffer);
             }
         }
 

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -332,34 +332,33 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
     MpiWorld& thisWorld = setUpThisWorld();
 
     std::vector<int> messageData = { 0, 1, 2 };
-    int rootRank = 0;
+    int recvRank = 0;
 
-    std::thread otherWorldThread([this, rootRank, &messageData] {
+    std::thread otherWorldThread([this, recvRank, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
-        // Call reduce from two non-local-master ranks (they just send)
+        // Call reduce from two non-local-leader ranks (they just send)
         otherWorld.reduce(4,
-                          rootRank,
+                          recvRank,
                           BYTES(messageData.data()),
                           nullptr,
                           MPI_INT,
                           messageData.size(),
                           MPI_SUM);
 
-        // Call reduce from two non-local-master ranks (they just send)
         otherWorld.reduce(5,
-                          rootRank,
+                          recvRank,
                           BYTES(messageData.data()),
                           nullptr,
                           MPI_INT,
                           messageData.size(),
                           MPI_SUM);
 
-        // Call reduce from the remote, local-master rank (it receives the two
-        // previous broadcasts and sends to root)
-        // Note that it must be fine to provide a null-pointing recvBuffer
+        // Call reduce from the remote, local-leader rank (it receives the two
+        // previous broadcasts and sends to receiver)
+        // Note that we must support providing a null-pointing recvBuffer
         otherWorld.reduce(3,
-                          rootRank,
+                          recvRank,
                           BYTES(messageData.data()),
                           nullptr,
                           MPI_INT,
@@ -371,9 +370,9 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
         otherWorld.destroy();
     });
 
-    // First, reduce from the two non-root local ranks (they just send)
+    // First, reduce from the local ranks that don't receive the reduce
     thisWorld.reduce(1,
-                     rootRank,
+                     recvRank,
                      BYTES(messageData.data()),
                      nullptr,
                      MPI_INT,
@@ -381,17 +380,17 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
                      MPI_SUM);
 
     thisWorld.reduce(2,
-                     rootRank,
+                     recvRank,
                      BYTES(messageData.data()),
                      nullptr,
                      MPI_INT,
                      messageData.size(),
                      MPI_SUM);
 
-    // Lastly, we reduce from the root rank
+    // Lastly, we call reduce from the rank receiving the reduction
     std::vector<int> actual(messageData.size(), -1);
-    thisWorld.reduce(rootRank,
-                     rootRank,
+    thisWorld.reduce(recvRank,
+                     recvRank,
                      BYTES(messageData.data()),
                      BYTES(actual.data()),
                      MPI_INT,
@@ -1118,7 +1117,6 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
                  "Test number of messages sent during reduce",
                  "[mpi]")
 {
-    // Register three ranks
     setWorldSizes(4, 2, 2);
 
     // Init worlds
@@ -1128,66 +1126,67 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     REQUIRE(getMpiHostsToRanksMessages().size() == 1);
     otherWorld.initialiseFromMsg(msg);
 
-    // Call broadcast and check sent messages
-    std::set<int> expectedRecvRanks;
-    int expectedNumMsg;
+    std::set<int> expectedSentMsgRanks;
+    int expectedNumMsgSent;
     int sendRank;
-    int rootRank;
+    int recvRank;
 
-    SECTION("Check from root rank (local), and root is local master")
+    SECTION("Call reduce from receiver (local), and receiver is local leader")
     {
-        rootRank = 0;
-        sendRank = rootRank;
-        expectedNumMsg = 0;
-        expectedRecvRanks = {};
+        recvRank = 0;
+        sendRank = recvRank;
+        expectedNumMsgSent = 0;
+        expectedSentMsgRanks = {};
     }
 
-    SECTION("Check from root rank (local), and root is non-local master")
+    SECTION(
+      "Call reduce from receiver (local), and receiver is non-local leader")
     {
-        rootRank = 1;
-        sendRank = rootRank;
-        expectedNumMsg = 0;
-        expectedRecvRanks = {};
+        recvRank = 1;
+        sendRank = recvRank;
+        expectedNumMsgSent = 0;
+        expectedSentMsgRanks = {};
     }
 
-    SECTION("Check from local non-root rank, and non-root is local master")
+    SECTION("Call reduce from non-receiver, colocated with receiver, and local "
+            "leader")
     {
-        rootRank = 1;
+        recvRank = 1;
         sendRank = 0;
-        expectedNumMsg = 1;
-        expectedRecvRanks = { rootRank };
+        expectedNumMsgSent = 1;
+        expectedSentMsgRanks = { recvRank };
     }
 
-    SECTION("Check from local non-root rank, and non-root is non-local-master")
+    SECTION("Call reduce from non-receiver, colocated with receiver")
     {
-        rootRank = 0;
+        recvRank = 0;
         sendRank = 1;
-        expectedNumMsg = 1;
-        expectedRecvRanks = { rootRank };
+        expectedNumMsgSent = 1;
+        expectedSentMsgRanks = { recvRank };
     }
 
-    SECTION("Check from remote rank, and remote rank is local master")
+    SECTION("Call reduce from non-receiver rank, not colocated with receiver, "
+            "but local leader")
     {
-        rootRank = 0;
+        recvRank = 0;
         sendRank = 2;
-        expectedNumMsg = 1;
-        expectedRecvRanks = { rootRank };
+        expectedNumMsgSent = 1;
+        expectedSentMsgRanks = { recvRank };
     }
 
-    SECTION("Check from remote rank, and remote rank is not local master")
+    SECTION("Call reduce from non-receiver rank, not colocated with receiver")
     {
-        rootRank = 0;
+        recvRank = 0;
         sendRank = 3;
-        expectedNumMsg = 1;
-        expectedRecvRanks = { 2 };
+        expectedNumMsgSent = 1;
+        expectedSentMsgRanks = { 2 };
     }
 
-    // Check for root
     std::vector<int> messageData = { 0, 1, 2 };
     std::vector<int> recvData(messageData.size());
     if (sendRank < 2) {
         thisWorld.reduce(sendRank,
-                         rootRank,
+                         recvRank,
                          BYTES(messageData.data()),
                          BYTES(recvData.data()),
                          MPI_INT,
@@ -1195,7 +1194,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
                          MPI_SUM);
     } else {
         otherWorld.reduce(sendRank,
-                          rootRank,
+                          recvRank,
                           BYTES(messageData.data()),
                           BYTES(recvData.data()),
                           MPI_INT,
@@ -1203,8 +1202,8 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
                           MPI_SUM);
     }
     auto msgs = getMpiMockedMessages(sendRank);
-    REQUIRE(msgs.size() == expectedNumMsg);
-    REQUIRE(getReceiversFromMessages(msgs) == expectedRecvRanks);
+    REQUIRE(msgs.size() == expectedNumMsgSent);
+    REQUIRE(getReceiversFromMessages(msgs) == expectedSentMsgRanks);
 
     faabric::util::setMockMode(false);
     otherWorld.destroy();


### PR DESCRIPTION
In this PR I apply the same logic from #187 to the reduce collecive communication algorithm.

The logic is the same than for `broadcast()` but inverted.
1. If we are the receiver of the reduce, we expect all our local ranks to send their data for reduction. We also expect all remote leaders to send us their data.
2. If we are a local leader such that we are not co-located with the receiver rank: we (i) wait for all our local ranks to send us their data for reduction, and (ii) send our reduced data to the receiver of the reduce (1).
3. If we are neither the receiver rank nor a local leader, we send our data for reduction to either our local master or the receiver: if we are colocated with the receiver, we send to the receiver, and if not we send to our local master.

Note that this assumes all our reduce operations to be associative and commutative, which is an assumption we already make.