### PR TITLE
Remove timed mutex from ptp broker

### DIFF
--- a/include/faabric/transport/PointToPointBroker.h
+++ b/include/faabric/transport/PointToPointBroker.h
@@ -63,8 +63,6 @@ class PointToPointGroup
   private:
     faabric::util::SystemConfig& conf;
 
-    int timeoutMs = DEFAULT_DISTRIBUTED_TIMEOUT_MS;
-
     std::string masterHost;
     int appId = 0;
     int groupId = 0;

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -8,14 +8,6 @@
 
 #define NO_LOCK_OWNER_IDX -1
 
-#define LOCK_TIMEOUT(mx, ms)                                                   \
-    auto timePoint =                                                           \
-      std::chrono::system_clock::now() + std::chrono::milliseconds(ms);        \
-    bool success = mx.try_lock_until(timePoint);                               \
-    if (!success) {                                                            \
-        throw std::runtime_error("Distributed coordination timeout");          \
-    }
-
 #define MAPPING_TIMEOUT_MS 20000
 
 namespace faabric::transport {
@@ -238,7 +230,7 @@ void PointToPointGroup::lock(int groupIdx, bool recursive)
 
 void PointToPointGroup::localLock()
 {
-    LOCK_TIMEOUT(localMx, timeoutMs);
+    localMx.lock();
 }
 
 bool PointToPointGroup::localTryLock()


### PR DESCRIPTION
This was causing a noticeable performance hit vs. a simple lock. This is on the critical ptp messaging path, so performance improvement outweighs risk of timeouts. 