### PR TITLE
Zero-copy snapshot diffs

### DIFF
--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -15,12 +15,11 @@ class FunctionCallServer final
   private:
     Scheduler& scheduler;
 
-    void doAsyncRecv(int header,
-                     const uint8_t* buffer,
-                     size_t bufferSize) override;
+    void doAsyncRecv(int header, transport::Message&& message) override;
 
-    std::unique_ptr<google::protobuf::Message>
-    doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize) override;
+    std::unique_ptr<google::protobuf::Message> doSyncRecv(
+      int header,
+      transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> recvFlush(const uint8_t* buffer,
                                                          size_t bufferSize);

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -193,6 +193,10 @@ class Scheduler
 
     void deregisterThread(uint32_t msgId);
 
+    std::vector<uint32_t> getRegisteredThreads();
+
+    size_t getCachedMessageCount();
+
     void vacateSlot();
 
     void notifyExecutorShutdown(Executor* exec, const faabric::Message& msg);

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -189,6 +189,10 @@ class Scheduler
 
     void registerThread(uint32_t msgId);
 
+    void deregisterThreads(std::shared_ptr<faabric::BatchExecuteRequest> req);
+
+    void deregisterThread(uint32_t msgId);
+
     void vacateSlot();
 
     void notifyExecutorShutdown(Executor* exec, const faabric::Message& msg);

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -173,6 +173,15 @@ class Scheduler
 
     void setThreadResultLocally(uint32_t msgId, int32_t returnValue);
 
+    /**
+     * Caches a message along with the thread result, to allow the thread result
+     * to refer to data held in that message (i.e. snapshot diffs). The message
+     * will be destroyed once the thread result is consumed.
+     */
+    void setThreadResultLocally(uint32_t msgId,
+                                int32_t returnValue,
+                                faabric::transport::Message&& message);
+
     std::vector<std::pair<uint32_t, int32_t>> awaitThreadResults(
       std::shared_ptr<faabric::BatchExecuteRequest> req);
 
@@ -261,6 +270,8 @@ class Scheduler
     faabric::snapshot::SnapshotRegistry& reg;
 
     std::unordered_map<uint32_t, std::promise<int32_t>> threadResults;
+    std::unordered_map<uint32_t, faabric::transport::Message>
+      threadResultMessages;
 
     std::unordered_map<uint32_t,
                        std::promise<std::unique_ptr<faabric::Message>>>

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -32,7 +32,7 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     void recvDeleteSnapshot(const uint8_t* buffer, size_t bufferSize);
 
     std::unique_ptr<google::protobuf::Message> recvThreadResult(
-            faabric::transport::Message &&message);
+      faabric::transport::Message&& message);
 
   private:
     faabric::transport::PointToPointBroker& broker;

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -15,12 +15,11 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     SnapshotServer();
 
   protected:
-    void doAsyncRecv(int header,
-                     const uint8_t* buffer,
-                     size_t bufferSize) override;
+    void doAsyncRecv(int header, transport::Message&& message) override;
 
-    std::unique_ptr<google::protobuf::Message>
-    doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize) override;
+    std::unique_ptr<google::protobuf::Message> doSyncRecv(
+      int header,
+      transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> recvPushSnapshot(
       const uint8_t* buffer,

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -32,8 +32,7 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     void recvDeleteSnapshot(const uint8_t* buffer, size_t bufferSize);
 
     std::unique_ptr<google::protobuf::Message> recvThreadResult(
-      const uint8_t* buffer,
-      size_t bufferSize);
+            faabric::transport::Message &&message);
 
   private:
     faabric::transport::PointToPointBroker& broker;

--- a/include/faabric/state/StateServer.h
+++ b/include/faabric/state/StateServer.h
@@ -15,12 +15,11 @@ class StateServer final : public faabric::transport::MessageEndpointServer
 
     void logOperation(const std::string& op);
 
-    void doAsyncRecv(int header,
-                     const uint8_t* buffer,
-                     size_t bufferSize) override;
+    void doAsyncRecv(int header, transport::Message&& message) override;
 
-    std::unique_ptr<google::protobuf::Message>
-    doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize) override;
+    std::unique_ptr<google::protobuf::Message> doSyncRecv(
+      int header,
+      transport::Message&& message) override;
 
     // Sync methods
 

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -6,7 +6,7 @@
 namespace faabric::transport {
 
 /**
- * Types of message failures
+ * Types of message send/ receive outcomes.
  */
 enum MessageResponseCode
 {

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -8,7 +8,8 @@ namespace faabric::transport {
 /**
  * Types of message failures
  */
-enum MessageFailCode {
+enum MessageResponseCode
+{
     SUCCESS,
     TERM,
     TIMEOUT,
@@ -36,13 +37,11 @@ class Message
 
     explicit Message(Message&& other) noexcept;
 
-    explicit Message(MessageFailCode failCodeIn);
+    explicit Message(MessageResponseCode failCodeIn);
 
     Message& operator=(Message&&);
 
-    MessageFailCode getFailCode() {
-        return failCode;
-    }
+    MessageResponseCode getResponseCode() { return failCode; }
 
     char* data();
 
@@ -59,6 +58,6 @@ class Message
 
     bool _more = false;
 
-    MessageFailCode failCode = MessageFailCode::SUCCESS;
+    MessageResponseCode failCode = MessageResponseCode::SUCCESS;
 };
 }

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -25,8 +25,14 @@ class Message
 
     explicit Message(Message&& other) noexcept;
 
-    // Empty message signals shutdown
+    Message& operator=(Message&&);
+
+    /**
+     * Empty messages imply a failure or shutdown request
+     */
     Message() = default;
+
+    bool empty();
 
     char* data();
 

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -4,6 +4,17 @@
 #include <zmq.hpp>
 
 namespace faabric::transport {
+
+/**
+ * Types of message failures
+ */
+enum MessageFailCode {
+    SUCCESS,
+    TERM,
+    TIMEOUT,
+    ERROR
+};
+
 /**
  * Represents message data passed around the transport layer. Essentially an
  * array of bytes, with a size and a flag to say whether there's more data to
@@ -25,14 +36,13 @@ class Message
 
     explicit Message(Message&& other) noexcept;
 
+    explicit Message(MessageFailCode failCodeIn);
+
     Message& operator=(Message&&);
 
-    /**
-     * Empty messages imply a failure or shutdown request
-     */
-    Message() = default;
-
-    bool empty();
+    MessageFailCode getFailCode() {
+        return failCode;
+    }
 
     char* data();
 
@@ -48,5 +58,7 @@ class Message
     zmq::message_t msg;
 
     bool _more = false;
+
+    MessageFailCode failCode = MessageFailCode::SUCCESS;
 };
 }

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -23,6 +23,8 @@ class Message
      */
     explicit Message(zmq::message_t&& msgIn);
 
+    explicit Message(Message&& other) noexcept;
+
     // Empty message signals shutdown
     Message() = default;
 

--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -63,11 +63,11 @@ class MessageEndpoint
                 size_t dataSize,
                 bool more);
 
-    std::optional<Message> doRecv(zmq::socket_t& socket, int size = 0);
+    Message doRecv(zmq::socket_t& socket, int size = 0);
 
-    std::optional<Message> recvBuffer(zmq::socket_t& socket, int size);
+    Message recvBuffer(zmq::socket_t& socket, int size);
 
-    std::optional<Message> recvNoBuffer(zmq::socket_t& socket);
+    Message recvNoBuffer(zmq::socket_t& socket);
 };
 
 class AsyncSendMessageEndpoint final : public MessageEndpoint
@@ -132,7 +132,7 @@ class RecvMessageEndpoint : public MessageEndpoint
 
     virtual ~RecvMessageEndpoint(){};
 
-    virtual std::optional<Message> recv(int size = 0);
+    virtual Message recv(int size = 0);
 
     zmq::socket_t socket;
 };
@@ -192,7 +192,7 @@ class AsyncRecvMessageEndpoint final : public RecvMessageEndpoint
     AsyncRecvMessageEndpoint(int portIn,
                              int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    std::optional<Message> recv(int size = 0) override;
+    Message recv(int size = 0) override;
 };
 
 class AsyncInternalRecvMessageEndpoint final : public RecvMessageEndpoint
@@ -201,7 +201,7 @@ class AsyncInternalRecvMessageEndpoint final : public RecvMessageEndpoint
     AsyncInternalRecvMessageEndpoint(const std::string& inprocLabel,
                                      int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    std::optional<Message> recv(int size = 0) override;
+    Message recv(int size = 0) override;
 };
 
 class SyncRecvMessageEndpoint final : public RecvMessageEndpoint
@@ -213,7 +213,7 @@ class SyncRecvMessageEndpoint final : public RecvMessageEndpoint
     SyncRecvMessageEndpoint(int portIn,
                             int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    std::optional<Message> recv(int size = 0) override;
+    Message recv(int size = 0) override;
 
     void sendResponse(const uint8_t* data, int size);
 };
@@ -224,7 +224,7 @@ class AsyncDirectRecvEndpoint final : public RecvMessageEndpoint
     AsyncDirectRecvEndpoint(const std::string& inprocLabel,
                             int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    std::optional<Message> recv(int size = 0) override;
+    Message recv(int size = 0) override;
 };
 
 class AsyncDirectSendEndpoint final : public MessageEndpoint

--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -66,11 +66,10 @@ class MessageEndpointServer
 
   protected:
     virtual void doAsyncRecv(int header,
-                             const uint8_t* buffer,
-                             size_t bufferSize) = 0;
+            transport::Message &&message) = 0;
 
     virtual std::unique_ptr<google::protobuf::Message>
-    doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize) = 0;
+    doSyncRecv(int header, transport::Message &&message) = 0;
 
   private:
     friend class MessageEndpointServerHandler;

--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -65,11 +65,11 @@ class MessageEndpointServer
     int getNThreads();
 
   protected:
-    virtual void doAsyncRecv(int header,
-            transport::Message &&message) = 0;
+    virtual void doAsyncRecv(int header, transport::Message&& message) = 0;
 
-    virtual std::unique_ptr<google::protobuf::Message>
-    doSyncRecv(int header, transport::Message &&message) = 0;
+    virtual std::unique_ptr<google::protobuf::Message> doSyncRecv(
+      int header,
+      transport::Message&& message) = 0;
 
   private:
     friend class MessageEndpointServerHandler;

--- a/include/faabric/transport/PointToPointServer.h
+++ b/include/faabric/transport/PointToPointServer.h
@@ -13,12 +13,11 @@ class PointToPointServer final : public MessageEndpointServer
   private:
     PointToPointBroker& broker;
 
-    void doAsyncRecv(int header,
-                     const uint8_t* buffer,
-                     size_t bufferSize) override;
+    void doAsyncRecv(int header, transport::Message&& message) override;
 
-    std::unique_ptr<google::protobuf::Message>
-    doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize) override;
+    std::unique_ptr<google::protobuf::Message> doSyncRecv(
+      int header,
+      transport::Message&& message) override;
 
     void onWorkerStop() override;
 

--- a/include/faabric/transport/macros.h
+++ b/include/faabric/transport/macros.h
@@ -1,36 +1,36 @@
 #pragma once
 
 #define PARSE_MSG(T, data, size)                                               \
-    T msg;                                                                     \
-    if (!msg.ParseFromArray(data, size)) {                                     \
+    T parsedMsg;                                                               \
+    if (!parsedMsg.ParseFromArray(data, size)) {                               \
         throw std::runtime_error("Error deserialising message");               \
     }
 
-#define SERIALISE_MSG(msg)                                                     \
-    size_t msgSize = msg.ByteSizeLong();                                       \
-    uint8_t buffer[msgSize];                                                   \
-    if (!msg.SerializeToArray(buffer, msgSize)) {                              \
+#define SERIALISE_MSG(_msg)                                                    \
+    size_t serialisedSize = _msg.ByteSizeLong();                               \
+    uint8_t serialisedBuffer[serialisedSize];                                  \
+    if (!_msg.SerializeToArray(serialisedBuffer, serialisedSize)) {            \
         throw std::runtime_error("Error serialising message");                 \
     }
 
-#define SERIALISE_MSG_PTR(msg)                                                 \
-    size_t msgSize = msg->ByteSizeLong();                                      \
-    uint8_t buffer[msgSize];                                                   \
-    if (!msg->SerializeToArray(buffer, msgSize)) {                             \
+#define SERIALISE_MSG_PTR(_msg)                                                \
+    size_t serialisedSize = _msg->ByteSizeLong();                              \
+    uint8_t serialisedBuffer[serialisedSize];                                  \
+    if (!_msg->SerializeToArray(serialisedBuffer, serialisedSize)) {           \
         throw std::runtime_error("Error serialising message");                 \
     }
 
-#define SEND_FB_MSG(T, mb)                                                     \
+#define SEND_FB_MSG(T, _mb)                                                    \
     {                                                                          \
-        const uint8_t* buffer = mb.GetBufferPointer();                         \
-        int size = mb.GetSize();                                               \
-        faabric::EmptyResponse response;                                       \
-        syncSend(T, buffer, size, &response);                                  \
+        const uint8_t* _buffer = _mb.GetBufferPointer();                       \
+        int _size = _mb.GetSize();                                             \
+        faabric::EmptyResponse _response;                                      \
+        syncSend(T, _buffer, _size, &_response);                               \
     }
 
-#define SEND_FB_MSG_ASYNC(T, mb)                                               \
+#define SEND_FB_MSG_ASYNC(T, _mb)                                              \
     {                                                                          \
-        const uint8_t* buffer = mb.GetBufferPointer();                         \
-        int size = mb.GetSize();                                               \
-        asyncSend(T, buffer, size);                                            \
+        const uint8_t* _buffer = _mb.GetBufferPointer();                       \
+        int _size = _mb.GetSize();                                             \
+        asyncSend(T, _buffer, _size);                                          \
     }

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -57,19 +57,18 @@ enum SnapshotMergeOperation
  * Represents a modification to a snapshot (a.k.a. a dirty region). Specifies
  * the modified data, as well as its offset within the snapshot.
  *
- * Each diff does not own the data, it just provides a span pointing at the original
- * data.
+ * Each diff does not own the data, it just provides a span pointing at the
+ * original data.
  */
 class SnapshotDiff
 {
   public:
     SnapshotDiff() = default;
 
-    SnapshotDiff(
-      SnapshotDataType dataTypeIn,
-      SnapshotMergeOperation operationIn,
-      uint32_t offsetIn,
-      std::span<const uint8_t> dataIn);
+    SnapshotDiff(SnapshotDataType dataTypeIn,
+                 SnapshotMergeOperation operationIn,
+                 uint32_t offsetIn,
+                 std::span<const uint8_t> dataIn);
 
     SnapshotDataType getDataType() const { return dataType; }
 

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -91,6 +91,8 @@ class SnapshotDiff
 
     uint32_t getOffset() const { return offset; }
 
+    SnapshotDiffOwnership getOwnership() const { return ownership; }
+
     std::span<const uint8_t> getData() const { return data; }
 
     std::vector<uint8_t> getDataCopy() const;

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -21,17 +21,6 @@ namespace faabric::util {
 #define ARRAY_COMP_CHUNK_SIZE 128
 
 /**
- * Ownership modes for snapshot diffs. Because snapshot diffs often reference
- * large amounts of data, it's more efficient to avoid copying the data where
- * possible.
- */
-enum SnapshotDiffOwnership
-{
-    Owner,
-    NotOwner
-};
-
-/**
  * Defines the permitted datatypes for snapshot diffs. Each has a predefined
  * length, except for the raw option which is used for generic streams of bytes.
  */
@@ -68,9 +57,7 @@ enum SnapshotMergeOperation
  * Represents a modification to a snapshot (a.k.a. a dirty region). Specifies
  * the modified data, as well as its offset within the snapshot.
  *
- * Each diff either owns the data, or is a view on data it doesn't own. If it
- * owns the data, it copies data into a buffer whose lifecycle is the same as
- * the diff itself. If not, it just provides a span pointing at the original
+ * Each diff does not own the data, it just provides a span pointing at the original
  * data.
  */
 class SnapshotDiff
@@ -82,16 +69,13 @@ class SnapshotDiff
       SnapshotDataType dataTypeIn,
       SnapshotMergeOperation operationIn,
       uint32_t offsetIn,
-      std::span<const uint8_t> dataIn,
-      SnapshotDiffOwnership ownershipIn = SnapshotDiffOwnership::Owner);
+      std::span<const uint8_t> dataIn);
 
     SnapshotDataType getDataType() const { return dataType; }
 
     SnapshotMergeOperation getOperation() const { return operation; }
 
     uint32_t getOffset() const { return offset; }
-
-    SnapshotDiffOwnership getOwnership() const { return ownership; }
 
     std::span<const uint8_t> getData() const { return data; }
 
@@ -101,10 +85,8 @@ class SnapshotDiff
     SnapshotDataType dataType = SnapshotDataType::Raw;
     SnapshotMergeOperation operation = SnapshotMergeOperation::Bytewise;
     uint32_t offset = 0;
-    SnapshotDiffOwnership ownership = SnapshotDiffOwnership::Owner;
 
     std::span<const uint8_t> data;
-    std::vector<uint8_t> ownedData;
 };
 
 /*

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -269,6 +269,10 @@ class SnapshotData
 
     size_t getQueuedDiffsCount();
 
+    void applyDiffs(const std::vector<SnapshotDiff>& diffs);
+
+    void applyDiff(const SnapshotDiff& diff);
+
     void queueDiffs(const std::vector<SnapshotDiff>& diffs);
 
     int writeQueuedDiffs();

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -159,8 +159,7 @@ std::vector<std::pair<uint32_t, int32_t>> Executor::executeThreads(
             SPDLOG_DEBUG("Updating main thread snapshot for {} with {} diffs",
                          faabric::util::funcToString(msg, false),
                          updates.size());
-            snap->queueDiffs(updates);
-            snap->writeQueuedDiffs();
+            snap->applyDiffs(updates);
         }
 
         // Clear merge regions, not persisted between batches of threads
@@ -483,6 +482,8 @@ void Executor::threadPoolThread(int threadPoolIdx)
             auto thisThreadDirtyRegions =
               tracker->getThreadLocalDirtyPages(memView);
 
+            // TODO - remove this synchronisation point, some kind of
+            // append-only data structure?
             faabric::util::FullLock lock(threadExecutionMutex);
             faabric::util::mergeDirtyPages(dirtyRegions,
                                            thisThreadDirtyRegions);

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -196,6 +196,9 @@ std::vector<std::pair<uint32_t, int32_t>> Executor::executeThreads(
         tracker->startThreadLocalTracking(memView);
     }
 
+    // Deregister the threads
+    sch.deregisterThreads(req);
+
     return results;
 }
 

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -17,17 +17,15 @@ FunctionCallServer::FunctionCallServer()
   , scheduler(getScheduler())
 {}
 
-void FunctionCallServer::doAsyncRecv(int header,
-                                     const uint8_t* buffer,
-                                     size_t bufferSize)
+void FunctionCallServer::doAsyncRecv(int header, transport::Message&& message)
 {
     switch (header) {
         case faabric::scheduler::FunctionCalls::ExecuteFunctions: {
-            recvExecuteFunctions(buffer, bufferSize);
+            recvExecuteFunctions(message.udata(), message.size());
             break;
         }
         case faabric::scheduler::FunctionCalls::Unregister: {
-            recvUnregister(buffer, bufferSize);
+            recvUnregister(message.udata(), message.size());
             break;
         }
         default: {
@@ -39,18 +37,17 @@ void FunctionCallServer::doAsyncRecv(int header,
 
 std::unique_ptr<google::protobuf::Message> FunctionCallServer::doSyncRecv(
   int header,
-  const uint8_t* buffer,
-  size_t bufferSize)
+  transport::Message&& message)
 {
     switch (header) {
         case faabric::scheduler::FunctionCalls::Flush: {
-            return recvFlush(buffer, bufferSize);
+            return recvFlush(message.udata(), message.size());
         }
         case faabric::scheduler::FunctionCalls::GetResources: {
-            return recvGetResources(buffer, bufferSize);
+            return recvGetResources(message.udata(), message.size());
         }
         case faabric::scheduler::FunctionCalls::PendingMigrations: {
-            return recvPendingMigrations(buffer, bufferSize);
+            return recvPendingMigrations(message.udata(), message.size());
         }
         default: {
             throw std::runtime_error(

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -76,9 +76,9 @@ void FunctionCallServer::recvExecuteFunctions(const uint8_t* buffer,
 
     // This host has now been told to execute these functions no matter what
     // TODO - avoid this copy
-    msg.mutable_messages()->at(0).set_topologyhint("FORCE_LOCAL");
+    parsedMsg.mutable_messages()->at(0).set_topologyhint("FORCE_LOCAL");
     scheduler.callFunctions(
-      std::make_shared<faabric::BatchExecuteRequest>(msg));
+      std::make_shared<faabric::BatchExecuteRequest>(parsedMsg));
 }
 
 void FunctionCallServer::recvUnregister(const uint8_t* buffer,
@@ -86,11 +86,12 @@ void FunctionCallServer::recvUnregister(const uint8_t* buffer,
 {
     PARSE_MSG(faabric::UnregisterRequest, buffer, bufferSize)
 
-    std::string funcStr = faabric::util::funcToString(msg.function(), false);
-    SPDLOG_DEBUG("Unregistering host {} for {}", msg.host(), funcStr);
+    std::string funcStr =
+      faabric::util::funcToString(parsedMsg.function(), false);
+    SPDLOG_DEBUG("Unregistering host {} for {}", parsedMsg.host(), funcStr);
 
     // Remove the host from the warm set
-    scheduler.removeRegisteredHost(msg.host(), msg.function());
+    scheduler.removeRegisteredHost(parsedMsg.host(), parsedMsg.function());
 }
 
 std::unique_ptr<google::protobuf::Message> FunctionCallServer::recvGetResources(
@@ -108,7 +109,7 @@ FunctionCallServer::recvPendingMigrations(const uint8_t* buffer,
 {
     PARSE_MSG(faabric::PendingMigrations, buffer, bufferSize);
 
-    auto msgPtr = std::make_shared<faabric::PendingMigrations>(msg);
+    auto msgPtr = std::make_shared<faabric::PendingMigrations>(parsedMsg);
 
     scheduler.addPendingMigration(msgPtr);
 

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -89,7 +89,7 @@ faabric::MpiHostsToRanksMessage MpiWorld::recvMpiHostRankMsg()
     }
 
     SPDLOG_TRACE("Receiving MPI host ranks on {}", basePort);
-    faabric::transport::Message m = ranksRecvEndpoint->recv().value();
+    faabric::transport::Message m(std::move(ranksRecvEndpoint->recv().value()));
     PARSE_MSG(faabric::MpiHostsToRanksMessage, m.data(), m.size());
 
     return msg;

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -89,10 +89,10 @@ faabric::MpiHostsToRanksMessage MpiWorld::recvMpiHostRankMsg()
     }
 
     SPDLOG_TRACE("Receiving MPI host ranks on {}", basePort);
-    faabric::transport::Message m(std::move(ranksRecvEndpoint->recv().value()));
+    faabric::transport::Message m = ranksRecvEndpoint->recv();
     PARSE_MSG(faabric::MpiHostsToRanksMessage, m.data(), m.size());
 
-    return msg;
+    return parsedMsg;
 }
 
 void MpiWorld::sendMpiHostRankMsg(const std::string& hostIn,
@@ -112,7 +112,7 @@ void MpiWorld::sendMpiHostRankMsg(const std::string& hostIn,
 
     SPDLOG_TRACE("Sending MPI host ranks to {}:{}", hostIn, basePort);
     SERIALISE_MSG(msg)
-    ranksSendEndpoints[hostIn]->send(buffer, msgSize, false);
+    ranksSendEndpoints[hostIn]->send(serialisedBuffer, serialisedSize, false);
 }
 
 void MpiWorld::initRemoteMpiEndpoint(int localRank, int remoteRank)

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1135,6 +1135,25 @@ void Scheduler::deregisterThread(uint32_t msgId)
     threadResultMessages.erase(msgId);
 }
 
+std::vector<uint32_t> Scheduler::getRegisteredThreads()
+{
+    faabric::util::SharedLock lock(mx);
+
+    std::vector<uint32_t> registeredIds;
+    for (auto const& p : threadResults) {
+        registeredIds.push_back(p.first);
+    }
+
+    std::sort(registeredIds.begin(), registeredIds.end());
+
+    return registeredIds;
+}
+
+size_t Scheduler::getCachedMessageCount()
+{
+    return threadResultMessages.size();
+}
+
 faabric::Message Scheduler::getFunctionResult(unsigned int messageId,
                                               int timeoutMs)
 {

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1055,6 +1055,9 @@ void Scheduler::setThreadResult(
                          msg.groupid());
 
             auto snap = reg.getSnapshot(key);
+
+            // Ok not to take ownership of diffs data here, executor memory will
+            // outlast the need for the diffs
             snap->queueDiffs(diffs);
         }
 

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -25,13 +25,11 @@ SnapshotServer::SnapshotServer()
   , reg(faabric::snapshot::getSnapshotRegistry())
 {}
 
-void SnapshotServer::doAsyncRecv(int header,
-                                 const uint8_t* buffer,
-                                 size_t bufferSize)
+void SnapshotServer::doAsyncRecv(int header, transport::Message&& message)
 {
     switch (header) {
         case faabric::snapshot::SnapshotCalls::DeleteSnapshot: {
-            recvDeleteSnapshot(buffer, bufferSize);
+            recvDeleteSnapshot(message.udata(), message.size());
             break;
         }
         default: {
@@ -41,18 +39,19 @@ void SnapshotServer::doAsyncRecv(int header,
     }
 }
 
-std::unique_ptr<google::protobuf::Message>
-SnapshotServer::doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize)
+std::unique_ptr<google::protobuf::Message> SnapshotServer::doSyncRecv(
+  int header,
+  transport::Message&& message)
 {
     switch (header) {
         case faabric::snapshot::SnapshotCalls::PushSnapshot: {
-            return recvPushSnapshot(buffer, bufferSize);
+            return recvPushSnapshot(message.udata(), message.size());
         }
         case faabric::snapshot::SnapshotCalls::PushSnapshotUpdate: {
-            return recvPushSnapshotUpdate(buffer, bufferSize);
+            return recvPushSnapshotUpdate(message.udata(), message.size());
         }
         case faabric::snapshot::SnapshotCalls::ThreadResult: {
-            return recvThreadResult(buffer, bufferSize);
+            return recvThreadResult(message.udata(), message.size());
         }
         default: {
             throw std::runtime_error(

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -130,6 +130,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
         }
 
         // Queue on the snapshot
+        // TODO - take ownership of data here
         snap->queueDiffs(diffs);
     }
 
@@ -163,16 +164,13 @@ SnapshotServer::recvPushSnapshotUpdate(const uint8_t* buffer, size_t bufferSize)
           std::span<const uint8_t>(diff->data()->data(), diff->data()->size()));
     }
 
-    // Queue on the snapshot
-    snap->queueDiffs(diffs);
-
     // Write diffs and set merge regions
     SPDLOG_DEBUG("Writing queued diffs to snapshot {} ({} regions)",
                  r->key()->str(),
                  r->merge_regions()->size());
 
-    // Write queued diffs
-    snap->writeQueuedDiffs();
+    // Apply the diffs
+    snap->applyDiffs(diffs);
 
     // Clear merge regions
     snap->clearMergeRegions();

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -131,13 +131,13 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
         }
 
         // Queue on the snapshot
-        // TODO - make sure the message doesn't go out of scope
         snap->queueDiffs(diffs);
     }
 
     // Set the result locally
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.setThreadResultLocally(r->message_id(), r->return_value());
+    sch.setThreadResultLocally(
+      r->message_id(), r->return_value(), std::move(message));
 
     return std::make_unique<faabric::EmptyResponse>();
 }

--- a/src/state/StateServer.cpp
+++ b/src/state/StateServer.cpp
@@ -21,37 +21,36 @@ StateServer::StateServer(State& stateIn)
   , state(stateIn)
 {}
 
-void StateServer::doAsyncRecv(int header,
-                              const uint8_t* buffer,
-                              size_t bufferSize)
+void StateServer::doAsyncRecv(int header, transport::Message&& message)
 {
     throw std::runtime_error("State server does not support async recv");
 }
 
-std::unique_ptr<google::protobuf::Message>
-StateServer::doSyncRecv(int header, const uint8_t* buffer, size_t bufferSize)
+std::unique_ptr<google::protobuf::Message> StateServer::doSyncRecv(
+  int header,
+  transport::Message&& message)
 {
     switch (header) {
         case faabric::state::StateCalls::Pull: {
-            return recvPull(buffer, bufferSize);
+            return recvPull(message.udata(), message.size());
         }
         case faabric::state::StateCalls::Push: {
-            return recvPush(buffer, bufferSize);
+            return recvPush(message.udata(), message.size());
         }
         case faabric::state::StateCalls::Size: {
-            return recvSize(buffer, bufferSize);
+            return recvSize(message.udata(), message.size());
         }
         case faabric::state::StateCalls::Append: {
-            return recvAppend(buffer, bufferSize);
+            return recvAppend(message.udata(), message.size());
         }
         case faabric::state::StateCalls::ClearAppended: {
-            return recvClearAppended(buffer, bufferSize);
+            return recvClearAppended(message.udata(), message.size());
         }
         case faabric::state::StateCalls::PullAppended: {
-            return recvPullAppended(buffer, bufferSize);
+            return recvPullAppended(message.udata(), message.size());
         }
         case faabric::state::StateCalls::Delete: {
-            return recvDelete(buffer, bufferSize);
+            return recvDelete(message.udata(), message.size());
         }
         default: {
             throw std::runtime_error(

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -12,16 +12,14 @@ Message::Message(Message&& other) noexcept
   : Message(std::move(other.msg))
 {}
 
+Message::Message(MessageFailCode failCodeIn):failCode(failCodeIn) {
+}
+
 Message& Message::operator=(Message&& other)
 {
     msg.move(other.msg);
 
     return *this;
-}
-
-bool Message::empty()
-{
-    return msg.empty();
 }
 
 char* Message::data()

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -19,7 +19,8 @@ Message& Message::operator=(Message&& other)
     return *this;
 }
 
-bool Message::empty() {
+bool Message::empty()
+{
     return msg.empty();
 }
 

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -12,6 +12,17 @@ Message::Message(Message&& other) noexcept
   : Message(std::move(other.msg))
 {}
 
+Message& Message::operator=(Message&& other)
+{
+    msg.move(other.msg);
+
+    return *this;
+}
+
+bool Message::empty() {
+    return msg.empty();
+}
+
 char* Message::data()
 {
     return reinterpret_cast<char*>(msg.data());

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -12,8 +12,9 @@ Message::Message(Message&& other) noexcept
   : Message(std::move(other.msg))
 {}
 
-Message::Message(MessageFailCode failCodeIn):failCode(failCodeIn) {
-}
+Message::Message(MessageResponseCode failCodeIn)
+  : failCode(failCodeIn)
+{}
 
 Message& Message::operator=(Message&& other)
 {

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -8,6 +8,10 @@ Message::Message(zmq::message_t&& msgIn)
   , _more(msg.more())
 {}
 
+Message::Message(Message&& other) noexcept
+  : Message(std::move(other.msg))
+{}
+
 char* Message::data()
 {
     return reinterpret_cast<char*>(msg.data());

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -273,7 +273,7 @@ Message MessageEndpoint::recvBuffer(zmq::socket_t& socket, int size)
                            size,
                            timeoutMs,
                            address);
-              return Message(MessageFailCode::TIMEOUT);
+              return Message(MessageResponseCode::TIMEOUT);
           }
 
           if (res.has_value() && (res->size != res->untruncated_size)) {
@@ -286,7 +286,7 @@ Message MessageEndpoint::recvBuffer(zmq::socket_t& socket, int size)
       } catch (zmq::error_t& e) {
           if (e.num() == ZMQ_ETERM) {
               SPDLOG_WARN("Endpoint {} received ETERM on recv", address);
-              return Message(MessageFailCode::TERM);
+              return Message(MessageResponseCode::TERM);
           }
 
           throw;
@@ -307,12 +307,12 @@ Message MessageEndpoint::recvNoBuffer(zmq::socket_t& socket)
               SPDLOG_TRACE("Did not receive message within {}ms on {}",
                            timeoutMs,
                            address);
-              return Message(MessageFailCode::TIMEOUT);
+              return Message(MessageResponseCode::TIMEOUT);
           }
       } catch (zmq::error_t& e) {
           if (e.num() == ZMQ_ETERM) {
               SPDLOG_WARN("Endpoint {} received ETERM on recv", address);
-              return Message(MessageFailCode::TERM);
+              return Message(MessageResponseCode::TERM);
           }
           throw;
       },
@@ -400,9 +400,10 @@ Message SyncSendMessageEndpoint::sendAwaitResponse(const uint8_t* data,
     // Do the receive
     SPDLOG_TRACE("RECV (REQ) {}", address);
     auto msg = recvNoBuffer(reqSocket);
-    if (msg.getFailCode() != MessageFailCode::SUCCESS) {
-        SPDLOG_ERROR(
-          "Failed getting response on {}: code {}", address, msg.getFailCode());
+    if (msg.getResponseCode() != MessageResponseCode::SUCCESS) {
+        SPDLOG_ERROR("Failed getting response on {}: code {}",
+                     address,
+                     msg.getResponseCode());
         throw MessageTimeoutException("Error on waiting for response.");
     }
 

--- a/src/transport/MessageEndpointServer.cpp
+++ b/src/transport/MessageEndpointServer.cpp
@@ -73,8 +73,8 @@ void MessageEndpointServerHandler::start(
                     while (true) {
                         // Receive header and body
                         Message headerMessage = endpoint->recv();
-                        if (headerMessage.getFailCode() ==
-                            MessageFailCode::TIMEOUT) {
+                        if (headerMessage.getResponseCode() ==
+                            MessageResponseCode::TIMEOUT) {
                             SPDLOG_TRACE(
                               "Server on {}, looping after no message",
                               endpoint->getAddress());
@@ -108,11 +108,12 @@ void MessageEndpointServerHandler::start(
                         }
 
                         Message body = endpoint->recv();
-                        if (body.getFailCode() != MessageFailCode::SUCCESS) {
+                        if (body.getResponseCode() !=
+                            MessageResponseCode::SUCCESS) {
                             SPDLOG_ERROR("Server on port {}, got header, error "
                                          "on body: {}",
                                          endpoint->getAddress(),
-                                         body.getFailCode());
+                                         body.getResponseCode());
                             throw MessageTimeoutException(
                               "Server, got header, error on body");
                         }

--- a/src/transport/MessageEndpointServer.cpp
+++ b/src/transport/MessageEndpointServer.cpp
@@ -117,8 +117,7 @@ void MessageEndpointServerHandler::start(
                               "Server, got header, timed out on body");
                         }
 
-                        Message& body = bodyMaybe.value();
-                        if (body.more()) {
+                        if (bodyMaybe.value().more()) {
                             throw std::runtime_error(
                               "Body sent with SNDMORE flag");
                         }
@@ -129,13 +128,14 @@ void MessageEndpointServerHandler::start(
 
                         if (async) {
                             // Server-specific async handling
-                            server->doAsyncRecv(
-                              header, body.udata(), body.size());
+                            server->doAsyncRecv(header,
+                                                std::move(bodyMaybe.value()));
                         } else {
                             // Server-specific sync handling
                             std::unique_ptr<google::protobuf::Message> resp =
-                              server->doSyncRecv(
-                                header, body.udata(), body.size());
+                              server->doSyncRecv(header,
+                                                 std::move(bodyMaybe.value()));
+
                             size_t respSize = resp->ByteSizeLong();
 
                             uint8_t buffer[respSize];

--- a/src/transport/MpiMessageEndpoint.cpp
+++ b/src/transport/MpiMessageEndpoint.cpp
@@ -16,18 +16,17 @@ void MpiMessageEndpoint::sendMpiMessage(
   const std::shared_ptr<faabric::MPIMessage>& msg)
 {
     SERIALISE_MSG_PTR(msg)
-    sendSocket.send(buffer, msgSize, false);
+    sendSocket.send(serialisedBuffer, serialisedSize, false);
 }
 
 std::shared_ptr<faabric::MPIMessage> MpiMessageEndpoint::recvMpiMessage()
 {
-    std::optional<Message> mMaybe = recvSocket.recv();
-    if (!mMaybe.has_value()) {
+    Message msg = recvSocket.recv();
+    if (msg.empty()) {
         throw MessageTimeoutException("Mpi message timeout");
     }
-    Message& m = mMaybe.value();
-    PARSE_MSG(faabric::MPIMessage, m.data(), m.size());
+    PARSE_MSG(faabric::MPIMessage, msg.data(), msg.size());
 
-    return std::make_shared<faabric::MPIMessage>(msg);
+    return std::make_shared<faabric::MPIMessage>(parsedMsg);
 }
 }

--- a/src/transport/MpiMessageEndpoint.cpp
+++ b/src/transport/MpiMessageEndpoint.cpp
@@ -22,8 +22,8 @@ void MpiMessageEndpoint::sendMpiMessage(
 std::shared_ptr<faabric::MPIMessage> MpiMessageEndpoint::recvMpiMessage()
 {
     Message msg = recvSocket.recv();
-    if (msg.getFailCode() != MessageFailCode::SUCCESS) {
-        SPDLOG_ERROR("Error on MPI message: {}", msg.getFailCode());
+    if (msg.getResponseCode() != MessageResponseCode::SUCCESS) {
+        SPDLOG_ERROR("Error on MPI message: {}", msg.getResponseCode());
         throw MessageTimeoutException("Mpi message error");
     }
     PARSE_MSG(faabric::MPIMessage, msg.data(), msg.size());

--- a/src/transport/MpiMessageEndpoint.cpp
+++ b/src/transport/MpiMessageEndpoint.cpp
@@ -22,8 +22,9 @@ void MpiMessageEndpoint::sendMpiMessage(
 std::shared_ptr<faabric::MPIMessage> MpiMessageEndpoint::recvMpiMessage()
 {
     Message msg = recvSocket.recv();
-    if (msg.empty()) {
-        throw MessageTimeoutException("Mpi message timeout");
+    if (msg.getFailCode() != MessageFailCode::SUCCESS) {
+        SPDLOG_ERROR("Error on MPI message: {}", msg.getFailCode());
+        throw MessageTimeoutException("Mpi message error");
     }
     PARSE_MSG(faabric::MPIMessage, msg.data(), msg.size());
 

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -564,8 +564,7 @@ std::vector<uint8_t> PointToPointBroker::recvMessage(int groupId,
                      recvEndpoints[label]->getAddress());
     }
 
-    Message message =
-      recvEndpoints[label]->recv();
+    Message message = recvEndpoints[label]->recv();
 
     // TODO - possible to avoid this copy?
     return message.dataCopy();

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -564,11 +564,11 @@ std::vector<uint8_t> PointToPointBroker::recvMessage(int groupId,
                      recvEndpoints[label]->getAddress());
     }
 
-    std::optional<Message> messageDataMaybe =
-      recvEndpoints[label]->recv().value();
+    Message message =
+      recvEndpoints[label]->recv();
 
     // TODO - possible to avoid this copy?
-    return messageDataMaybe.value().dataCopy();
+    return message.dataCopy();
 }
 
 void PointToPointBroker::clearGroup(int groupId)

--- a/src/transport/PointToPointServer.cpp
+++ b/src/transport/PointToPointServer.cpp
@@ -27,11 +27,11 @@ void PointToPointServer::doAsyncRecv(int header, transport::Message&& message)
               faabric::PointToPointMessage, message.udata(), message.size())
 
             // Send the message locally to the downstream socket
-            broker.sendMessage(msg.groupid(),
-                               msg.sendidx(),
-                               msg.recvidx(),
-                               BYTES_CONST(msg.data().c_str()),
-                               msg.data().size());
+            broker.sendMessage(parsedMsg.groupid(),
+                               parsedMsg.sendidx(),
+                               parsedMsg.recvidx(),
+                               BYTES_CONST(parsedMsg.data().c_str()),
+                               parsedMsg.data().size());
             break;
         }
         case faabric::transport::PointToPointCall::LOCK_GROUP: {
@@ -79,7 +79,7 @@ std::unique_ptr<google::protobuf::Message> PointToPointServer::doRecvMappings(
     PARSE_MSG(faabric::PointToPointMappings, buffer, bufferSize)
 
     faabric::util::SchedulingDecision decision =
-      faabric::util::SchedulingDecision::fromPointToPointMappings(msg);
+      faabric::util::SchedulingDecision::fromPointToPointMappings(parsedMsg);
 
     SPDLOG_DEBUG("Receiving {} point-to-point mappings", decision.nFunctions);
 
@@ -94,11 +94,11 @@ void PointToPointServer::recvGroupLock(const uint8_t* buffer,
 {
     PARSE_MSG(faabric::PointToPointMessage, buffer, bufferSize)
     SPDLOG_TRACE("Receiving lock on {} for idx {} (recursive {})",
-                 msg.groupid(),
-                 msg.sendidx(),
+                 parsedMsg.groupid(),
+                 parsedMsg.sendidx(),
                  recursive);
 
-    PointToPointGroup::getGroup(msg.groupid())->lock(msg.sendidx(), recursive);
+    PointToPointGroup::getGroup(parsedMsg.groupid())->lock(parsedMsg.sendidx(), recursive);
 }
 
 void PointToPointServer::recvGroupUnlock(const uint8_t* buffer,
@@ -108,12 +108,12 @@ void PointToPointServer::recvGroupUnlock(const uint8_t* buffer,
     PARSE_MSG(faabric::PointToPointMessage, buffer, bufferSize)
 
     SPDLOG_TRACE("Receiving unlock on {} for idx {} (recursive {})",
-                 msg.groupid(),
-                 msg.sendidx(),
+                 parsedMsg.groupid(),
+                 parsedMsg.sendidx(),
                  recursive);
 
-    PointToPointGroup::getGroup(msg.groupid())
-      ->unlock(msg.sendidx(), recursive);
+    PointToPointGroup::getGroup(parsedMsg.groupid())
+      ->unlock(parsedMsg.sendidx(), recursive);
 }
 
 void PointToPointServer::onWorkerStop()

--- a/src/transport/PointToPointServer.cpp
+++ b/src/transport/PointToPointServer.cpp
@@ -98,7 +98,8 @@ void PointToPointServer::recvGroupLock(const uint8_t* buffer,
                  parsedMsg.sendidx(),
                  recursive);
 
-    PointToPointGroup::getGroup(parsedMsg.groupid())->lock(parsedMsg.sendidx(), recursive);
+    PointToPointGroup::getGroup(parsedMsg.groupid())
+      ->lock(parsedMsg.sendidx(), recursive);
 }
 
 void PointToPointServer::recvGroupUnlock(const uint8_t* buffer,

--- a/src/util/snapshot.cpp
+++ b/src/util/snapshot.cpp
@@ -326,6 +326,13 @@ size_t SnapshotData::getQueuedDiffsCount()
     return queuedDiffs.size();
 }
 
+void SnapshotData::applyDiffs(const std::vector<SnapshotDiff>& diffs)
+{
+    for (const auto& diff : diffs) {
+        applyDiff(diff);
+    }
+}
+
 void SnapshotData::queueDiffs(const std::vector<SnapshotDiff>& diffs)
 {
     if (diffs.empty()) {
@@ -348,98 +355,7 @@ int SnapshotData::writeQueuedDiffs()
     // Iterate through diffs
     int nDiffs = queuedDiffs.size();
     for (auto& diff : queuedDiffs) {
-        if (diff.getOperation() ==
-            faabric::util::SnapshotMergeOperation::Ignore) {
-
-            SPDLOG_TRACE("Ignoring region {}-{}",
-                         diff.getOffset(),
-                         diff.getOffset() + diff.getData().size());
-
-            continue;
-        }
-
-        if (diff.getOperation() ==
-            faabric::util::SnapshotMergeOperation::Bytewise) {
-            writeData(diff.getData(), diff.getOffset());
-            continue;
-        }
-
-        if (diff.getOperation() == faabric::util::SnapshotMergeOperation::XOR) {
-            xorData(diff.getData(), diff.getOffset());
-            continue;
-        }
-
-        uint8_t* copyTarget = validatedOffsetPtr(diff.getOffset());
-        switch (diff.getDataType()) {
-            case (faabric::util::SnapshotDataType::Int): {
-                int32_t finalValue =
-                  applyDiffValue<int32_t>(validatedOffsetPtr(diff.getOffset()),
-                                          diff.getData().data(),
-                                          diff.getOperation());
-
-                SPDLOG_TRACE("Writing int {} diff: {} {} -> {}",
-                             snapshotMergeOpStr(diff.getOperation()),
-                             unalignedRead<int32_t>(copyTarget),
-                             unalignedRead<int32_t>(diff.getData().data()),
-                             finalValue);
-
-                writeData({ BYTES(&finalValue), sizeof(int32_t) },
-                          diff.getOffset());
-                break;
-            }
-            case (faabric::util::SnapshotDataType::Long): {
-                long finalValue =
-                  applyDiffValue<long>(validatedOffsetPtr(diff.getOffset()),
-                                       diff.getData().data(),
-                                       diff.getOperation());
-
-                SPDLOG_TRACE("Writing long {} diff: {} {} -> {}",
-                             snapshotMergeOpStr(diff.getOperation()),
-                             unalignedRead<long>(copyTarget),
-                             unalignedRead<long>(diff.getData().data()),
-                             finalValue);
-
-                writeData({ BYTES(&finalValue), sizeof(long) },
-                          diff.getOffset());
-                break;
-            }
-            case (faabric::util::SnapshotDataType::Float): {
-                float finalValue =
-                  applyDiffValue<float>(validatedOffsetPtr(diff.getOffset()),
-                                        diff.getData().data(),
-                                        diff.getOperation());
-
-                SPDLOG_TRACE("Writing float {} diff: {} {} -> {}",
-                             snapshotMergeOpStr(diff.getOperation()),
-                             unalignedRead<float>(copyTarget),
-                             unalignedRead<float>(diff.getData().data()),
-                             finalValue);
-
-                writeData({ BYTES(&finalValue), sizeof(float) },
-                          diff.getOffset());
-                break;
-            }
-            case (faabric::util::SnapshotDataType::Double): {
-                double finalValue =
-                  applyDiffValue<double>(validatedOffsetPtr(diff.getOffset()),
-                                         diff.getData().data(),
-                                         diff.getOperation());
-
-                SPDLOG_TRACE("Writing double {} diff: {} {} -> {}",
-                             snapshotMergeOpStr(diff.getOperation()),
-                             unalignedRead<double>(copyTarget),
-                             unalignedRead<double>(diff.getData().data()),
-                             finalValue);
-
-                writeData({ BYTES(&finalValue), sizeof(double) },
-                          diff.getOffset());
-                break;
-            }
-            default: {
-                SPDLOG_ERROR("Unsupported data type: {}", diff.getDataType());
-                throw std::runtime_error("Unsupported merge data type");
-            }
-        }
+        applyDiff(diff);
     }
 
     // Clear queue
@@ -447,6 +363,98 @@ int SnapshotData::writeQueuedDiffs()
     PROF_END(WriteQueuedDiffs)
 
     return nDiffs;
+}
+
+void SnapshotData::applyDiff(const SnapshotDiff& diff)
+{
+    if (diff.getOperation() == faabric::util::SnapshotMergeOperation::Ignore) {
+
+        SPDLOG_TRACE("Ignoring region {}-{}",
+                     diff.getOffset(),
+                     diff.getOffset() + diff.getData().size());
+
+        return;
+    }
+
+    if (diff.getOperation() ==
+        faabric::util::SnapshotMergeOperation::Bytewise) {
+        writeData(diff.getData(), diff.getOffset());
+        return;
+    }
+
+    if (diff.getOperation() == faabric::util::SnapshotMergeOperation::XOR) {
+        xorData(diff.getData(), diff.getOffset());
+        return;
+    }
+
+    uint8_t* copyTarget = validatedOffsetPtr(diff.getOffset());
+    switch (diff.getDataType()) {
+        case (faabric::util::SnapshotDataType::Int): {
+            int32_t finalValue =
+              applyDiffValue<int32_t>(validatedOffsetPtr(diff.getOffset()),
+                                      diff.getData().data(),
+                                      diff.getOperation());
+
+            SPDLOG_TRACE("Writing int {} diff: {} {} -> {}",
+                         snapshotMergeOpStr(diff.getOperation()),
+                         unalignedRead<int32_t>(copyTarget),
+                         unalignedRead<int32_t>(diff.getData().data()),
+                         finalValue);
+
+            writeData({ BYTES(&finalValue), sizeof(int32_t) },
+                      diff.getOffset());
+            break;
+        }
+        case (faabric::util::SnapshotDataType::Long): {
+            long finalValue =
+              applyDiffValue<long>(validatedOffsetPtr(diff.getOffset()),
+                                   diff.getData().data(),
+                                   diff.getOperation());
+
+            SPDLOG_TRACE("Writing long {} diff: {} {} -> {}",
+                         snapshotMergeOpStr(diff.getOperation()),
+                         unalignedRead<long>(copyTarget),
+                         unalignedRead<long>(diff.getData().data()),
+                         finalValue);
+
+            writeData({ BYTES(&finalValue), sizeof(long) }, diff.getOffset());
+            break;
+        }
+        case (faabric::util::SnapshotDataType::Float): {
+            float finalValue =
+              applyDiffValue<float>(validatedOffsetPtr(diff.getOffset()),
+                                    diff.getData().data(),
+                                    diff.getOperation());
+
+            SPDLOG_TRACE("Writing float {} diff: {} {} -> {}",
+                         snapshotMergeOpStr(diff.getOperation()),
+                         unalignedRead<float>(copyTarget),
+                         unalignedRead<float>(diff.getData().data()),
+                         finalValue);
+
+            writeData({ BYTES(&finalValue), sizeof(float) }, diff.getOffset());
+            break;
+        }
+        case (faabric::util::SnapshotDataType::Double): {
+            double finalValue =
+              applyDiffValue<double>(validatedOffsetPtr(diff.getOffset()),
+                                     diff.getData().data(),
+                                     diff.getOperation());
+
+            SPDLOG_TRACE("Writing double {} diff: {} {} -> {}",
+                         snapshotMergeOpStr(diff.getOperation()),
+                         unalignedRead<double>(copyTarget),
+                         unalignedRead<double>(diff.getData().data()),
+                         finalValue);
+
+            writeData({ BYTES(&finalValue), sizeof(double) }, diff.getOffset());
+            break;
+        }
+        default: {
+            SPDLOG_ERROR("Unsupported data type: {}", diff.getDataType());
+            throw std::runtime_error("Unsupported merge data type");
+        }
+    }
 }
 
 void SnapshotData::clearTrackedChanges()
@@ -662,6 +670,9 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
     }
     startPage += std::distance(startIt, foundIt);
 
+    // Seems to be quicker to access this via a raw ptr
+    const char* dirtyRegionsPtr = dirtyRegions.data();
+
     // Bytewise and XOR both deal with overwriting bytes without any
     // other logic. Bytewise will filter in only the modified bytes,
     // whereas XOR will transmit the XOR of the whole page and the original
@@ -670,7 +681,7 @@ void SnapshotMergeRegion::addDiffs(std::vector<SnapshotDiff>& diffs,
         // Iterate through pages
         for (int p = startPage; p < endPage; p++) {
             // Skip if page not dirty
-            if (dirtyRegions.at(p) == 0) {
+            if (dirtyRegionsPtr[p] == 0) {
                 continue;
             }
 

--- a/tests/test/snapshot/test_snapshot_diffs.cpp
+++ b/tests/test/snapshot/test_snapshot_diffs.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "faabric/util/bytes.h"
+#include "faabric/util/snapshot.h"
 #include "faabric_utils.h"
 
 #include <faabric/snapshot/SnapshotRegistry.h>
@@ -198,5 +200,83 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
     checkSnapshotDiff(offsetB2, dataB2, changeDiffs.at(3));
     checkSnapshotDiff(offsetC, expectedDataC, changeDiffs.at(4));
     checkSnapshotDiff(regionOffsetD, expectedDataD, changeDiffs.at(5));
+}
+
+TEST_CASE_METHOD(SnapshotTestFixture,
+                 "Test snapshot diff ownership",
+                 "[snapshot]")
+{
+    SECTION("Raw data")
+    {
+        size_t memSize = 200;
+        MemoryRegion mem = allocatePrivateMemory(memSize);
+        std::span<uint8_t> memView(mem.get(), memSize);
+
+        uint8_t* rawSubsection = mem.get() + 50;
+        std::span<uint8_t> subsection(rawSubsection, 100);
+
+        SECTION("Non-owner")
+        {
+            // Create a diff from the memory, check it still refers to the same
+            // data
+            SnapshotDiff d(SnapshotDataType::Raw,
+                           SnapshotMergeOperation::Bytewise,
+                           123,
+                           subsection,
+                           SnapshotDiffOwnership::NotOwner);
+
+            std::span<const uint8_t> actual = d.getData();
+            REQUIRE(actual.data() == rawSubsection);
+            REQUIRE(actual.size() == subsection.size());
+        }
+
+        SECTION("Owner")
+        {
+            // Check owner creates copy
+            SnapshotDiff d(SnapshotDataType::Raw,
+                           SnapshotMergeOperation::Bytewise,
+                           123,
+                           subsection,
+                           SnapshotDiffOwnership::Owner);
+
+            std::span<const uint8_t> actual = d.getData();
+            REQUIRE(actual.data() != rawSubsection);
+            REQUIRE(actual.size() == subsection.size());
+        }
+    }
+
+    SECTION("Integers")
+    {
+        int originalInt = 123;
+        uint8_t* originalBytes = BYTES(&originalInt);
+
+        SECTION("Not owner")
+        {
+            SnapshotDiff d(SnapshotDataType::Int,
+                           SnapshotMergeOperation::Sum,
+                           100,
+                           std::span<uint8_t>(originalBytes, sizeof(int)),
+                           SnapshotDiffOwnership::NotOwner);
+
+            std::span<const uint8_t> actual = d.getData();
+
+            REQUIRE(actual.data() == originalBytes);
+        }
+
+        SECTION("Owner")
+        {
+            SnapshotDiff d(SnapshotDataType::Int,
+                           SnapshotMergeOperation::Sum,
+                           100,
+                           std::span<uint8_t>(originalBytes, sizeof(int)),
+                           SnapshotDiffOwnership::Owner);
+
+            std::span<const uint8_t> actual = d.getData();
+            REQUIRE(actual.data() != originalBytes);
+
+            int actualInt = faabric::util::unalignedRead<int>(actual.data());
+            REQUIRE(actualInt == originalInt);
+        }
+    }
 }
 }

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -32,7 +32,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     src.send(msg, expectedMsg.size());
 
     // Receive message
-    faabric::transport::Message recvMsg = dst.recv().value();
+    faabric::transport::Message recvMsg = dst.recv();
     REQUIRE(recvMsg.size() == expectedMsg.size());
     std::string actualMsg(recvMsg.data(), recvMsg.size());
     REQUIRE(actualMsg == expectedMsg);
@@ -54,7 +54,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
 
         // Receive message
         AsyncRecvMessageEndpoint dst(TEST_PORT);
-        faabric::transport::Message recvMsg = dst.recv().value();
+        faabric::transport::Message recvMsg = dst.recv();
 
         assert(recvMsg.size() == expectedMsg.size());
         std::string actualMsg(recvMsg.data(), recvMsg.size());
@@ -96,7 +96,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test await response", "[transport]")
 
     // Receive message
     SyncRecvMessageEndpoint dst(TEST_PORT);
-    faabric::transport::Message recvMsg = dst.recv().value();
+    faabric::transport::Message recvMsg = dst.recv();
     REQUIRE(recvMsg.size() == expectedMsg.size());
     std::string actualMsg(recvMsg.data(), recvMsg.size());
     REQUIRE(actualMsg == expectedMsg);
@@ -131,7 +131,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     // Receive messages
     AsyncRecvMessageEndpoint dst(TEST_PORT);
     for (int i = 0; i < numMessages; i++) {
-        faabric::transport::Message recvMsg = dst.recv().value();
+        faabric::transport::Message recvMsg = dst.recv();
         // Check just a subset of the messages
         // This implicitly tests in-order message delivery
         if ((i % (numMessages / 10)) == 0) {
@@ -171,7 +171,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     // Receive messages
     AsyncRecvMessageEndpoint dst(TEST_PORT);
     for (int i = 0; i < numSenders * numMessages; i++) {
-        faabric::transport::Message recvMsg = dst.recv().value();
+        faabric::transport::Message recvMsg = dst.recv();
         // Check just a subset of the messages
         if ((i % numMessages) == 0) {
             REQUIRE(recvMsg.size() == expectedMsg.size());
@@ -244,14 +244,13 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test direct messaging", "[transport]")
     std::string actual;
     SECTION("Recv with size")
     {
-        faabric::transport::Message recvMsg =
-          receiver.recv(expected.size()).value();
+        faabric::transport::Message recvMsg = receiver.recv(expected.size());
         actual = std::string(recvMsg.data(), recvMsg.size());
     }
 
     SECTION("Recv no size")
     {
-        faabric::transport::Message recvMsg = receiver.recv().value();
+        faabric::transport::Message recvMsg = receiver.recv();
         actual = std::string(recvMsg.data(), recvMsg.size());
     }
 
@@ -307,7 +306,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
 
             // Receive messages
             for (int m = 0; m < nMessages; m++) {
-                faabric::transport::Message recvMsg = receiver.recv().value();
+                faabric::transport::Message recvMsg = receiver.recv();
                 std::string actual(recvMsg.data(), recvMsg.size());
 
                 std::string expected =

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -52,7 +52,6 @@ class SnapshotMergeTestFixture
             REQUIRE(actualDiff.getOperation() == expectedDiff.getOperation());
             REQUIRE(actualDiff.getDataType() == expectedDiff.getDataType());
             REQUIRE(actualDiff.getOffset() == expectedDiff.getOffset());
-            REQUIRE(actualDiff.getOwnership() == expectedDiff.getOwnership());
 
             std::vector<uint8_t> actualData = actualDiff.getDataCopy();
             std::vector<uint8_t> expectedData = expectedDiff.getDataCopy();
@@ -460,23 +459,19 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         { SnapshotDataType::Int,
           SnapshotMergeOperation::Subtract,
           offsetA,
-          { BYTES(&subA), sizeof(int32_t) },
-          SnapshotDiffOwnership::Owner },
+          { BYTES(&subA), sizeof(int32_t) } },
         { SnapshotDataType::Int,
           SnapshotMergeOperation::Sum,
           offsetB,
-          { BYTES(&sumB), sizeof(int32_t) },
-          SnapshotDiffOwnership::Owner },
+          { BYTES(&sumB), sizeof(int32_t) } },
         { SnapshotDataType::Int,
           SnapshotMergeOperation::Subtract,
           offsetC,
-          { BYTES(&subC), sizeof(int32_t) },
-          SnapshotDiffOwnership::Owner },
+          { BYTES(&subC), sizeof(int32_t) } },
         { SnapshotDataType::Int,
           SnapshotMergeOperation::Sum,
           offsetD,
-          { BYTES(&sumD), sizeof(int32_t) },
-          SnapshotDiffOwnership::Owner },
+          { BYTES(&sumD), sizeof(int32_t) } },
     };
 
     tracker->stopTracking(memView);
@@ -520,8 +515,6 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
       faabric::util::SnapshotDataType::Raw;
     faabric::util::SnapshotMergeOperation operation =
       faabric::util::SnapshotMergeOperation::Bytewise;
-    faabric::util::SnapshotDiffOwnership ownership =
-      faabric::util::SnapshotDiffOwnership::Owner;
 
     size_t dataLength = 0;
     size_t regionLength = 0;
@@ -794,7 +787,6 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
             diffValue = false;
 
             operation = faabric::util::SnapshotMergeOperation::Bytewise;
-            ownership = SnapshotDiffOwnership::NotOwner;
         }
 
         originalData = faabric::util::valueToBytes<bool>(originalValue);
@@ -815,14 +807,12 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         {
             regionLength = dataLength;
             operation = faabric::util::SnapshotMergeOperation::Bytewise;
-            ownership = SnapshotDiffOwnership::NotOwner;
         }
 
         SECTION("Bytewise unspecified length")
         {
             regionLength = 0;
             operation = faabric::util::SnapshotMergeOperation::Bytewise;
-            ownership = SnapshotDiffOwnership::NotOwner;
         }
 
         SECTION("Ignore")
@@ -871,12 +861,12 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
     } else {
         // Check diff
         REQUIRE(actualDiffs.size() == 1);
-        std::vector<SnapshotDiff> expectedDiffs = { { expectedDataType,
-                                                      operation,
-                                                      offset,
-                                                      { expectedData.data(),
-                                                        expectedData.size() },
-                                                      ownership } };
+        std::vector<SnapshotDiff> expectedDiffs = {
+            { expectedDataType,
+              operation,
+              offset,
+              { expectedData.data(), expectedData.size() } }
+        };
 
         checkDiffs(actualDiffs, expectedDiffs);
     }
@@ -1047,23 +1037,19 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         { SnapshotDataType::Raw,
           SnapshotMergeOperation::Bytewise,
           offsetA,
-          { dataA.data(), dataA.size() },
-          SnapshotDiffOwnership::NotOwner },
+          { dataA.data(), dataA.size() } },
         { SnapshotDataType::Raw,
           SnapshotMergeOperation::Bytewise,
           offsetB,
-          { dataB.data(), dataB.size() },
-          SnapshotDiffOwnership::NotOwner },
+          { dataB.data(), dataB.size() } },
         { SnapshotDataType::Raw,
           SnapshotMergeOperation::Bytewise,
           offsetC,
-          { dataC.data(), dataC.size() },
-          SnapshotDiffOwnership::NotOwner },
+          { dataC.data(), dataC.size() } },
         { SnapshotDataType::Raw,
           SnapshotMergeOperation::Bytewise,
           offsetD,
-          { dataD.data(), dataD.size() },
-          SnapshotDiffOwnership::NotOwner },
+          { dataD.data(), dataD.size() } },
     };
 
     // Add a single merge region for all the changes
@@ -1357,13 +1343,11 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         { faabric::util::SnapshotDataType::Raw,
           faabric::util::SnapshotMergeOperation::Bytewise,
           bytewiseAOffset,
-          { BYTES(bytewiseData.data()), bytewiseData.size() },
-          faabric::util::SnapshotDiffOwnership::NotOwner },
+          { BYTES(bytewiseData.data()), bytewiseData.size() } },
         { faabric::util::SnapshotDataType::Int,
           faabric::util::SnapshotMergeOperation::Sum,
           sumOffset,
-          { BYTES(&sumExpected), sizeof(int32_t) },
-          faabric::util::SnapshotDiffOwnership::Owner },
+          { BYTES(&sumExpected), sizeof(int32_t) } },
     };
 
     tracker->stopTracking(memView);
@@ -1441,8 +1425,7 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         expectedDiffs = { { faabric::util::SnapshotDataType::Raw,
                             faabric::util::SnapshotMergeOperation::Bytewise,
                             (uint32_t)snapSize,
-                            expectedDataA,
-                            faabric::util::SnapshotDiffOwnership::NotOwner } };
+                            expectedDataA } };
     }
 
     SECTION("Change and merge region aligned at end of original data")
@@ -1458,8 +1441,7 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         expectedDiffs = { { faabric::util::SnapshotDataType::Raw,
                             faabric::util::SnapshotMergeOperation::Bytewise,
                             (uint32_t)snapSize,
-                            expectedDataA,
-                            faabric::util::SnapshotDiffOwnership::NotOwner } };
+                            expectedDataA } };
     }
 
     SECTION("Change and merge region after end of original data")
@@ -1476,8 +1458,7 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         expectedDiffs = { { faabric::util::SnapshotDataType::Raw,
                             faabric::util::SnapshotMergeOperation::Bytewise,
                             (uint32_t)snapSize,
-                            expectedDataA,
-                            faabric::util::SnapshotDiffOwnership::NotOwner } };
+                            expectedDataA } };
     }
 
     SECTION("Merge region and change both crossing end of original data")
@@ -1506,13 +1487,11 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
         expectedDiffs = { { faabric::util::SnapshotDataType::Raw,
                             faabric::util::SnapshotMergeOperation::Bytewise,
                             (uint32_t)snapSize,
-                            expectedDataB,
-                            SnapshotDiffOwnership::NotOwner },
+                            expectedDataB },
                           { faabric::util::SnapshotDataType::Raw,
                             faabric::util::SnapshotMergeOperation::Bytewise,
                             changeOffset,
-                            expectedDataA,
-                            SnapshotDiffOwnership::NotOwner } };
+                            expectedDataA } };
     }
 
     // Copy in the changed data

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -1633,8 +1633,7 @@ TEST_CASE_METHOD(DirtyTrackingTestFixture,
         REQUIRE(actualDiff.getOffset() == offsetC);
 
         // Apply diffs from memory to the snapshot
-        snap->queueDiffs(actualDiffs);
-        snap->writeQueuedDiffs();
+        snap->applyDiffs(actualDiffs);
     }
 
     // Check snapshot now shows both diffs
@@ -1995,8 +1994,7 @@ TEST_CASE_METHOD(DirtyTrackingTestFixture, "Test XOR diffs", "[util][snapshot]")
     REQUIRE(diffB.getOffset() == offsetB);
 
     // Apply the diffs to the snapshot
-    snap->queueDiffs(actual);
-    snap->writeQueuedDiffs();
+    snap->applyDiffs(actual);
 
     // Check snapshot data is now as expected
     REQUIRE(snap->getDataCopy() == expectedSnapData);


### PR DESCRIPTION
Changes:

- Pass `faabric::transport::Message` to subclasses of `MessageEndpointServer` instead of raw buffers. This allows subclasses to handle the lifecycle of these messages (and avoid needing to copy the data).
- Remove use of `std::optional` in message endpoints, makes reasoning about lifecycle and copying easier.
- Change `SnapshotDiff`s to no longer take ownership over the underlying data, thus avoiding the need to copy data.
- Cache the `faabric::transport::Message` associated with a thread result with diffs, thus allowing the diffs themselves to be a view on the message data, rather than a copy.