### PR TITLE
Return argv for message as a vector of char pointers

### DIFF
--- a/include/faabric/util/func.h
+++ b/include/faabric/util/func.h
@@ -46,6 +46,8 @@ std::vector<uint8_t> messageToBytes(const faabric::Message& msg);
 
 std::vector<std::string> getArgvForMessage(const faabric::Message& msg);
 
+std::vector<char*> getCStyleArgvForMessage(const faabric::Message& msg);
+
 /*
  * Gets the key for the main thread snapshot for the given message. Result will
  * be the same on all hosts.

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -9,8 +9,6 @@
 #include <faabric/util/gids.h>
 #include <faabric/util/random.h>
 
-#include <faabric/util/logging.h>
-
 namespace faabric::util {
 
 std::vector<uint8_t> messageToBytes(const faabric::Message& msg)

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -9,6 +9,8 @@
 #include <faabric/util/gids.h>
 #include <faabric/util/random.h>
 
+#include <faabric/util/logging.h>
+
 namespace faabric::util {
 
 std::vector<uint8_t> messageToBytes(const faabric::Message& msg)
@@ -172,6 +174,21 @@ std::vector<std::string> getArgvForMessage(const faabric::Message& msg)
     argv.insert(argv.end(), extraArgs.begin(), extraArgs.end());
 
     return argv;
+}
+
+std::vector<char*> getCStyleArgvForMessage(const faabric::Message& msg)
+{
+    // Get vector-style argv
+    std::vector<std::string> argv = getArgvForMessage(msg);
+
+    // Convert to vector of char pointers
+    std::vector<char*> cArgv;
+    cArgv.resize(argv.size());
+    for (int i = 0; i < argv.size(); i++) {
+        cArgv.at(i) = const_cast<char*>(argv.at(i).c_str());
+    }
+
+    return cArgv;
 }
 
 std::string getMainThreadSnapshotKey(const faabric::Message& msg)

--- a/tests/test/util/test_func.cpp
+++ b/tests/test/util/test_func.cpp
@@ -169,4 +169,29 @@ TEST_CASE("Test creating async response")
 
     REQUIRE(expected == actual);
 }
+
+TEST_CASE("Test getting argv from message")
+{
+    faabric::Message msg = faabric::util::messageFactory("foo", "bar");
+    msg.set_cmdline("foo bar baz");
+    std::vector<std::string> expected = {
+        "function.wasm", "foo", "bar", "baz"
+    };
+
+    SECTION("Regular argv")
+    {
+        REQUIRE(expected == faabric::util::getArgvForMessage(msg));
+    }
+
+    SECTION("C-Style argv")
+    {
+        std::vector<char*> actualCStyle =
+          faabric::util::getCStyleArgvForMessage(msg);
+        for (int i = 0; i < expected.size(); i++) {
+            // Catch2 does not like comparing char*, so we cast the actual
+            // result to a string.
+            REQUIRE(std::string(actualCStyle.at(i)) == expected.at(i));
+        }
+    }
+}
 }


### PR DESCRIPTION
In this PR I add a utility function to return the argv for a message in a vector of `char*` instead of `std::string`.

This is convinient to serialise the whole thing as a `char**` and send it to the enclave as a byte array.