### PR TITLE
Load Balance `allReduce` Operations

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -235,6 +235,9 @@ class MpiWorld
     std::vector<int> remoteLeaders;
     void initLocalRemoteLeaders();
 
+    // Variable allReduce leader to distribute load evenly
+    int allReduceLeader = 0;
+
     // In-memory queues for local messaging
     std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueues;
     void initLocalQueues();

--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -235,9 +235,6 @@ class MpiWorld
     std::vector<int> remoteLeaders;
     void initLocalRemoteLeaders();
 
-    // Variable allReduce leader to distribute load evenly
-    int allReduceLeader = 0;
-
     // In-memory queues for local messaging
     std::vector<std::shared_ptr<InMemoryMpiQueue>> localQueues;
     void initLocalQueues();

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -37,6 +37,9 @@ static thread_local std::unordered_map<
 // Id of the message that created this thread-local instance
 static thread_local faabric::Message* thisRankMsg = nullptr;
 
+// Variable allReduce leader to distribute load evenly
+static thread_local int allReduceLeader = 0;
+
 namespace faabric::scheduler {
 
 // -----------------------------------
@@ -1176,11 +1179,9 @@ void MpiWorld::allReduce(int rank,
               count,
               faabric::MPIMessage::ALLREDUCE);
 
-    // Lastly, the local leader increments the all reduce leader value, so that
-    // the next all reduce is lead by a different rank
-    if (localLeader == rank) {
-        allReduceLeader = (allReduceLeader + 1) % size;
-    }
+    // Lastly, increment the all reduce leader value, so that the next all
+    // reduce is lead by a different rank
+    allReduceLeader = (allReduceLeader + 1) % size;
 }
 
 void MpiWorld::op_reduce(faabric_op_t* operation,


### PR DESCRIPTION
In this PR I change the `allReduce` behaviour to alter the leading rank every subsequent invocation. Before, every `allReduce` call (implemented as a `reduce` + `broadcast`) was lead by rank 0.

Now, we change the leading rank every time we call `allReduce` hopefuly this will: reduce the load on rank 0, collaterally positively impact a theoretical pipelining of chained `allReduce` oeprations.