### PR TITLE
Remove SGX-related message fields

### DIFF
--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -137,13 +137,7 @@ std::pair<int, std::string> FaabricEndpointHandler::executeFunction(
           sch.getFunctionResult(msg.id(), conf.globalMessageTimeout);
         SPDLOG_DEBUG("Worker thread {} result {}", tid, funcStr);
 
-        if (result.sgxresult().empty()) {
-            return std::make_pair(result.returnvalue(),
-                                  result.outputdata() + "\n");
-        }
-
-        return std::make_pair(result.returnvalue(),
-                              faabric::util::getJsonOutput(result));
+        return std::make_pair(result.returnvalue(), result.outputdata() + "\n");
     } catch (faabric::redis::RedisNoResponseException& ex) {
         return std::make_pair(1, "No response from function\n");
     }

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -156,25 +156,16 @@ message Message {
 
     string cmdline = 34;
 
-    // SGX
-    bool isSgx = 35;
-
-    string sgxSid = 36;
-    string sgxNonce = 37;
-    string sgxTag = 38;
-    bytes sgxPolicy = 39;
-    bytes sgxResult = 40;
-
     // Exec-graph utils
-    bool recordExecGraph = 41;
-    map<string, int32> intExecGraphDetails = 42;
-    map<string, string> execGraphDetails = 43;
+    bool recordExecGraph = 35;
+    map<string, int32> intExecGraphDetails = 36;
+    map<string, string> execGraphDetails = 37;
 
     // Function migration
-    int32 migrationCheckPeriod = 44;
+    int32 migrationCheckPeriod = 38;
 
     // Scheduling
-    string topologyHint = 45;
+    string topologyHint = 39;
 }
 
 // ---------------------------------------------

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -28,10 +28,6 @@ std::string funcToString(const faabric::Message& msg, bool includeId)
         str += ":" + std::to_string(msg.id());
     }
 
-    if (msg.issgx()) {
-        str += ":sgx";
-    }
-
     return str;
 }
 

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -151,40 +151,6 @@ std::string messageToJson(const faabric::Message& msg)
                     a);
     }
 
-    if (msg.issgx()) {
-        d.AddMember("sgx", msg.issgx(), a);
-    }
-
-    if (!msg.sgxsid().empty()) {
-        d.AddMember(
-          "sgxsid", Value(msg.sgxsid().c_str(), msg.sgxsid().size()).Move(), a);
-    }
-
-    if (!msg.sgxnonce().empty()) {
-        d.AddMember("sgxnonce",
-                    Value(msg.sgxnonce().c_str(), msg.sgxnonce().size()).Move(),
-                    a);
-    }
-
-    if (!msg.sgxtag().empty()) {
-        d.AddMember(
-          "sgxtag", Value(msg.sgxtag().c_str(), msg.sgxtag().size()).Move(), a);
-    }
-
-    if (!msg.sgxpolicy().empty()) {
-        d.AddMember(
-          "sgxpolicy",
-          Value(msg.sgxpolicy().c_str(), msg.sgxpolicy().size()).Move(),
-          a);
-    }
-
-    if (!msg.sgxresult().empty()) {
-        d.AddMember(
-          "sgxresult",
-          Value(msg.sgxresult().c_str(), msg.sgxresult().size()).Move(),
-          a);
-    }
-
     if (msg.recordexecgraph()) {
         d.AddMember("record_exec_graph", msg.recordexecgraph(), a);
 
@@ -251,8 +217,6 @@ std::string getJsonOutput(const faabric::Message& msg)
     Document d;
     d.SetObject();
     Document::AllocatorType& a = d.GetAllocator();
-    std::string result_ = cppcodec::base64_rfc4648::encode(msg.sgxresult());
-    d.AddMember("result", Value(result_.c_str(), result_.size(), a).Move(), a);
     d.AddMember(
       "output_data",
       Value(msg.outputdata().c_str(), msg.outputdata().size(), a).Move(),
@@ -420,13 +384,6 @@ faabric::Message jsonToMessage(const std::string& jsonIn)
     msg.set_mpiworldsize(getIntFromJson(d, "mpi_world_size", 0));
 
     msg.set_cmdline(getStringFromJson(d, "cmdline", ""));
-
-    msg.set_issgx(getBoolFromJson(d, "sgx", false));
-    msg.set_sgxsid(getStringFromJson(d, "sgxsid", ""));
-    msg.set_sgxnonce(getStringFromJson(d, "sgxnonce", ""));
-    msg.set_sgxtag(getStringFromJson(d, "sgxtag", ""));
-    msg.set_sgxpolicy(getStringFromJson(d, "sgxpolicy", ""));
-    msg.set_sgxresult(getStringFromJson(d, "sgxresult", ""));
 
     msg.set_recordexecgraph(getBoolFromJson(d, "record_exec_graph", false));
 

--- a/tests/test/util/test_json.cpp
+++ b/tests/test/util/test_json.cpp
@@ -34,13 +34,6 @@ TEST_CASE("Test message to JSON round trip", "[util]")
 
     msg.set_cmdline("some cmdline");
 
-    msg.set_issgx(true);
-    msg.set_sgxsid("test sid string");
-    msg.set_sgxnonce("test nonce string");
-    msg.set_sgxtag("test tag string");
-    msg.set_sgxpolicy("test policy string");
-    msg.set_sgxresult("test result string");
-
     msg.set_recordexecgraph(true);
     auto& map = *msg.mutable_execgraphdetails();
     map["foo"] = "bar";
@@ -92,17 +85,5 @@ TEST_CASE("Test with raw string literals", "[util]")
       jsonToMessage(R"({"user": "foo", "function": "bar"})");
     REQUIRE(msg.user() == "foo");
     REQUIRE(msg.function() == "bar");
-}
-
-TEST_CASE("Test base64-encoded result", "[util]")
-{
-    faabric::Message msg;
-    msg.set_sgxresult("test tag string");
-    msg.set_outputdata("test output string");
-    std::string encodedOutput = getJsonOutput(msg);
-    REQUIRE(getValueFromJsonString("result", encodedOutput) ==
-            "dGVzdCB0YWcgc3RyaW5n");
-    REQUIRE(getValueFromJsonString("output_data", encodedOutput) ==
-            "test output string");
 }
 }

--- a/tests/utils/message_utils.cpp
+++ b/tests/utils/message_utils.cpp
@@ -41,13 +41,6 @@ void checkMessageEquality(const faabric::Message& msgA,
 
     REQUIRE(msgA.cmdline() == msgB.cmdline());
 
-    REQUIRE(msgA.issgx() == msgB.issgx());
-    REQUIRE(msgA.sgxsid() == msgB.sgxsid());
-    REQUIRE(msgA.sgxnonce() == msgB.sgxnonce());
-    REQUIRE(msgA.sgxtag() == msgB.sgxtag());
-    REQUIRE(msgA.sgxpolicy() == msgB.sgxpolicy());
-    REQUIRE(msgA.sgxresult() == msgB.sgxresult());
-
     REQUIRE(msgA.recordexecgraph() == msgB.recordexecgraph());
     checkMessageMapEquality(msgA.execgraphdetails(), msgB.execgraphdetails());
     checkMessageMapEquality(msgA.intexecgraphdetails(),


### PR DESCRIPTION
With faasm/faasm#587, we indicate SGX execution through the existing `WASM_VM` env. variable, instead of through a field in the message.

Further, no other SGX-related message fields were actually used, so I remove them altogether. This removes all references to SGX in faabric, and it should be kept this way if possible.

Related to #221 