### PR TITLE
Executor context

### DIFF
--- a/include/faabric/scheduler/ExecutorContext.h
+++ b/include/faabric/scheduler/ExecutorContext.h
@@ -1,0 +1,41 @@
+#include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/Scheduler.h>
+
+namespace faabric::scheduler {
+
+/**
+ * Globally-accessible wrapper that allows executing applications to query
+ * their execution context. The context is thread-local, so applications can
+ * query which specific message they are executing.
+ */
+class ExecutorContext
+{
+  public:
+    ExecutorContext(Executor* executorIn,
+                    std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
+                    int msgIdx);
+
+    static void set(Executor* executorIn,
+                    std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
+                    int msgIdxIn);
+
+    static std::shared_ptr<ExecutorContext> get();
+
+    Executor* getExecutor() { return executor; }
+
+    std::shared_ptr<faabric::BatchExecuteRequest> getBatchRequest()
+    {
+        return req;
+    }
+
+    faabric::Message& getMsg() { return req->mutable_messages()->at(msgIdx); }
+
+    int getMsgIdx() { return msgIdx; }
+
+  private:
+    Executor* executor = nullptr;
+    std::shared_ptr<faabric::BatchExecuteRequest> req = nullptr;
+    int msgIdx = 0;
+};
+
+}

--- a/include/faabric/scheduler/ExecutorContext.h
+++ b/include/faabric/scheduler/ExecutorContext.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/scheduler/Scheduler.h>
 
@@ -19,6 +21,8 @@ class ExecutorContext
                     std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
                     int msgIdxIn);
 
+    static void unset();
+
     static std::shared_ptr<ExecutorContext> get();
 
     Executor* getExecutor() { return executor; }
@@ -28,7 +32,14 @@ class ExecutorContext
         return req;
     }
 
-    faabric::Message& getMsg() { return req->mutable_messages()->at(msgIdx); }
+    faabric::Message& getMsg()
+    {
+        if (req == nullptr) {
+            throw std::runtime_error(
+              "Getting message when no request set in context");
+        }
+        return req->mutable_messages()->at(msgIdx);
+    }
 
     int getMsgIdx() { return msgIdx; }
 

--- a/include/faabric/scheduler/ExecutorContext.h
+++ b/include/faabric/scheduler/ExecutorContext.h
@@ -37,5 +37,4 @@ class ExecutorContext
     std::shared_ptr<faabric::BatchExecuteRequest> req = nullptr;
     int msgIdx = 0;
 };
-
 }

--- a/include/faabric/scheduler/ExecutorContext.h
+++ b/include/faabric/scheduler/ExecutorContext.h
@@ -17,6 +17,8 @@ class ExecutorContext
                     std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
                     int msgIdx);
 
+    static bool isSet();
+
     static void set(Executor* executorIn,
                     std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
                     int msgIdxIn);

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -38,13 +38,11 @@ class ExecutorTask
 
     ExecutorTask(int messageIndexIn,
                  std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
-                 std::shared_ptr<std::atomic<int>> batchCounterIn,
-                 bool skipResetIn);
+                 std::shared_ptr<std::atomic<int>> batchCounterIn);
 
     std::shared_ptr<faabric::BatchExecuteRequest> req;
     std::shared_ptr<std::atomic<int>> batchCounter;
     int messageIndex = 0;
-    bool skipReset = false;
 };
 
 class Executor
@@ -121,10 +119,6 @@ class Executor
 
     void threadPoolThread(int threadPoolIdx);
 };
-
-Executor* getExecutingExecutor();
-
-void setExecutingExecutor(Executor* exec);
 
 class Scheduler
 {

--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -1,5 +1,6 @@
 faabric_lib(scheduler
     ExecGraph.cpp
+    ExecutorContext.cpp
     ExecutorFactory.cpp
     Executor.cpp
     FunctionCallClient.cpp

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -74,7 +74,7 @@ void Executor::finish()
         // Send a kill message
         SPDLOG_TRACE("Executor {} killing thread pool {}", id, i);
         threadTaskQueues[i].enqueue(
-          ExecutorTask(POOL_SHUTDOWN, nullptr, nullptr, false));
+          ExecutorTask(POOL_SHUTDOWN, nullptr, nullptr));
 
         faabric::util::UniqueLock threadsLock(threadsMutex);
         // Copy shared_ptr to avoid racing

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -434,7 +434,7 @@ void Executor::threadPoolThread(int threadPoolIdx)
                      isThreads,
                      msg.groupid());
 
-        // Set executing executor
+        // Set up context
         ExecutorContext::set(this, task.req, task.messageIndex);
 
         // Execute the task
@@ -469,6 +469,9 @@ void Executor::threadPoolThread(int threadPoolIdx)
             SPDLOG_ERROR(errorMessage);
             msg.set_outputdata(errorMessage);
         }
+
+        // Unset context
+        ExecutorContext::unset();
 
         // Handle thread-local diffing for every thread
         if (doDirtyTracking) {

--- a/src/scheduler/ExecutorContext.cpp
+++ b/src/scheduler/ExecutorContext.cpp
@@ -20,8 +20,16 @@ void ExecutorContext::set(Executor* executorIn,
     context = std::make_shared<ExecutorContext>(executorIn, reqIn, appIdxIn);
 }
 
+void ExecutorContext::unset() {
+    context = nullptr;
+}
+
 std::shared_ptr<ExecutorContext> ExecutorContext::get()
 {
+    if (context == nullptr) {
+        SPDLOG_ERROR("No executor context set");
+        throw std::runtime_error("No executor context set");
+    }
     return context;
 }
 }

--- a/src/scheduler/ExecutorContext.cpp
+++ b/src/scheduler/ExecutorContext.cpp
@@ -13,6 +13,11 @@ ExecutorContext::ExecutorContext(
   , msgIdx(msgIdxIn)
 {}
 
+bool ExecutorContext::isSet()
+{
+    return context != nullptr;
+}
+
 void ExecutorContext::set(Executor* executorIn,
                           std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
                           int appIdxIn)
@@ -20,7 +25,8 @@ void ExecutorContext::set(Executor* executorIn,
     context = std::make_shared<ExecutorContext>(executorIn, reqIn, appIdxIn);
 }
 
-void ExecutorContext::unset() {
+void ExecutorContext::unset()
+{
     context = nullptr;
 }
 

--- a/src/scheduler/ExecutorContext.cpp
+++ b/src/scheduler/ExecutorContext.cpp
@@ -1,0 +1,27 @@
+#include <faabric/scheduler/ExecutorContext.h>
+
+namespace faabric::scheduler {
+
+static thread_local std::shared_ptr<ExecutorContext> context = nullptr;
+
+ExecutorContext::ExecutorContext(
+  Executor* executorIn,
+  std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
+  int msgIdxIn)
+  : executor(executorIn)
+  , req(reqIn)
+  , msgIdx(msgIdxIn)
+{}
+
+void ExecutorContext::set(Executor* executorIn,
+                          std::shared_ptr<faabric::BatchExecuteRequest> reqIn,
+                          int appIdxIn)
+{
+    context = std::make_shared<ExecutorContext>(executorIn, reqIn, appIdxIn);
+}
+
+std::shared_ptr<ExecutorContext> ExecutorContext::get()
+{
+    return context;
+}
+}

--- a/tests/test/scheduler/test_executor_context.cpp
+++ b/tests/test/scheduler/test_executor_context.cpp
@@ -13,11 +13,13 @@ TEST_CASE_METHOD(ExecutorContextTestFixture,
                  "Test executor context",
                  "[scheduler]")
 {
-    REQUIRE(ExecutorContext::get() == nullptr);
+    // Getting with no context should fail
+    REQUIRE_THROWS(ExecutorContext::get());
 
     faabric::Message msg = faabric::util::messageFactory("foo", "bar");
 
-    auto fac = getExecutorFactory();
+    std::shared_ptr<DummyExecutorFactory> fac =
+      std::make_shared<DummyExecutorFactory>();
     auto exec = fac->createExecutor(msg);
 
     auto req = faabric::util::batchExecFactory("foo", "bar", 5);
@@ -55,5 +57,8 @@ TEST_CASE_METHOD(ExecutorContextTestFixture,
         REQUIRE(ctx->getMsgIdx() == 3);
         REQUIRE(ctx->getMsg().id() == req->mutable_messages()->at(3).id());
     }
+
+    ExecutorContext::unset();
+    REQUIRE_THROWS(ExecutorContext::get());
 }
 }

--- a/tests/test/scheduler/test_executor_context.cpp
+++ b/tests/test/scheduler/test_executor_context.cpp
@@ -13,6 +13,8 @@ TEST_CASE_METHOD(ExecutorContextTestFixture,
                  "Test executor context",
                  "[scheduler]")
 {
+    REQUIRE(!ExecutorContext::isSet());
+
     // Getting with no context should fail
     REQUIRE_THROWS(ExecutorContext::get());
 

--- a/tests/test/scheduler/test_executor_context.cpp
+++ b/tests/test/scheduler/test_executor_context.cpp
@@ -1,0 +1,59 @@
+#include <catch2/catch.hpp>
+
+#include "faabric_utils.h"
+
+#include <faabric/scheduler/ExecutorContext.h>
+#include <faabric/util/func.h>
+
+using namespace faabric::scheduler;
+
+namespace tests {
+
+TEST_CASE_METHOD(ExecutorContextTestFixture,
+                 "Test executor context",
+                 "[scheduler]")
+{
+    REQUIRE(ExecutorContext::get() == nullptr);
+
+    faabric::Message msg = faabric::util::messageFactory("foo", "bar");
+
+    auto fac = getExecutorFactory();
+    auto exec = fac->createExecutor(msg);
+
+    auto req = faabric::util::batchExecFactory("foo", "bar", 5);
+
+    SECTION("Set both executor and request")
+    {
+        ExecutorContext::set(exec.get(), req, 3);
+
+        std::shared_ptr<ExecutorContext> ctx = ExecutorContext::get();
+        REQUIRE(ctx->getExecutor() == exec.get());
+        REQUIRE(ctx->getBatchRequest() == req);
+        REQUIRE(ctx->getMsgIdx() == 3);
+        REQUIRE(ctx->getMsg().id() == req->mutable_messages()->at(3).id());
+    }
+
+    SECTION("Just set executor")
+    {
+        ExecutorContext::set(exec.get(), nullptr, 0);
+
+        std::shared_ptr<ExecutorContext> ctx = ExecutorContext::get();
+        REQUIRE(ctx->getExecutor() == exec.get());
+        REQUIRE(ctx->getBatchRequest() == nullptr);
+        REQUIRE(ctx->getMsgIdx() == 0);
+
+        REQUIRE_THROWS(ctx->getMsg());
+    }
+
+    SECTION("Just set request")
+    {
+        ExecutorContext::set(nullptr, req, 3);
+
+        std::shared_ptr<ExecutorContext> ctx = ExecutorContext::get();
+        REQUIRE(ctx->getExecutor() == nullptr);
+        REQUIRE(ctx->getBatchRequest() == req);
+        REQUIRE(ctx->getMsgIdx() == 3);
+        REQUIRE(ctx->getMsg().id() == req->mutable_messages()->at(3).id());
+    }
+}
+}

--- a/tests/utils/DummyExecutorFactory.h
+++ b/tests/utils/DummyExecutorFactory.h
@@ -11,9 +11,9 @@ class DummyExecutorFactory : public ExecutorFactory
 
     int getFlushCount();
 
-  protected:
     std::shared_ptr<Executor> createExecutor(faabric::Message& msg) override;
 
+  protected:
     void flushHost() override;
 
   private:

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -3,6 +3,7 @@
 #include <sys/mman.h>
 
 #include <faabric/redis/Redis.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/ExecutorFactory.h>
 #include <faabric/scheduler/MpiWorld.h>
 #include <faabric/scheduler/MpiWorldRegistry.h>
@@ -20,6 +21,7 @@
 #include <faabric/util/testing.h>
 
 #include "DummyExecutorFactory.h"
+#include "faabric/util/func.h"
 #include "faabric/util/scheduling.h"
 
 namespace tests {
@@ -334,6 +336,29 @@ class PointToPointClientServerFixture
   protected:
     faabric::transport::PointToPointClient cli;
     faabric::transport::PointToPointServer server;
+};
+
+class ExecutorContextTestFixture
+{
+  public:
+    ExecutorContextTestFixture() {}
+
+    ~ExecutorContextTestFixture()
+    {
+        faabric::scheduler::ExecutorContext::unset();
+    }
+
+    /**
+     * Shortcut method to set context from a single message.
+     */
+    void setContextFromMessage(faabric::Message& msg)
+    {
+        auto req =
+          faabric::util::batchExecFactory(msg.user(), msg.function(), 1);
+        req->mutable_messages()->at(0) = msg;
+
+        faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
+    }
 };
 
 #define TEST_EXECUTOR_DEFAULT_MEMORY_SIZE (10 * faabric::util::HOST_PAGE_SIZE)

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -2,6 +2,7 @@
 
 #include <sys/mman.h>
 
+#include <faabric/proto/faabric.pb.h>
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/ExecutorFactory.h>
@@ -15,15 +16,14 @@
 #include <faabric/transport/PointToPointClient.h>
 #include <faabric/transport/PointToPointServer.h>
 #include <faabric/util/dirty.h>
+#include <faabric/util/func.h>
 #include <faabric/util/latch.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/network.h>
+#include <faabric/util/scheduling.h>
 #include <faabric/util/testing.h>
 
 #include "DummyExecutorFactory.h"
-#include "faabric/proto/faabric.pb.h"
-#include "faabric/util/func.h"
-#include "faabric/util/scheduling.h"
 
 namespace tests {
 class RedisTestFixture

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -21,6 +21,7 @@
 #include <faabric/util/testing.h>
 
 #include "DummyExecutorFactory.h"
+#include "faabric/proto/faabric.pb.h"
 #include "faabric/util/func.h"
 #include "faabric/util/scheduling.h"
 
@@ -351,13 +352,16 @@ class ExecutorContextTestFixture
     /**
      * Shortcut method to set context from a single message.
      */
-    void setContextFromMessage(faabric::Message& msg)
+    std::shared_ptr<faabric::BatchExecuteRequest> setUpContext(
+      const std::string& user,
+      const std::string& func,
+      int nMsgs = 1)
     {
-        auto req =
-          faabric::util::batchExecFactory(msg.user(), msg.function(), 1);
-        req->mutable_messages()->at(0) = msg;
+        auto req = faabric::util::batchExecFactory(user, func, nMsgs);
 
         faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
+
+        return req;
     }
 };
 

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -350,7 +350,7 @@ class ExecutorContextTestFixture
     }
 
     /**
-     * Shortcut method to set context from a single message.
+     * Creates a batch request and sets up the associated context
      */
     std::shared_ptr<faabric::BatchExecuteRequest> setUpContext(
       const std::string& user,
@@ -359,9 +359,17 @@ class ExecutorContextTestFixture
     {
         auto req = faabric::util::batchExecFactory(user, func, nMsgs);
 
-        faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
+        setUpContext(req);
 
         return req;
+    }
+
+    /**
+     * Sets up context for the given batch request
+     */
+    void setUpContext(std::shared_ptr<faabric::BatchExecuteRequest> req)
+    {
+        faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
     }
 };
 


### PR DESCRIPTION
Some applications need to access the current execution context via global functions to query the currently executing message or executor. At the moment this done through a few global functions spread over Faasm/ Faabric e.g. `getExecutingExecutor` and `getExecutingCall`, and does not provide any way to access the currently executing batch request.

This PR wraps all these accesses in a new `ExecutorContext`, which captures the executor, batch request and message index (i.e. which message within the batch request is executing). 

