### PR TITLE
Reintroduce diffs as part of snapshot result

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -171,11 +171,6 @@ class Scheduler
                          const std::string& key,
                          const std::vector<faabric::util::SnapshotDiff>& diffs);
 
-    void pushSnapshotDiffs(
-      const faabric::Message& msg,
-      const std::string& snapshotKey,
-      const std::vector<faabric::util::SnapshotDiff>& diffs);
-
     void setThreadResultLocally(uint32_t msgId, int32_t returnValue);
 
     std::vector<std::pair<uint32_t, int32_t>> awaitThreadResults(

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -166,12 +166,10 @@ class Scheduler
 
     faabric::Message getFunctionResult(unsigned int messageId, int timeout);
 
-    void setThreadResult(const faabric::Message& msg, int32_t returnValue);
-
-    void setThreadResultWithDiffs(
-      const faabric::Message& msg,
-      int32_t returnValue,
-      const std::vector<faabric::util::SnapshotDiff>& diffs);
+    void setThreadResult(const faabric::Message& msg,
+                         int32_t returnValue,
+                         const std::string& key,
+                         const std::vector<faabric::util::SnapshotDiff>& diffs);
 
     void pushSnapshotDiffs(
       const faabric::Message& msg,
@@ -265,7 +263,7 @@ class Scheduler
       executors;
 
     // ---- Threads ----
-    faabric::snapshot::SnapshotRegistry &reg;
+    faabric::snapshot::SnapshotRegistry& reg;
 
     std::unordered_map<uint32_t, std::promise<int32_t>> threadResults;
 

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -168,6 +168,11 @@ class Scheduler
 
     void setThreadResult(const faabric::Message& msg, int32_t returnValue);
 
+    void setThreadResultWithDiffs(
+      const faabric::Message& msg,
+      int32_t returnValue,
+      const std::vector<faabric::util::SnapshotDiff>& diffs);
+
     void pushSnapshotDiffs(
       const faabric::Message& msg,
       const std::string& snapshotKey,
@@ -260,6 +265,8 @@ class Scheduler
       executors;
 
     // ---- Threads ----
+    faabric::snapshot::SnapshotRegistry &reg;
+
     std::unordered_map<uint32_t, std::promise<int32_t>> threadResults;
 
     std::unordered_map<uint32_t,

--- a/include/faabric/snapshot/SnapshotApi.h
+++ b/include/faabric/snapshot/SnapshotApi.h
@@ -5,7 +5,7 @@ enum SnapshotCalls
 {
     NoSnapshotCall = 0,
     PushSnapshot = 1,
-    PushSnapshotDiffs = 2,
+    PushSnapshotUpdate = 2,
     DeleteSnapshot = 3,
     ThreadResult = 4,
 };

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -53,7 +53,7 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
       uint32_t messageId,
       int returnValue,
       const std::string &key,
-      std::vector<faabric::util::SnapshotDiff>& diffs);
+      const std::vector<faabric::util::SnapshotDiff>& diffs);
 
   private:
     void sendHeader(faabric::snapshot::SnapshotCalls call);

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -43,10 +43,6 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
       const std::shared_ptr<faabric::util::SnapshotData>& data,
       const std::vector<faabric::util::SnapshotDiff>& diffs);
 
-    void pushSnapshotDiffs(
-      std::string snapshotKey,
-      const std::vector<faabric::util::SnapshotDiff>& diffs);
-
     void deleteSnapshot(const std::string& key);
 
     void pushThreadResult(

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -48,7 +48,7 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
     void pushThreadResult(
       uint32_t messageId,
       int returnValue,
-      const std::string &key,
+      const std::string& key,
       const std::vector<faabric::util::SnapshotDiff>& diffs);
 
   private:

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -12,6 +12,14 @@ namespace faabric::snapshot {
 // Mocking
 // -----------------------------------
 
+struct MockThreadResult
+{
+    uint32_t msgId = 0;
+    int res = 0;
+    std::string key;
+    std::vector<faabric::util::SnapshotDiff> diffs;
+};
+
 std::vector<
   std::pair<std::string, std::shared_ptr<faabric::util::SnapshotData>>>
 getSnapshotPushes();
@@ -21,8 +29,7 @@ getSnapshotDiffPushes();
 
 std::vector<std::pair<std::string, std::string>> getSnapshotDeletes();
 
-std::vector<std::pair<std::string, std::pair<uint32_t, int>>>
-getThreadResults();
+std::vector<std::pair<std::string, MockThreadResult>> getThreadResults();
 
 void clearMockSnapshotRequests();
 

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -49,7 +49,11 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
 
     void deleteSnapshot(const std::string& key);
 
-    void pushThreadResult(uint32_t messageId, int returnValue);
+    void pushThreadResult(
+      uint32_t messageId,
+      int returnValue,
+      const std::string &key,
+      std::vector<faabric::util::SnapshotDiff>& diffs);
 
   private:
     void sendHeader(faabric::snapshot::SnapshotCalls call);

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -60,10 +60,5 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
 
   private:
     void sendHeader(faabric::snapshot::SnapshotCalls call);
-
-    void doPushSnapshotDiffs(
-      const std::string& snapshotKey,
-      const std::shared_ptr<faabric::util::SnapshotData>& data,
-      const std::vector<faabric::util::SnapshotDiff>& diffs);
 };
 }

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -26,7 +26,7 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
       const uint8_t* buffer,
       size_t bufferSize);
 
-    std::unique_ptr<google::protobuf::Message> recvPushSnapshotDiffs(
+    std::unique_ptr<google::protobuf::Message> recvPushSnapshotUpdate(
       const uint8_t* buffer,
       size_t bufferSize);
 

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -32,7 +32,9 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
 
     void recvDeleteSnapshot(const uint8_t* buffer, size_t bufferSize);
 
-    void recvThreadResult(const uint8_t* buffer, size_t bufferSize);
+    std::unique_ptr<google::protobuf::Message> recvThreadResult(
+      const uint8_t* buffer,
+      size_t bufferSize);
 
   private:
     faabric::transport::PointToPointBroker& broker;

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -36,5 +36,6 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
 
   private:
     faabric::transport::PointToPointBroker& broker;
+    faabric::snapshot::SnapshotRegistry& reg;
 };
 }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -242,7 +242,7 @@ class SnapshotData
 
     size_t getQueuedDiffsCount();
 
-    void queueDiffs(const std::vector<SnapshotDiff> &diffs);
+    void queueDiffs(const std::vector<SnapshotDiff>& diffs);
 
     int writeQueuedDiffs();
 

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -242,7 +242,7 @@ class SnapshotData
 
     size_t getQueuedDiffsCount();
 
-    void queueDiffs(std::span<SnapshotDiff> diffs);
+    void queueDiffs(const std::vector<SnapshotDiff> &diffs);
 
     int writeQueuedDiffs();
 

--- a/src/flat/faabric.fbs
+++ b/src/flat/faabric.fbs
@@ -23,9 +23,8 @@ table SnapshotDiffRequest {
   data:[ubyte];
 }
 
-table SnapshotDiffPushRequest {
+table SnapshotUpdateRequest {
   key:string;
-  force:bool;
   merge_regions:[SnapshotMergeRegionRequest];
   diffs:[SnapshotDiffRequest];
 }

--- a/src/flat/faabric.fbs
+++ b/src/flat/faabric.fbs
@@ -33,4 +33,6 @@ table SnapshotDiffPushRequest {
 table ThreadResultRequest {
   message_id:int;
   return_value:int;
+  key:string;
+  diffs:[SnapshotDiffRequest];
 }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -531,7 +531,8 @@ void Executor::threadPoolThread(int threadPoolIdx)
                 dirtyRegions.clear();
             }
 
-            // If last in batch on this host, clear the merge regions
+            // If last in batch on this host, clear the merge regions (only
+            // needed for doing the diffing on the current host)
             SPDLOG_DEBUG("Clearing merge regions for {}", mainThreadSnapKey);
             snap->clearMergeRegions();
         }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -426,7 +426,6 @@ void Executor::threadPoolThread(int threadPoolIdx)
               faabric::transport::PointToPointGroup::getGroup(msg.groupid());
         }
 
-        bool isMaster = msg.masterhost() == conf.endpointHost;
         SPDLOG_TRACE("Thread {}:{} executing task {} ({}, thread={}, group={})",
                      id,
                      threadPoolIdx,

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -505,6 +505,9 @@ void Executor::threadPoolThread(int threadPoolIdx)
                      oldTaskCount - 1);
 
         // Handle last-in-batch dirty tracking
+        std::string mainThreadSnapKey =
+          faabric::util::getMainThreadSnapshotKey(msg);
+        std::vector<faabric::util::SnapshotDiff> diffs;
         if (isLastInBatch && doDirtyTracking) {
             // Stop non-thread-local tracking as we're the last in the batch
             std::span<uint8_t> memView = getMemoryView();
@@ -518,37 +521,15 @@ void Executor::threadPoolThread(int threadPoolIdx)
             }
 
             // Fill snapshot gaps with overwrite regions first
-            std::string mainThreadSnapKey =
-              faabric::util::getMainThreadSnapshotKey(msg);
             auto snap = reg.getSnapshot(mainThreadSnapKey);
             snap->fillGapsWithBytewiseRegions();
 
             // Compare snapshot with all dirty regions for this executor
-            std::vector<faabric::util::SnapshotDiff> diffs;
             {
                 // Do the diffing
                 faabric::util::FullLock lock(threadExecutionMutex);
                 diffs = snap->diffWithDirtyRegions(memView, dirtyRegions);
                 dirtyRegions.clear();
-            }
-
-            if (diffs.empty()) {
-                SPDLOG_DEBUG("No diffs for {}", mainThreadSnapKey);
-            } else {
-                // On master we queue the diffs locally directly, on a remote
-                // host we push them back to master
-                if (isMaster) {
-                    SPDLOG_DEBUG(
-                      "Queueing {} diffs for {} to snapshot {} (group {})",
-                      diffs.size(),
-                      faabric::util::funcToString(msg, false),
-                      mainThreadSnapKey,
-                      msg.groupid());
-
-                    snap->queueDiffs(diffs);
-                } else if (isLastInBatch) {
-                    sch.pushSnapshotDiffs(msg, mainThreadSnapKey, diffs);
-                }
             }
 
             // If last in batch on this host, clear the merge regions
@@ -612,7 +593,12 @@ void Executor::threadPoolThread(int threadPoolIdx)
         // not be reused for a repeat invocation.
         if (isThreads) {
             // Set non-final thread result
-            sch.setThreadResult(msg, returnValue);
+            if (isLastInBatch) {
+                // Include diffs if this is the last one
+                sch.setThreadResult(msg, returnValue, mainThreadSnapKey, diffs);
+            } else {
+                sch.setThreadResult(msg, returnValue, "", {});
+            }
         } else {
             // Set normal function result
             sch.setFunctionResult(msg);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1023,6 +1023,7 @@ void Scheduler::registerThread(uint32_t msgId)
 void Scheduler::setThreadResult(
   const faabric::Message& msg,
   int32_t returnValue,
+  const std::string& key,
   const std::vector<faabric::util::SnapshotDiff>& diffs)
 {
     bool isMaster = msg.masterhost() == conf.endpointHost;

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1028,15 +1028,15 @@ void Scheduler::setThreadResult(
 {
     bool isMaster = msg.masterhost() == conf.endpointHost;
     if (isMaster) {
-        // On master we queue the diffs locally directly, on a remote
-        // host we push them back to master
-        SPDLOG_DEBUG("Queueing {} diffs for {} to snapshot {} (group {})",
-                     diffs.size(),
-                     faabric::util::funcToString(msg, false),
-                     key,
-                     msg.groupid());
-
         if (!diffs.empty()) {
+            // On master we queue the diffs locally directly, on a remote
+            // host we push them back to master
+            SPDLOG_DEBUG("Queueing {} diffs for {} to snapshot {} (group {})",
+                         diffs.size(),
+                         faabric::util::funcToString(msg, false),
+                         key,
+                         msg.groupid());
+
             auto snap = reg.getSnapshot(key);
             snap->queueDiffs(diffs);
         }

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1053,28 +1053,6 @@ void Scheduler::setThreadResult(
     }
 }
 
-void Scheduler::pushSnapshotDiffs(
-  const faabric::Message& msg,
-  const std::string& snapshotKey,
-  const std::vector<faabric::util::SnapshotDiff>& diffs)
-{
-    if (diffs.empty()) {
-        return;
-    }
-
-    bool isMaster = msg.masterhost() == conf.endpointHost;
-
-    if (isMaster) {
-        SPDLOG_ERROR("{} pushing snapshot diffs for {} on master",
-                     faabric::util::funcToString(msg, false),
-                     snapshotKey);
-        throw std::runtime_error("Cannot push snapshot diffs on master");
-    }
-
-    SnapshotClient& c = getSnapshotClient(msg.masterhost());
-    c.pushSnapshotDiffs(snapshotKey, diffs);
-}
-
 void Scheduler::setThreadResultLocally(uint32_t msgId, int32_t returnValue)
 {
     faabric::util::FullLock lock(mx);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1026,9 +1026,6 @@ void Scheduler::setThreadResult(
   const std::string& key,
   const std::vector<faabric::util::SnapshotDiff>& diffs)
 {
-    std::string mainThreadSnapKey =
-      faabric::util::getMainThreadSnapshotKey(msg);
-
     bool isMaster = msg.masterhost() == conf.endpointHost;
     if (isMaster) {
         // On master we queue the diffs locally directly, on a remote
@@ -1036,11 +1033,11 @@ void Scheduler::setThreadResult(
         SPDLOG_DEBUG("Queueing {} diffs for {} to snapshot {} (group {})",
                      diffs.size(),
                      faabric::util::funcToString(msg, false),
-                     mainThreadSnapKey,
+                     key,
                      msg.groupid());
 
         if (!diffs.empty()) {
-            auto snap = reg.getSnapshot(mainThreadSnapKey);
+            auto snap = reg.getSnapshot(key);
             snap->queueDiffs(diffs);
         }
 
@@ -1049,7 +1046,7 @@ void Scheduler::setThreadResult(
     } else {
         // Push thread result and diffs together
         SnapshotClient& c = getSnapshotClient(msg.masterhost());
-        c.pushThreadResult(msg.id(), returnValue, mainThreadSnapKey, diffs);
+        c.pushThreadResult(msg.id(), returnValue, key, diffs);
     }
 }
 

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -220,7 +220,7 @@ void SnapshotClient::pushThreadResult(
   uint32_t messageId,
   int returnValue,
   const std::string& key,
-  std::vector<faabric::util::SnapshotDiff>& diffs)
+  const std::vector<faabric::util::SnapshotDiff>& diffs)
 {
     if (faabric::util::isMockMode()) {
         faabric::util::UniqueLock lock(mockMutex);

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -229,7 +229,7 @@ void SnapshotClient::pushThreadResult(
           mb, messageId, returnValue, keyOffset, diffsOffset);
 
         mb.Finish(requestOffset);
-        SEND_FB_MSG_ASYNC(SnapshotCalls::ThreadResult, mb)
+        SEND_FB_MSG(SnapshotCalls::ThreadResult, mb);
     }
 }
 }

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -24,8 +24,7 @@ static std::vector<
 
 static std::vector<std::pair<std::string, std::string>> snapshotDeletes;
 
-static std::vector<std::pair<std::string, std::pair<uint32_t, int>>>
-  threadResults;
+static std::vector<std::pair<std::string, MockThreadResult>> threadResults;
 
 std::vector<
   std::pair<std::string, std::shared_ptr<faabric::util::SnapshotData>>>
@@ -48,7 +47,7 @@ std::vector<std::pair<std::string, std::string>> getSnapshotDeletes()
     return snapshotDeletes;
 }
 
-std::vector<std::pair<std::string, std::pair<uint32_t, int>>> getThreadResults()
+std::vector<std::pair<std::string, MockThreadResult>> getThreadResults()
 {
     faabric::util::UniqueLock lock(mockMutex);
     return threadResults;
@@ -196,8 +195,10 @@ void SnapshotClient::pushThreadResult(
 {
     if (faabric::util::isMockMode()) {
         faabric::util::UniqueLock lock(mockMutex);
-        threadResults.emplace_back(
-          std::make_pair(host, std::make_pair(messageId, returnValue)));
+        MockThreadResult mockResult{
+            .msgId = messageId, .res = returnValue, .key = key, .diffs = diffs
+        };
+        threadResults.emplace_back(std::make_pair(host, mockResult));
 
     } else {
         flatbuffers::FlatBufferBuilder mb;

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -164,7 +164,7 @@ void SnapshotClient::pushSnapshotUpdate(
 
         mb.Finish(requestOffset);
 
-        SEND_FB_MSG(SnapshotCalls::PushSnapshotDiffs, mb);
+        SEND_FB_MSG(SnapshotCalls::PushSnapshotUpdate, mb);
     }
 }
 

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -48,8 +48,8 @@ SnapshotServer::doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize)
         case faabric::snapshot::SnapshotCalls::PushSnapshot: {
             return recvPushSnapshot(buffer, bufferSize);
         }
-        case faabric::snapshot::SnapshotCalls::PushSnapshotDiffs: {
-            return recvPushSnapshotDiffs(buffer, bufferSize);
+        case faabric::snapshot::SnapshotCalls::PushSnapshotUpdate: {
+            return recvPushSnapshotUpdate(buffer, bufferSize);
         }
         case faabric::snapshot::SnapshotCalls::ThreadResult: {
             return recvThreadResult(buffer, bufferSize);
@@ -141,7 +141,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
 }
 
 std::unique_ptr<google::protobuf::Message>
-SnapshotServer::recvPushSnapshotDiffs(const uint8_t* buffer, size_t bufferSize)
+SnapshotServer::recvPushSnapshotUpdate(const uint8_t* buffer, size_t bufferSize)
 {
     const SnapshotUpdateRequest* r =
       flatbuffers::GetRoot<SnapshotUpdateRequest>(buffer);

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -252,16 +252,23 @@ void SnapshotData::fillGapsWithBytewiseRegions()
     // Sort merge regions to ensure loop below works
     std::sort(regionsCopy.begin(), regionsCopy.end());
 
+    // Iterate through the merge regions, adding regions that fill the gaps
+    // between them
     uint32_t lastRegionEnd = 0;
     for (const auto& r : regionsCopy) {
+        // This checks whether the very first byte is in a merge region
         if (r.offset == 0) {
-            // Zeroth byte is in a merge region
             lastRegionEnd = r.length;
             continue;
         }
 
-        uint32_t regionLen = r.offset - lastRegionEnd;
+        // This checks whether we have two adjacent regions
+        if (r.offset == lastRegionEnd) {
+            lastRegionEnd += r.length;
+            continue;
+        }
 
+        uint32_t regionLen = r.offset - lastRegionEnd;
         SPDLOG_TRACE("Filling gap with bytewise merge region {}-{}",
                      lastRegionEnd,
                      lastRegionEnd + regionLen);

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -319,7 +319,7 @@ size_t SnapshotData::getQueuedDiffsCount()
     return queuedDiffs.size();
 }
 
-void SnapshotData::queueDiffs(const std::span<SnapshotDiff> diffs)
+void SnapshotData::queueDiffs(const std::vector<SnapshotDiff> &diffs)
 {
     faabric::util::FullLock lock(snapMx);
     for (const auto& diff : diffs) {

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -319,8 +319,12 @@ size_t SnapshotData::getQueuedDiffsCount()
     return queuedDiffs.size();
 }
 
-void SnapshotData::queueDiffs(const std::vector<SnapshotDiff> &diffs)
+void SnapshotData::queueDiffs(const std::vector<SnapshotDiff>& diffs)
 {
+    if (diffs.empty()) {
+        return;
+    }
+
     faabric::util::FullLock lock(snapMx);
     for (const auto& diff : diffs) {
         queuedDiffs.emplace_back(std::move(diff));

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -862,7 +862,7 @@ TEST_CASE_METHOD(SlowExecutorFixture,
     std::string snapshotKey;
 
     // Set the thread result
-    sch.setThreadResult(msg, returnValue);
+    sch.setThreadResult(msg, returnValue, "", {});
 
     auto actualResults = faabric::snapshot::getThreadResults();
 

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -869,9 +869,11 @@ TEST_CASE_METHOD(SlowExecutorFixture,
     REQUIRE(actualResults.size() == 1);
     REQUIRE(actualResults.at(0).first == "otherHost");
 
-    auto actualPair = actualResults.at(0).second;
-    REQUIRE(actualPair.first == msg.id());
-    REQUIRE(actualPair.second == returnValue);
+    auto actualRes = actualResults.at(0).second;
+    REQUIRE(actualRes.msgId == msg.id());
+    REQUIRE(actualRes.res == returnValue);
+    REQUIRE(actualRes.key.empty());
+    REQUIRE(actualRes.diffs.empty());
 }
 
 TEST_CASE_METHOD(DummyExecutorFixture, "Test executor reuse", "[scheduler]")

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -281,16 +281,11 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     SnapshotDiff diffA2(
       SnapshotDataType::Int, SnapshotMergeOperation::Sum, offsetA2, intDataA2);
 
-    size_t originalDiffsApplied = snap->getQueuedDiffsCount();
-
     // Push diffs with result for a fake thread
     int msgId = 345;
     sch.registerThread(msgId);
     diffs = { diffA1, diffA2 };
     cli.pushThreadResult(msgId, 0, snapKey, diffs);
-
-    // Ensure the right number of diffs is applied
-    REQUIRE(snap->getQueuedDiffsCount() == originalDiffsApplied + 2);
 
     // Write and check diffs have been applied according to the merge operations
     snap->writeQueuedDiffs();

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -440,8 +440,8 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     sch.registerThread(threadIdA);
     sch.registerThread(threadIdB);
 
-    cli.pushThreadResult(threadIdA, returnValueA);
-    cli.pushThreadResult(threadIdB, returnValueB);
+    cli.pushThreadResult(threadIdA, returnValueA, "", {});
+    cli.pushThreadResult(threadIdB, returnValueB, "", {});
 
     // Set up two threads to await the results
     std::thread tA([threadIdA, returnValueA] {

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -144,7 +144,7 @@ void checkDiffsApplied(const uint8_t* snapBase, std::vector<SnapshotDiff> diffs)
 }
 
 TEST_CASE_METHOD(SnapshotClientServerFixture,
-                 "Test push snapshot diffs",
+                 "Test push snapshot updates",
                  "[snapshot]")
 {
     std::string thisHost = getSystemConfig().endpointHost;
@@ -174,7 +174,7 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
         otherSnap->addMergeRegion(m.offset, m.length, m.dataType, m.operation);
     }
 
-    // Set up some diffs for the initial request
+    // Set up some diffs for the initial update
     uint32_t offsetA1 = 5;
     uint32_t offsetA2 = 2 * HOST_PAGE_SIZE;
     std::vector<uint8_t> diffDataA1 = { 0, 1, 2, 3 };
@@ -192,9 +192,9 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
                         offsetA2,
                         diffDataA2);
 
+    // Push initial update
     std::vector<SnapshotDiff> diffsA = { diffA1, diffA2 };
-    cli.pushSnapshotDiffs(snapKey, diffsA);
-    REQUIRE(snap->getQueuedDiffsCount() == 2);
+    cli.pushSnapshotUpdate(snapKey, snap, diffsA);
 
     // Submit some more diffs, some larger than the original snapshot (to check
     // it gets extended)
@@ -223,40 +223,23 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
 
     std::vector<SnapshotDiff> diffsB = { diffB1, diffB2, diffB3 };
 
-    SECTION("Full update")
-    {
-        // Make the request
-        cli.pushSnapshotUpdate(snapKey, otherSnap, diffsB);
+    // Make the request
+    cli.pushSnapshotUpdate(snapKey, otherSnap, diffsB);
 
-        // Check nothing queued
-        REQUIRE(snap->getQueuedDiffsCount() == 0);
+    // Check nothing queued
+    REQUIRE(snap->getQueuedDiffsCount() == 0);
 
-        // Check merge regions from other snap pushed
-        REQUIRE(snap->getMergeRegions().size() == mergeRegions.size());
+    // Check merge regions from other snap pushed
+    REQUIRE(snap->getMergeRegions().size() == mergeRegions.size());
 
-        for (int i = 0; i < mergeRegions.size(); i++) {
-            SnapshotMergeRegion expected = mergeRegions.at(i);
-            SnapshotMergeRegion actual = snap->getMergeRegions()[i];
+    for (int i = 0; i < mergeRegions.size(); i++) {
+        SnapshotMergeRegion expected = mergeRegions.at(i);
+        SnapshotMergeRegion actual = snap->getMergeRegions()[i];
 
-            REQUIRE(actual.offset == expected.offset);
-            REQUIRE(actual.dataType == expected.dataType);
-            REQUIRE(actual.length == expected.length);
-            REQUIRE(actual.operation == expected.operation);
-        }
-    }
-
-    SECTION("Just diffs")
-    {
-        // Make the request
-        cli.pushSnapshotDiffs(snapKey, diffsB);
-
-        // Check and write queued diffs
-        REQUIRE(snap->getQueuedDiffsCount() == 5);
-
-        snap->writeQueuedDiffs();
-
-        // Check no merge regions sent
-        REQUIRE(snap->getMergeRegions().empty());
+        REQUIRE(actual.offset == expected.offset);
+        REQUIRE(actual.dataType == expected.dataType);
+        REQUIRE(actual.length == expected.length);
+        REQUIRE(actual.operation == expected.operation);
     }
 
     // Check diffs have been applied
@@ -300,8 +283,11 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
 
     size_t originalDiffsApplied = snap->getQueuedDiffsCount();
 
+    // Push diffs with result for a fake thread
+    int msgId = 345;
+    sch.registerThread(msgId);
     diffs = { diffA1, diffA2 };
-    cli.pushSnapshotDiffs(snapKey, diffs);
+    cli.pushThreadResult(msgId, 0, snapKey, diffs);
 
     // Ensure the right number of diffs is applied
     REQUIRE(snap->getQueuedDiffsCount() == originalDiffsApplied + 2);
@@ -316,7 +302,7 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
 }
 
 TEST_CASE_METHOD(SnapshotClientServerFixture,
-                 "Test snapshot diffs with merge ops",
+                 "Test applying snapshot diffs with merge ops",
                  "[snapshot]")
 {
     // Set up a snapshot
@@ -415,8 +401,11 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
 
     size_t originalDiffsApplied = snap->getQueuedDiffsCount();
 
+    // Push diffs for a fake thread
+    int msgId = 123;
+    sch.registerThread(msgId);
     std::vector<SnapshotDiff> diffs = { diff };
-    cli.pushSnapshotDiffs(snapKey, diffs);
+    cli.pushThreadResult(msgId, 0, snapKey, diffs);
 
     // Ensure the right number of diffs is applied
     REQUIRE(snap->getQueuedDiffsCount() == originalDiffsApplied + 1);

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -443,17 +443,18 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     cli.pushThreadResult(threadIdA, returnValueA, "", {});
     cli.pushThreadResult(threadIdB, returnValueB, "", {});
 
+    int rA = 0;
+    int rB = 0;
+
     // Set up two threads to await the results
-    std::thread tA([threadIdA, returnValueA] {
+    std::thread tA([&rA, threadIdA] {
         faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-        int32_t r = sch.awaitThreadResult(threadIdA);
-        assert(r == returnValueA);
+        rA = sch.awaitThreadResult(threadIdA);
     });
 
-    std::thread tB([threadIdB, returnValueB] {
+    std::thread tB([&rB, threadIdB] {
         faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-        int32_t r = sch.awaitThreadResult(threadIdB);
-        assert(r == returnValueB);
+        rB = sch.awaitThreadResult(threadIdB);
     });
 
     if (tA.joinable()) {
@@ -463,5 +464,8 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     if (tB.joinable()) {
         tB.join();
     }
+
+    REQUIRE(rA == returnValueA);
+    REQUIRE(rB == returnValueB);
 }
 }

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -1104,6 +1104,35 @@ void doFillGapsChecks(SnapshotMergeOperation op)
                                      SnapshotMergeOperation::Bytewise);
     }
 
+    SECTION("Adjacent regions")
+    {
+        snap->addMergeRegion(HOST_PAGE_SIZE,
+                             sizeof(int),
+                             SnapshotDataType::Int,
+                             SnapshotMergeOperation::Sum);
+
+        snap->addMergeRegion(HOST_PAGE_SIZE + sizeof(int),
+                             sizeof(int),
+                             SnapshotDataType::Int,
+                             SnapshotMergeOperation::Sum);
+
+        expectedRegions.emplace_back(
+          0, HOST_PAGE_SIZE, SnapshotDataType::Raw, op);
+
+        expectedRegions.emplace_back(HOST_PAGE_SIZE,
+                                     sizeof(int),
+                                     SnapshotDataType::Int,
+                                     SnapshotMergeOperation::Sum);
+
+        expectedRegions.emplace_back(HOST_PAGE_SIZE + sizeof(int),
+                                     sizeof(int),
+                                     SnapshotDataType::Int,
+                                     SnapshotMergeOperation::Sum);
+
+        expectedRegions.emplace_back(
+          HOST_PAGE_SIZE + 2 * sizeof(int), 0, SnapshotDataType::Raw, op);
+    }
+
     SECTION("Multiple regions")
     {
         // Deliberately add out of order


### PR DESCRIPTION
This primarily fixes a race condition, but also a bug with adjacent merge regions.

The race condition occurs when a remote thread result is received and acted upon _before_ the snapshot diffs from that thread have been applied. This exists because the result and diffs are done in two separate requests, and the server can sometimes process them out of order. The solution is to merge the diffs into the thread result (which is what we used to do but it got lost in one of the big reworkings of the snapshotting logic).

The bug with adjacent merge regions occurred in the process for "filling the gaps" between merge regions. If two merge regions were adjacent, we'd insert another one with zero length between them, rather than skipping it completely. Zero length merge regions are interpreted as running from their offset to the end of the snapshot, so this really messed things up. It's now fixed with a simple change to the loop in the "gap filling" function.