### PR TITLE
Fix for scheduling on overloaded hosts

### DIFF
--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -386,11 +386,13 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
               registeredHosts[funcStr];
 
             for (const auto& h : thisRegisteredHosts) {
-                // Work out resources on this host
+                // Work out resources on the remote host
                 faabric::HostResources r = getHostResources(h);
                 int available = r.slots() - r.usedslots();
 
-                // Floor this at zero and claim as many as we can
+                // We need to floor at zero here in case the remote host is
+                // overloaded, in which case its used slots will be greater than
+                // its available slots.
                 available = std::max<int>(0, available);
                 int nOnThisHost = std::min<int>(available, remainder);
 
@@ -430,11 +432,13 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
                     continue;
                 }
 
-                // Work out resources on this host
+                // Work out resources on the remote host
                 faabric::HostResources r = getHostResources(h);
                 int available = r.slots() - r.usedslots();
 
-                // Floor at zero
+                // We need to floor at zero here in case the remote host is
+                // overloaded, in which case its used slots will be greater than
+                // its available slots.
                 available = std::max<int>(0, available);
                 int nOnThisHost = std::min(available, remainder);
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -341,6 +341,8 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
     }
 
     std::vector<std::string> hosts;
+    hosts.reserve(nMessages);
+
     if (topologyHint == faabric::util::SchedulingTopologyHint::FORCE_LOCAL) {
         // We're forced to execute locally here so we do all the messages
         SPDLOG_TRACE("Scheduling {}/{} of {} locally (force local)",
@@ -387,7 +389,10 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
                 // Work out resources on this host
                 faabric::HostResources r = getHostResources(h);
                 int available = r.slots() - r.usedslots();
-                int nOnThisHost = std::min(available, remainder);
+
+                // Floor this at zero and claim as many as we can
+                available = std::max<int>(0, available);
+                int nOnThisHost = std::min<int>(available, remainder);
 
                 // Under the NEVER_ALONE topology hint, we never choose a host
                 // unless we can schedule at least two requests in it.
@@ -428,6 +433,9 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
                 // Work out resources on this host
                 faabric::HostResources r = getHostResources(h);
                 int available = r.slots() - r.usedslots();
+
+                // Floor at zero
+                available = std::max<int>(0, available);
                 int nOnThisHost = std::min(available, remainder);
 
                 if (topologyHint ==

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -486,7 +486,12 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
     }
 
     // Sanity check
-    assert(hosts.size() == nMessages);
+    if (hosts.size() != nMessages) {
+        SPDLOG_ERROR(
+          "Serious scheduling error: {} != {}", hosts.size(), nMessages);
+
+        throw std::runtime_error("Not enough scheduled hosts for messages");
+    }
 
     // Set up decision
     SchedulingDecision decision(firstMsg.appid(), firstMsg.groupid());

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -881,7 +881,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
     int nThreads = 5;
 
     // Set host resources to force execution on other host
-    setHostResources({ thisHost, otherHost }, { 2, 10 });
+    setHostResources({ thisHost, otherHost }, { 2, 10 }, { 0, 0 });
 
     // Set up message for a batch of threads
     std::shared_ptr<BatchExecuteRequest> req =
@@ -941,7 +941,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
     REQUIRE(expectedDiffs.size() == 2);
 
     // Reset host resources
-    setHostResources({ thisHost, otherHost }, { 2, 10 });
+    setHostResources({ thisHost, otherHost }, { 2, 10 }, { 0, 0 });
 
     // Set up another function, make sure they have the same app ID
     std::shared_ptr<BatchExecuteRequest> reqB =

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -112,16 +112,23 @@ class SchedulerTestFixture : public CachedDecisionTestFixture
     // Helper method to set the available hosts and slots per host prior to
     // making a scheduling decision
     void setHostResources(std::vector<std::string> hosts,
-                          std::vector<int> slotsPerHost)
+                          std::vector<int> slotsPerHost,
+                          std::vector<int> usedPerHost)
     {
-        assert(hosts.size() == slotsPerHost.size());
+        if (hosts.size() != slotsPerHost.size() ||
+            hosts.size() != usedPerHost.size()) {
+            SPDLOG_ERROR("Must provide one value for slots and used per host");
+            throw std::runtime_error(
+              "Not providing one value per slot and used per host");
+        }
+
         sch.clearRecordedMessages();
         faabric::scheduler::clearMockRequests();
 
         for (int i = 0; i < hosts.size(); i++) {
             faabric::HostResources resources;
             resources.set_slots(slotsPerHost.at(i));
-            resources.set_usedslots(0);
+            resources.set_usedslots(usedPerHost.at(i));
 
             sch.addHostToGlobalSet(hosts.at(i));
 


### PR DESCRIPTION
This fixes an issue where scheduling functions on remote hosts would break if those hosts were overloaded.