### PR TITLE
Allow executors to specify max memory size

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -91,6 +91,8 @@ class Executor
 
     virtual void setMemorySize(size_t newSize);
 
+    virtual size_t getMaxMemorySize();
+
     faabric::Message boundMessage;
 
     Scheduler& sch;

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -339,7 +339,8 @@ std::shared_ptr<faabric::util::SnapshotData> Executor::getMainThreadSnapshot(
                          faabric::util::funcToString(msg, false));
 
             std::shared_ptr<faabric::util::SnapshotData> snap =
-              std::make_shared<faabric::util::SnapshotData>(getMemoryView());
+              std::make_shared<faabric::util::SnapshotData>(getMemoryView(),
+                                                            getMaxMemorySize());
             reg.registerSnapshot(snapshotKey, snap);
         } else {
             return reg.getSnapshot(snapshotKey);
@@ -698,6 +699,13 @@ std::span<uint8_t> Executor::getMemoryView()
 void Executor::setMemorySize(size_t newSize)
 {
     SPDLOG_WARN("Executor has not implemented set memory size method");
+}
+
+size_t Executor::getMaxMemorySize()
+{
+    SPDLOG_WARN("Executor has not implemented max memory size method");
+
+    return 0;
 }
 
 void Executor::restore(const std::string& snapshotKey)

--- a/src/snapshot/SnapshotRegistry.cpp
+++ b/src/snapshot/SnapshotRegistry.cpp
@@ -39,7 +39,10 @@ void SnapshotRegistry::registerSnapshot(
 {
     faabric::util::FullLock lock(snapshotsMx);
 
-    SPDLOG_DEBUG("Registering snapshot {} size {}", key, data->getSize());
+    SPDLOG_DEBUG("Registering snapshot {} size {} max {}",
+                 key,
+                 data->getSize(),
+                 data->getMaxSize());
 
     snapshotMap.insert_or_assign(key, std::move(data));
 }

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -378,6 +378,7 @@ class TestExecutor final : public faabric::scheduler::Executor
 
     faabric::util::MemoryRegion dummyMemory = nullptr;
     size_t dummyMemorySize = TEST_EXECUTOR_DEFAULT_MEMORY_SIZE;
+    size_t maxMemorySize = 0;
 
     void reset(faabric::Message& msg) override;
 
@@ -386,6 +387,8 @@ class TestExecutor final : public faabric::scheduler::Executor
     std::span<uint8_t> getMemoryView() override;
 
     void setUpDummyMemory(size_t memSize);
+
+    size_t getMaxMemorySize() override;
 
     int32_t executeTask(
       int threadPoolIdx,


### PR DESCRIPTION
When an `Executor` executes threads, it creates the main thread snapshot on the fly if necessary. Previously it wasn't setting a max size, so was failing when applying diffs that were larger than the original snapshot size.