### PR TITLE
Add switch to disable single host optimisations

### DIFF
--- a/include/faabric/util/config.h
+++ b/include/faabric/util/config.h
@@ -29,6 +29,7 @@ class SystemConfig
     int noScheduler;
     int overrideCpuCount;
     std::string noTopologyHints;
+    int noSingleHostOptimisations;
 
     // Worker-related timeouts
     int globalMessageTimeout;

--- a/include/faabric/util/scheduling.h
+++ b/include/faabric/util/scheduling.h
@@ -34,6 +34,13 @@ class SchedulingDecision
 
     std::string returnHost;
 
+    /**
+     * Work out if this decision is all on this host. If the decision is
+     * completely on *another* host, we still count it as not being on a single
+     * host, as this host will be the master.
+     *
+     * Will always return false if single host optimisations are switched off.
+     */
     bool isSingleHost();
 
     void addMessage(const std::string& host, const faabric::Message& msg);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -562,9 +562,11 @@ faabric::util::SchedulingDecision Scheduler::doCallFunctions(
         bool hasFunctionsOnThisHost = uniqueHosts.contains(thisHost);
 
         // Mark the request as being single-host if necessary
-        std::set<std::string> thisHostUniset = { thisHost };
-        isSingleHost = (uniqueHosts == thisHostUniset) && isMaster;
-        req->set_singlehost(isSingleHost);
+        if (conf.noSingleHostOptimisations == 0) {
+            std::set<std::string> thisHostUniset = { thisHost };
+            isSingleHost = (uniqueHosts == thisHostUniset) && isMaster;
+            req->set_singlehost(isSingleHost);
+        }
 
         if (hasFunctionsOnThisHost) {
             uniqueHosts.erase(thisHost);

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -35,6 +35,7 @@ void SystemConfig::initialise()
     noScheduler = this->getSystemConfIntParam("NO_SCHEDULER", "0");
     overrideCpuCount = this->getSystemConfIntParam("OVERRIDE_CPU_COUNT", "0");
     noTopologyHints = getEnvVar("NO_TOPOLOGY_HINTS", "off");
+    noSingleHostOptimisations = this->getSystemConfIntParam("NO_SINGLE_HOST", "0");
 
     // Worker-related timeouts (all in seconds)
     globalMessageTimeout =

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -35,7 +35,8 @@ void SystemConfig::initialise()
     noScheduler = this->getSystemConfIntParam("NO_SCHEDULER", "0");
     overrideCpuCount = this->getSystemConfIntParam("OVERRIDE_CPU_COUNT", "0");
     noTopologyHints = getEnvVar("NO_TOPOLOGY_HINTS", "off");
-    noSingleHostOptimisations = this->getSystemConfIntParam("NO_SINGLE_HOST", "0");
+    noSingleHostOptimisations =
+      this->getSystemConfIntParam("NO_SINGLE_HOST", "0");
 
     // Worker-related timeouts (all in seconds)
     globalMessageTimeout =

--- a/src/util/scheduling.cpp
+++ b/src/util/scheduling.cpp
@@ -86,10 +86,13 @@ SchedulingDecision::SchedulingDecision(uint32_t appIdIn, int32_t groupIdIn)
 
 bool SchedulingDecision::isSingleHost()
 {
-    // Work out if this decision is all on this host. If the decision is
-    // completely on *another* host, we still count it as not being on a single
-    // host, as this host will be the master
-    std::string thisHost = faabric::util::getSystemConfig().endpointHost;
+    // Always return false if single-host optimisations are switched off
+    SystemConfig& conf = getSystemConfig();
+    if (conf.noSingleHostOptimisations == 1) {
+        return false;
+    }
+
+    std::string thisHost = conf.endpointHost;
     return std::all_of(hosts.begin(), hosts.end(), [&](const std::string& s) {
         return s == thisHost;
     });

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -1029,6 +1029,12 @@ TEST_CASE_METHOD(TestExecutorFixture,
     int expectedResult = 0;
     SECTION("Single host") { expectedResult = 10; }
 
+    SECTION("Single host disabled in conf")
+    {
+        expectedResult = 20;
+        conf.noSingleHostOptimisations = 1;
+    }
+
     SECTION("Not single host")
     {
         expectedResult = 20;

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -489,6 +489,12 @@ TEST_CASE_METHOD(TestExecutorFixture,
 
     SECTION("Underloaded") { nThreads = 10; }
 
+    SECTION("Underloaded no single host optimisation")
+    {
+        nThreads = 10;
+        conf.noSingleHostOptimisations = 1;
+    }
+
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "blah", nThreads);
     req->set_type(faabric::BatchExecuteRequest::THREADS);
@@ -521,6 +527,12 @@ TEST_CASE_METHOD(TestExecutorFixture,
     SECTION("Underloaded") { nThreads = 8; }
 
     SECTION("Overloaded") { nThreads = 100; }
+
+    SECTION("Underloaded no single host optimisation")
+    {
+        nThreads = 10;
+        conf.noSingleHostOptimisations = 1;
+    }
 
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory("dummy", "thread-check", 1);

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Test default system config initialisation", "[util]")
     REQUIRE(conf.noScheduler == 0);
     REQUIRE(conf.overrideCpuCount == 0);
     REQUIRE(conf.noTopologyHints == "off");
+    REQUIRE(conf.noSingleHostOptimisations == 0);
 
     REQUIRE(conf.globalMessageTimeout == 60000);
     REQUIRE(conf.boundTimeout == 30000);
@@ -48,6 +49,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     std::string noScheduler = setEnvVar("NO_SCHEDULER", "1");
     std::string overrideCpuCount = setEnvVar("OVERRIDE_CPU_COUNT", "4");
     std::string noTopologyHints = setEnvVar("NO_TOPOLOGY_HINTS", "on");
+    std::string noSingleHost = setEnvVar("NO_SINGLE_HOST", "1");
 
     std::string globalTimeout = setEnvVar("GLOBAL_MESSAGE_TIMEOUT", "9876");
     std::string boundTimeout = setEnvVar("BOUND_TIMEOUT", "6666");
@@ -77,6 +79,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     REQUIRE(conf.noScheduler == 1);
     REQUIRE(conf.overrideCpuCount == 4);
     REQUIRE(conf.noTopologyHints == "on");
+    REQUIRE(conf.noSingleHostOptimisations == 1);
 
     REQUIRE(conf.globalMessageTimeout == 9876);
     REQUIRE(conf.boundTimeout == 6666);
@@ -105,6 +108,7 @@ TEST_CASE("Test overriding system config initialisation", "[util]")
     setEnvVar("NO_SCHEDULER", noScheduler);
     setEnvVar("OVERRIDE_CPU_COUNT", overrideCpuCount);
     setEnvVar("USE_TOPOLOGY_HINTS", noTopologyHints);
+    setEnvVar("NO_SINGLE_HOST", noSingleHost);
 
     setEnvVar("GLOBAL_MESSAGE_TIMEOUT", globalTimeout);
     setEnvVar("BOUND_TIMEOUT", boundTimeout);

--- a/tests/test/util/test_scheduling.cpp
+++ b/tests/test/util/test_scheduling.cpp
@@ -11,7 +11,9 @@ using namespace faabric::util;
 
 namespace tests {
 
-TEST_CASE("Test building scheduling decisions", "[util]")
+TEST_CASE_METHOD(ConfTestFixture,
+                 "Test building scheduling decisions",
+                 "[util]")
 {
     int appId = 123;
     int groupId = 345;
@@ -20,7 +22,8 @@ TEST_CASE("Test building scheduling decisions", "[util]")
     std::string hostB = "hostB";
     std::string hostC = "hostC";
 
-    std::string thisHost = faabric::util::getSystemConfig().endpointHost;
+    SystemConfig& conf = getSystemConfig();
+    std::string thisHost = conf.endpointHost;
 
     bool expectSingleHost = false;
     SECTION("Multi-host") {}
@@ -40,6 +43,17 @@ TEST_CASE("Test building scheduling decisions", "[util]")
         hostC = thisHost;
 
         expectSingleHost = true;
+    }
+
+    SECTION("All this host single host optimisations off")
+    {
+        conf.noSingleHostOptimisations = 1;
+
+        hostA = thisHost;
+        hostB = thisHost;
+        hostC = thisHost;
+
+        expectSingleHost = false;
     }
 
     auto req = batchExecFactory("foo", "bar", 3);


### PR DESCRIPTION
Single host optimisations skip a lot of snapshotting code when applications are executing on a single host, which is good for performance, but reduces test coverage and makes it difficult to profile the non-single-host case. 

This PR introduces a switch to disable the single-host optimisations. 