### PR TITLE
Move `restore` logic into Faabric

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -84,9 +84,9 @@ class Executor
 
     virtual std::span<uint8_t> getMemoryView();
 
-  protected:
     virtual void restore(const std::string& snapshotKey);
 
+  protected:
     virtual void postFinish();
 
     virtual void setMemorySize(size_t newSize);

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -702,6 +702,17 @@ void Executor::setMemorySize(size_t newSize)
 
 void Executor::restore(const std::string& snapshotKey)
 {
-    SPDLOG_WARN("Executor has not implemented restore method");
+    std::span<uint8_t> memView = getMemoryView();
+    if (memView.empty()) {
+        SPDLOG_ERROR("No memory on {} to restore {}", id, snapshotKey);
+        throw std::runtime_error("No memory to restore executor");
+    }
+
+    // Expand memory if necessary
+    auto snap = reg.getSnapshot(snapshotKey);
+    setMemorySize(snap->getSize());
+
+    // Map the memory onto the snapshot
+    snap->mapToMemory({ memView.data(), snap->getSize() });
 }
 }

--- a/tests/dist/DistTestExecutor.cpp
+++ b/tests/dist/DistTestExecutor.cpp
@@ -62,20 +62,6 @@ void DistTestExecutor::reset(faabric::Message& msg)
                  faabric::util::funcToString(msg, false));
 }
 
-void DistTestExecutor::restore(const std::string& snapshotKey)
-{
-    SPDLOG_DEBUG("Dist test executor restoring from {}", snapshotKey);
-
-    if (dummyMemory.get() == nullptr) {
-        SPDLOG_ERROR("No memory for dist test executor to restore {}",
-                     snapshotKey);
-        throw std::runtime_error("No memory to restore dist test executor");
-    }
-
-    auto snap = reg.getSnapshot(snapshotKey);
-    snap->mapToMemory({ dummyMemory.get(), dummyMemorySize });
-}
-
 std::span<uint8_t> DistTestExecutor::getMemoryView()
 {
     if (dummyMemory.get() == nullptr) {

--- a/tests/dist/DistTestExecutor.h
+++ b/tests/dist/DistTestExecutor.h
@@ -23,8 +23,6 @@ class DistTestExecutor final : public faabric::scheduler::Executor
 
     void reset(faabric::Message& msg) override;
 
-    void restore(const std::string& snapshotKey) override;
-
     std::span<uint8_t> getMemoryView() override;
 
     std::span<uint8_t> getDummyMemory();


### PR DESCRIPTION
We previously relied on all `Executor`s to implement their own `restore` method, but they all ended up the same, and just use Faabric-only logic anyway, so we can move it into the `Executor`. 

This also allows us to change the way that we map snapshots into memory without breaking things (e.g. to implement `userfaultfd`-based demand paging). 