### PR TITLE
Detect CPU information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options(-fcolor-diagnostics)
 endif()
 
-# Assume skylake for some easy performance wins
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    add_compile_options(-march=skylake -mtune=skylake)
-endif ()
+# Optimise for CPU
+include(cmake/OptimiseCPU.cmake)
 
 # Top-level CMake config
 set(CMAKE_CXX_FLAGS "-Wall")

--- a/cmake/OptimiseCPU.cmake
+++ b/cmake/OptimiseCPU.cmake
@@ -1,7 +1,3 @@
-
-set(CPU_ARCH "none")
-set(CPU_ARCH_FLAGS "")
-
 set(CPU_VENDOR)
 set(CPU_FAMILY)
 set(CPU_MODEL)
@@ -19,13 +15,12 @@ string(REGEX REPLACE ".*flags[ \t]*:[ \t]+([^\n]+).*" "\\1"
 
 message("Found CPU: Vendor = ${CPU_VENDOR} Family = ${CPU_FAMILY} Model = ${CPU_MODEL} Props = ${CPU_PROPS}")
 
-set(CPU_COMPILE_FLAGS)
-
 # See this file for an example of extending this list:
 # https://github.com/VcDevel/Vc/blob/1.4/cmake/OptimizeForArchitecture.cmake
 # See the LLVM source for list of supported arch, e.g. this test:
 # https://github.com/llvm/llvm-project/blob/main/clang/test/Driver/x86-march.c
 
+set(CPU_COMPILE_FLAGS)
 if(CPU_VENDOR STREQUAL "GenuineIntel")
     if(CPU_FAMILY EQUAL 6)
         if(CPU_MODEL EQUAL 78 OR CPU_MODEL EQUAL 94)

--- a/cmake/OptimiseCPU.cmake
+++ b/cmake/OptimiseCPU.cmake
@@ -1,0 +1,44 @@
+
+set(CPU_ARCH "none")
+set(CPU_ARCH_FLAGS "")
+
+set(CPU_VENDOR)
+set(CPU_FAMILY)
+set(CPU_MODEL)
+set(CPU_PROPS)
+
+file(READ "/proc/cpuinfo" _cpuinfo)
+string(REGEX REPLACE ".*vendor_id[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1"
+    CPU_VENDOR "${_cpuinfo}")
+string(REGEX REPLACE ".*cpu family[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1"
+    CPU_FAMILY "${_cpuinfo}")
+string(REGEX REPLACE ".*model[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1"
+    CPU_MODEL "${_cpuinfo}")
+string(REGEX REPLACE ".*flags[ \t]*:[ \t]+([^\n]+).*" "\\1"
+    CPU_PROPS "${_cpuinfo}")
+
+message("Found CPU: Vendor = ${CPU_VENDOR} Family = ${CPU_FAMILY} Model = ${CPU_MODEL} Flags = ${CPU_FLAGS}")
+
+set(CPU_COMPILE_FLAGS)
+
+# See this file for an example of extending this list:
+# https://github.com/VcDevel/Vc/blob/1.4/cmake/OptimizeForArchitecture.cmake
+
+if(CPU_VENDOR STREQUAL "GenuineIntel")
+    if(CPU_FAMILY EQUAL 6)
+        if(CPU_MODEL EQUAL 78 OR CPU_MODEL EQUAL 94)
+            # Skylake
+            set(CPU_COMPILE_FLAGS "-march=skylake -mtune=skylake")
+        elseif(CPU_MODEL EQUAL 58 OR CPU_MODEL EQUAL 62)
+            # Ivy bridge
+            set(CPU_COMPILE_FLAGS "-march=ivybridge -mtune=ivybridge")
+        endif()
+    endif()
+endif()
+
+if(CPU_COMPILE_FLAGS)
+    message("Setting following CPU-specific compile flags: ${CPU_COMPILE_FLAGS}")
+    add_compile_options(${CPU_COMPILE_FLAGS})
+else()
+    message("Could not provide any CPU-specific compile flags")
+endif()

--- a/cmake/OptimiseCPU.cmake
+++ b/cmake/OptimiseCPU.cmake
@@ -17,21 +17,23 @@ string(REGEX REPLACE ".*model[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1"
 string(REGEX REPLACE ".*flags[ \t]*:[ \t]+([^\n]+).*" "\\1"
     CPU_PROPS "${_cpuinfo}")
 
-message("Found CPU: Vendor = ${CPU_VENDOR} Family = ${CPU_FAMILY} Model = ${CPU_MODEL} Flags = ${CPU_FLAGS}")
+message("Found CPU: Vendor = ${CPU_VENDOR} Family = ${CPU_FAMILY} Model = ${CPU_MODEL} Props = ${CPU_PROPS}")
 
 set(CPU_COMPILE_FLAGS)
 
 # See this file for an example of extending this list:
 # https://github.com/VcDevel/Vc/blob/1.4/cmake/OptimizeForArchitecture.cmake
+# See the LLVM source for list of supported arch, e.g. this test:
+# https://github.com/llvm/llvm-project/blob/main/clang/test/Driver/x86-march.c
 
 if(CPU_VENDOR STREQUAL "GenuineIntel")
     if(CPU_FAMILY EQUAL 6)
         if(CPU_MODEL EQUAL 78 OR CPU_MODEL EQUAL 94)
             # Skylake
-            set(CPU_COMPILE_FLAGS "-march=skylake -mtune=skylake")
+            set(CPU_COMPILE_FLAGS -march=skylake -mtune=skylake)
         elseif(CPU_MODEL EQUAL 58 OR CPU_MODEL EQUAL 62)
             # Ivy bridge
-            set(CPU_COMPILE_FLAGS "-march=ivybridge -mtune=ivybridge")
+            set(CPU_COMPILE_FLAGS -march=ivybridge -mtune=ivybridge)
         endif()
     endif()
 endif()


### PR DESCRIPTION
Currently we use `-march=skylake` for any x86_64 CPU which causes some very hard-to-diagnose errors on non-skylake CPUs. This adds a CMake script to automatically detect CPU type based off `/proc/cpuinfo`.