### PR TITLE
Alternatives to current in-memory MPI local message queues

### DIFF
--- a/include/faabric/scheduler/MpiWorld.h
+++ b/include/faabric/scheduler/MpiWorld.h
@@ -31,8 +31,13 @@ std::vector<faabric::MpiHostsToRanksMessage> getMpiHostsToRanksMessages();
 std::vector<std::shared_ptr<faabric::MPIMessage>> getMpiMockedMessages(
   int sendRank);
 
+#if 0
 typedef faabric::util::Queue<std::shared_ptr<faabric::MPIMessage>>
   InMemoryMpiQueue;
+#else
+typedef faabric::util::SpscQueue<std::shared_ptr<faabric::MPIMessage>>
+  InMemoryMpiQueue;
+#endif
 
 class MpiWorld
 {

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -22,6 +22,8 @@ static thread_local std::set<int> iSendRequests;
 
 static thread_local std::map<int, std::pair<int, int>> reqIdToRanks;
 
+static thread_local int localMsgCount = 1;
+
 // These long-lived sockets are used by each world to communicate rank-to-host
 // mappings. They are thread-local to ensure separation between concurrent
 // worlds executing on the same host
@@ -624,7 +626,7 @@ void MpiWorld::send(int sendRank,
     bool isLocal = otherHost == thisHost;
 
     // Generate a message ID
-    int msgId = (int)faabric::util::generateGid();
+    int msgId = (localMsgCount + 1) % INT32_MAX; // (int)faabric::util::generateGid();
 
     // Create the message
     auto m = std::make_shared<faabric::MPIMessage>();


### PR DESCRIPTION
In certain high-contention experiments, the locking around our in-memory queues for local MPI messages becomes the bottleneck. The aim of this PR is to explore alternatives to said queues.

### Single-Producer Single-Consumer lock-free queues ([boost](https://www.boost.org/doc/libs/1_59_0/doc/html/boost/lockfree/spsc_queue.html)):
The first alternative is to use boost's single producer, single consumer lock free queues (i.e. ring buffers). As we know there will only be one thread producing, and one thread receiving, this data structure could be a good option.

Pros:
* Very minimal implementation and drop-in replacement with current in-memory queues.
* Preliminary results show a very relevant reduction (30-40%) in elapsed time for high-contention, high-throughput benchmarks.
* Preliminary results show no detriment in the other use cases.

Cons:
* If we really want to go lock-free, it means threads sending or receiving must busy-wait until able to send or receive. This will drive up our CPU usage.

### ZeroMQ In-Memory PAIR Sockets:
To be implemented.