### PR TITLE
Don't use `util::generateGid()` for MPI messages

### DIFF
--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -22,6 +22,8 @@ static thread_local std::set<int> iSendRequests;
 
 static thread_local std::map<int, std::pair<int, int>> reqIdToRanks;
 
+static thread_local int localMsgCount = 1;
+
 // These long-lived sockets are used by each world to communicate rank-to-host
 // mappings. They are thread-local to ensure separation between concurrent
 // worlds executing on the same host
@@ -624,7 +626,7 @@ void MpiWorld::send(int sendRank,
     bool isLocal = otherHost == thisHost;
 
     // Generate a message ID
-    int msgId = (int)faabric::util::generateGid();
+    int msgId = (localMsgCount + 1) % INT32_MAX;
 
     // Create the message
     auto m = std::make_shared<faabric::MPIMessage>();


### PR DESCRIPTION
The message ID in the `MPIMessage` protobuf objects is not necessary to guarantee execution integrity. It is just useful for logging and debugging purposes. Further, given that each message has also a sending and receiving rank, a per-rank counter suffices to uniquely identify them. As MPI ranks are single-threaded, we can get away with a `thread local` counter.

Note that, profiling in high contention experiments, showed a non-negligable amount of time spent in `generateGid()`. I am not sure what is causing it, but we definately don't need it in the MPI message, thus I remove it.