### PR TITLE
Transport layer to fixed-sized, aligned messages

### DIFF
--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -50,8 +50,5 @@ class FunctionCallClient : public faabric::transport::MessageEndpointClient
     void executeFunctions(std::shared_ptr<faabric::BatchExecuteRequest> req);
 
     void unregister(faabric::UnregisterRequest& req);
-
-  private:
-    void sendHeader(faabric::scheduler::FunctionCalls call);
 };
 }

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -15,10 +15,10 @@ class FunctionCallServer final
   private:
     Scheduler& scheduler;
 
-    void doAsyncRecv(transport::Message&& message) override;
+    void doAsyncRecv(transport::Message& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override;
+      transport::Message& message) override;
 
     std::unique_ptr<google::protobuf::Message> recvFlush(const uint8_t* buffer,
                                                          size_t bufferSize);

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -15,10 +15,9 @@ class FunctionCallServer final
   private:
     Scheduler& scheduler;
 
-    void doAsyncRecv(int header, transport::Message&& message) override;
+    void doAsyncRecv(transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> recvFlush(const uint8_t* buffer,

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -180,7 +180,7 @@ class Scheduler
      */
     void setThreadResultLocally(uint32_t msgId,
                                 int32_t returnValue,
-                                faabric::transport::Message&& message);
+                                faabric::transport::Message& message);
 
     std::vector<std::pair<uint32_t, int32_t>> awaitThreadResults(
       std::shared_ptr<faabric::BatchExecuteRequest> req);

--- a/include/faabric/snapshot/SnapshotClient.h
+++ b/include/faabric/snapshot/SnapshotClient.h
@@ -57,8 +57,5 @@ class SnapshotClient final : public faabric::transport::MessageEndpointClient
       int returnValue,
       const std::string& key,
       const std::vector<faabric::util::SnapshotDiff>& diffs);
-
-  private:
-    void sendHeader(faabric::snapshot::SnapshotCalls call);
 };
 }

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -15,10 +15,9 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     SnapshotServer();
 
   protected:
-    void doAsyncRecv(int header, transport::Message&& message) override;
+    void doAsyncRecv(transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> recvPushSnapshot(

--- a/include/faabric/snapshot/SnapshotServer.h
+++ b/include/faabric/snapshot/SnapshotServer.h
@@ -15,10 +15,10 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     SnapshotServer();
 
   protected:
-    void doAsyncRecv(transport::Message&& message) override;
+    void doAsyncRecv(transport::Message& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override;
+      transport::Message& message) override;
 
     std::unique_ptr<google::protobuf::Message> recvPushSnapshot(
       const uint8_t* buffer,
@@ -31,7 +31,7 @@ class SnapshotServer final : public faabric::transport::MessageEndpointServer
     void recvDeleteSnapshot(const uint8_t* buffer, size_t bufferSize);
 
     std::unique_ptr<google::protobuf::Message> recvThreadResult(
-      faabric::transport::Message&& message);
+      faabric::transport::Message& message);
 
   private:
     faabric::transport::PointToPointBroker& broker;

--- a/include/faabric/state/StateServer.h
+++ b/include/faabric/state/StateServer.h
@@ -15,10 +15,9 @@ class StateServer final : public faabric::transport::MessageEndpointServer
 
     void logOperation(const std::string& op);
 
-    void doAsyncRecv(int header, transport::Message&& message) override;
+    void doAsyncRecv(transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override;
 
     // Sync methods

--- a/include/faabric/state/StateServer.h
+++ b/include/faabric/state/StateServer.h
@@ -15,10 +15,10 @@ class StateServer final : public faabric::transport::MessageEndpointServer
 
     void logOperation(const std::string& op);
 
-    void doAsyncRecv(transport::Message&& message) override;
+    void doAsyncRecv(transport::Message& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override;
+      transport::Message& message) override;
 
     // Sync methods
 

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -44,9 +44,16 @@ class Message
     std::vector<uint8_t> dataCopy();
 
     int size();
+
+    void setHeader(uint8_t header) { _header = header; };
+
+    uint8_t getHeader() { return _header; };
+
   private:
     std::vector<uint8_t> buffer;
 
     MessageResponseCode responseCode = MessageResponseCode::SUCCESS;
+
+    uint8_t _header = 0;
 };
 }

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -21,27 +21,21 @@ enum MessageResponseCode
  * array of bytes, with a size and a flag to say whether there's more data to
  * follow.
  *
- * Currently it's just a thin wrapper around a ZeroMQ message that avoids us
- * being dependent on the ZeroMQ API outside of boilerplate code.
+ * We must block users from accidentally copying these messages. If they need to
+ * be passed around, it should be done using move semantics/ constructors.
  */
 class Message
 {
   public:
-    /**
-     * Creates a message from a ZeroMQ message. Importantly avoids a copy by
-     * using the move constructor of zmq::message_t
-     *
-     * https://github.com/zeromq/cppzmq/blob/master/zmq.hpp#L408
-     */
-    explicit Message(zmq::message_t&& msgIn);
+    explicit Message(size_t size);
 
     explicit Message(Message&& other) noexcept;
 
-    explicit Message(MessageResponseCode failCodeIn);
+    explicit Message(MessageResponseCode responseCodeIn);
 
     Message& operator=(Message&&);
 
-    MessageResponseCode getResponseCode() { return failCode; }
+    MessageResponseCode getResponseCode() { return responseCode; }
 
     char* data();
 
@@ -50,14 +44,9 @@ class Message
     std::vector<uint8_t> dataCopy();
 
     int size();
-
-    bool more();
-
   private:
-    zmq::message_t msg;
+    std::vector<uint8_t> buffer;
 
-    bool _more = false;
-
-    MessageResponseCode failCode = MessageResponseCode::SUCCESS;
+    MessageResponseCode responseCode = MessageResponseCode::SUCCESS;
 };
 }

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -21,19 +21,24 @@ enum MessageResponseCode
  * array of bytes, with a size and a flag to say whether there's more data to
  * follow.
  *
- * We must block users from accidentally copying these messages. If they need to
- * be passed around, it should be done using move semantics/ constructors.
+ * Messages are not copyable, only movable, as they will regularly contain large
+ * amounts of data.
  */
 class Message
 {
   public:
-    explicit Message(size_t size);
+    // Delete everything copy-related, default everything move-related
+    Message(const Message& other) = delete;
 
-    explicit Message(Message&& other) noexcept;
+    Message& operator=(const Message& other) = delete;
 
-    explicit Message(MessageResponseCode responseCodeIn);
+    Message(Message&& other) = default;
 
-    Message& operator=(Message&&);
+    Message& operator=(Message&& other) = default;
+
+    Message(size_t size);
+
+    Message(MessageResponseCode responseCodeIn);
 
     MessageResponseCode getResponseCode() { return responseCode; }
 

--- a/include/faabric/transport/Message.h
+++ b/include/faabric/transport/Message.h
@@ -38,7 +38,5 @@ class Message
 
   private:
     zmq::message_t msg;
-
-    bool _more = false;
 };
 }

--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -49,6 +49,8 @@ class MessageEndpoint
 
     std::string getAddress();
 
+    virtual Message recv(int size);
+
   protected:
     const std::string address;
     const int timeoutMs;
@@ -66,8 +68,6 @@ class MessageEndpoint
     Message doRecv(zmq::socket_t& socket, int size = 0);
 
     Message recvBuffer(zmq::socket_t& socket, int size);
-
-    Message recvNoBuffer(zmq::socket_t& socket);
 };
 
 class AsyncSendMessageEndpoint final : public MessageEndpoint

--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -23,9 +23,11 @@
 // things haven't yet completed (usually only when there's an error).
 #define LINGER_MS 100
 
+#define NO_HEADER 0
 #define HEADER_MSG_SIZE (sizeof(uint8_t) + sizeof(size_t))
 
-static const std::vector<uint8_t> shutdownHeader = { 0, 0, 1, 1 };
+#define SHUTDOWN_HEADER 220
+static const std::vector<uint8_t> shutdownPayload = { 0, 0, 1, 1 };
 
 namespace faabric::transport {
 
@@ -52,8 +54,6 @@ class MessageEndpoint
     MessageEndpoint(const MessageEndpoint& ctx) = delete;
 
     std::string getAddress();
-
-    virtual Message recv(int size);
 
   protected:
     const std::string address;
@@ -140,10 +140,12 @@ class RecvMessageEndpoint : public MessageEndpoint
 
     virtual ~RecvMessageEndpoint(){};
 
-    virtual Message recv(bool async);
+    virtual Message recv();
+
+    zmq::socket_t socket;
 
   protected:
-    zmq::socket_t socket;
+    Message doRecv(bool async);
 };
 
 class FanInMessageEndpoint : public RecvMessageEndpoint

--- a/include/faabric/transport/MessageEndpoint.h
+++ b/include/faabric/transport/MessageEndpoint.h
@@ -23,6 +23,10 @@
 // things haven't yet completed (usually only when there's an error).
 #define LINGER_MS 100
 
+#define HEADER_MSG_SIZE (sizeof(uint8_t) + sizeof(size_t))
+
+static const std::vector<uint8_t> shutdownHeader = { 0, 0, 1, 1 };
+
 namespace faabric::transport {
 
 enum MessageEndpointConnectType
@@ -60,14 +64,20 @@ class MessageEndpoint
     zmq::socket_t setUpSocket(zmq::socket_type socketType,
                               MessageEndpointConnectType connectType);
 
-    void doSend(zmq::socket_t& socket,
-                const uint8_t* data,
-                size_t dataSize,
-                bool more);
+    void sendMessage(zmq::socket_t& socket,
+                     uint8_t header,
+                     const uint8_t* data,
+                     size_t dataSize);
 
-    Message doRecv(zmq::socket_t& socket, int size = 0);
+    Message recvMessage(zmq::socket_t& socket, bool async);
 
-    Message recvBuffer(zmq::socket_t& socket, int size);
+  private:
+    Message recvBuffer(zmq::socket_t& socket, size_t size);
+
+    void sendBuffer(zmq::socket_t& socket,
+                    const uint8_t* data,
+                    size_t dataSize,
+                    bool more);
 };
 
 class AsyncSendMessageEndpoint final : public MessageEndpoint
@@ -77,10 +87,9 @@ class AsyncSendMessageEndpoint final : public MessageEndpoint
                              int portIn,
                              int timeoutMs = DEFAULT_SEND_TIMEOUT_MS);
 
-    void sendHeader(int header);
+    void send(uint8_t header, const uint8_t* data, size_t dataSize);
 
-    void send(const uint8_t* data, size_t dataSize, bool more = false);
-
+  protected:
     zmq::socket_t socket;
 };
 
@@ -90,8 +99,9 @@ class AsyncInternalSendMessageEndpoint final : public MessageEndpoint
     AsyncInternalSendMessageEndpoint(const std::string& inProcLabel,
                                      int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    void send(const uint8_t* data, size_t dataSize, bool more = false);
+    void send(uint8_t header, const uint8_t* data, size_t dataSize);
 
+  protected:
     zmq::socket_t socket;
 };
 
@@ -102,13 +112,11 @@ class SyncSendMessageEndpoint final : public MessageEndpoint
                             int portIn,
                             int timeoutMs = DEFAULT_SEND_TIMEOUT_MS);
 
-    void sendHeader(int header);
-
     void sendRaw(const uint8_t* data, size_t dataSize);
 
-    Message sendAwaitResponse(const uint8_t* data,
-                              size_t dataSize,
-                              bool more = false);
+    Message sendAwaitResponse(uint8_t header,
+                              const uint8_t* data,
+                              size_t dataSize);
 
   private:
     zmq::socket_t reqSocket;
@@ -132,8 +140,9 @@ class RecvMessageEndpoint : public MessageEndpoint
 
     virtual ~RecvMessageEndpoint(){};
 
-    virtual Message recv(int size = 0);
+    virtual Message recv(bool async);
 
+  protected:
     zmq::socket_t socket;
 };
 
@@ -192,7 +201,7 @@ class AsyncRecvMessageEndpoint final : public RecvMessageEndpoint
     AsyncRecvMessageEndpoint(int portIn,
                              int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    Message recv(int size = 0) override;
+    Message recv() override;
 };
 
 class AsyncInternalRecvMessageEndpoint final : public RecvMessageEndpoint
@@ -201,7 +210,7 @@ class AsyncInternalRecvMessageEndpoint final : public RecvMessageEndpoint
     AsyncInternalRecvMessageEndpoint(const std::string& inprocLabel,
                                      int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    Message recv(int size = 0) override;
+    Message recv() override;
 };
 
 class SyncRecvMessageEndpoint final : public RecvMessageEndpoint
@@ -213,9 +222,9 @@ class SyncRecvMessageEndpoint final : public RecvMessageEndpoint
     SyncRecvMessageEndpoint(int portIn,
                             int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    Message recv(int size = 0) override;
+    Message recv() override;
 
-    void sendResponse(const uint8_t* data, int size);
+    void sendResponse(uint8_t header, const uint8_t* data, size_t dataSize);
 };
 
 class AsyncDirectRecvEndpoint final : public RecvMessageEndpoint
@@ -224,7 +233,7 @@ class AsyncDirectRecvEndpoint final : public RecvMessageEndpoint
     AsyncDirectRecvEndpoint(const std::string& inprocLabel,
                             int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    Message recv(int size = 0) override;
+    Message recv() override;
 };
 
 class AsyncDirectSendEndpoint final : public MessageEndpoint
@@ -233,8 +242,9 @@ class AsyncDirectSendEndpoint final : public MessageEndpoint
     AsyncDirectSendEndpoint(const std::string& inProcLabel,
                             int timeoutMs = DEFAULT_RECV_TIMEOUT_MS);
 
-    void send(const uint8_t* data, size_t dataSize, bool more = false);
+    void send(uint8_t header, const uint8_t* data, size_t dataSize);
 
+  protected:
     zmq::socket_t socket;
 };
 

--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -65,10 +65,10 @@ class MessageEndpointServer
     int getNThreads();
 
   protected:
-    virtual void doAsyncRecv(transport::Message&& message) = 0;
+    virtual void doAsyncRecv(transport::Message& message) = 0;
 
     virtual std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) = 0;
+      transport::Message& message) = 0;
 
   private:
     friend class MessageEndpointServerHandler;

--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -68,7 +68,6 @@ class MessageEndpointServer
     virtual void doAsyncRecv(transport::Message&& message) = 0;
 
     virtual std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) = 0;
 
   private:

--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -65,7 +65,7 @@ class MessageEndpointServer
     int getNThreads();
 
   protected:
-    virtual void doAsyncRecv(int header, transport::Message&& message) = 0;
+    virtual void doAsyncRecv(transport::Message&& message) = 0;
 
     virtual std::unique_ptr<google::protobuf::Message> doSyncRecv(
       int header,

--- a/include/faabric/transport/PointToPointServer.h
+++ b/include/faabric/transport/PointToPointServer.h
@@ -13,10 +13,9 @@ class PointToPointServer final : public MessageEndpointServer
   private:
     PointToPointBroker& broker;
 
-    void doAsyncRecv(int header, transport::Message&& message) override;
+    void doAsyncRecv(transport::Message&& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override;
 
     void onWorkerStop() override;

--- a/include/faabric/transport/PointToPointServer.h
+++ b/include/faabric/transport/PointToPointServer.h
@@ -13,10 +13,10 @@ class PointToPointServer final : public MessageEndpointServer
   private:
     PointToPointBroker& broker;
 
-    void doAsyncRecv(transport::Message&& message) override;
+    void doAsyncRecv(transport::Message& message) override;
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override;
+      transport::Message& message) override;
 
     void onWorkerStop() override;
 

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -17,8 +17,9 @@ FunctionCallServer::FunctionCallServer()
   , scheduler(getScheduler())
 {}
 
-void FunctionCallServer::doAsyncRecv(int header, transport::Message&& message)
+void FunctionCallServer::doAsyncRecv(transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case faabric::scheduler::FunctionCalls::ExecuteFunctions: {
             recvExecuteFunctions(message.udata(), message.size());
@@ -36,9 +37,9 @@ void FunctionCallServer::doAsyncRecv(int header, transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> FunctionCallServer::doSyncRecv(
-  int header,
   transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case faabric::scheduler::FunctionCalls::Flush: {
             return recvFlush(message.udata(), message.size());

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -17,7 +17,7 @@ FunctionCallServer::FunctionCallServer()
   , scheduler(getScheduler())
 {}
 
-void FunctionCallServer::doAsyncRecv(transport::Message&& message)
+void FunctionCallServer::doAsyncRecv(transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {
@@ -37,7 +37,7 @@ void FunctionCallServer::doAsyncRecv(transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> FunctionCallServer::doSyncRecv(
-  transport::Message&& message)
+  transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -112,7 +112,7 @@ void MpiWorld::sendMpiHostRankMsg(const std::string& hostIn,
 
     SPDLOG_TRACE("Sending MPI host ranks to {}:{}", hostIn, basePort);
     SERIALISE_MSG(msg)
-    ranksSendEndpoints[hostIn]->send(serialisedBuffer, serialisedSize, false);
+    ranksSendEndpoints[hostIn]->send(NO_HEADER, serialisedBuffer, serialisedSize);
 }
 
 void MpiWorld::initRemoteMpiEndpoint(int localRank, int remoteRank)
@@ -184,7 +184,7 @@ MpiWorld::getUnackedMessageBuffer(int sendRank, int recvRank)
     // We want to lazily initialise this data structure because, given its
     // thread local nature, we expect it to be quite sparse (i.e. filled with
     // nullptr).
-    if (unackedMessageBuffers.size() == 0) {
+    if (unackedMessageBuffers.empty()) {
         unackedMessageBuffers.resize(size * size, nullptr);
     }
 

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -112,7 +112,8 @@ void MpiWorld::sendMpiHostRankMsg(const std::string& hostIn,
 
     SPDLOG_TRACE("Sending MPI host ranks to {}:{}", hostIn, basePort);
     SERIALISE_MSG(msg)
-    ranksSendEndpoints[hostIn]->send(NO_HEADER, serialisedBuffer, serialisedSize);
+    ranksSendEndpoints[hostIn]->send(
+      NO_HEADER, serialisedBuffer, serialisedSize);
 }
 
 void MpiWorld::initRemoteMpiEndpoint(int localRank, int remoteRank)

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -138,6 +138,8 @@ void Scheduler::reset()
     availableHostsCache.clear();
     registeredHosts.clear();
     threadResults.clear();
+    threadResultMessages.clear();
+
     pushedSnapshotsMap.clear();
 
     // Reset function migration tracking

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1080,7 +1080,7 @@ void Scheduler::setThreadResultLocally(uint32_t msgId, int32_t returnValue)
 
 void Scheduler::setThreadResultLocally(uint32_t msgId,
                                        int32_t returnValue,
-                                       faabric::transport::Message&& message)
+                                       faabric::transport::Message& message)
 {
     setThreadResultLocally(msgId, returnValue);
 

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -108,6 +108,7 @@ void SnapshotClient::pushSnapshot(
         auto mrsOffset = mb.CreateVector(mrsFbVector);
         auto requestOffset = CreateSnapshotPushRequest(
           mb, keyOffset, data->getMaxSize(), dataOffset, mrsOffset);
+
         mb.Finish(requestOffset);
 
         // Send it

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -1,3 +1,4 @@
+#include "faabric/util/bytes.h"
 #include <faabric/snapshot/SnapshotClient.h>
 #include <faabric/transport/common.h>
 #include <faabric/transport/macros.h>
@@ -110,6 +111,14 @@ void SnapshotClient::pushSnapshot(
           mb, keyOffset, data->getMaxSize(), dataOffset, mrsOffset);
 
         mb.Finish(requestOffset);
+
+        // Print first n characters
+        int nElems = 30;
+        SPDLOG_INFO("PRINTING {}", nElems);
+        const uint8_t* buff = mb.GetBufferPointer();
+        for (int i = 0; i < nElems; i++) {
+            SPDLOG_INFO("{}", buff[i]);
+        }
 
         // Send it
         SEND_FB_MSG(SnapshotCalls::PushSnapshot, mb)

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -217,6 +217,8 @@ void SnapshotClient::pushThreadResult(
         diffsFbVector.reserve(diffs.size());
         for (const auto& d : diffs) {
             std::span<const uint8_t> diffData = d.getData();
+
+            // Note that we're doing a copy here, but it's unavoidable
             auto dataOffset =
               mb.CreateVector<uint8_t>(diffData.data(), diffData.size());
 

--- a/src/snapshot/SnapshotClient.cpp
+++ b/src/snapshot/SnapshotClient.cpp
@@ -1,4 +1,3 @@
-#include "faabric/util/bytes.h"
 #include <faabric/snapshot/SnapshotClient.h>
 #include <faabric/transport/common.h>
 #include <faabric/transport/macros.h>
@@ -111,14 +110,6 @@ void SnapshotClient::pushSnapshot(
           mb, keyOffset, data->getMaxSize(), dataOffset, mrsOffset);
 
         mb.Finish(requestOffset);
-
-        // Print first n characters
-        int nElems = 30;
-        SPDLOG_INFO("PRINTING {}", nElems);
-        const uint8_t* buff = mb.GetBufferPointer();
-        for (int i = 0; i < nElems; i++) {
-            SPDLOG_INFO("{}", buff[i]);
-        }
 
         // Send it
         SEND_FB_MSG(SnapshotCalls::PushSnapshot, mb)

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -124,7 +124,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
               static_cast<SnapshotDataType>(diff->data_type()),
               static_cast<SnapshotMergeOperation>(diff->merge_op()),
               diff->offset(),
-              std::span<const uint8_t>(diff->data()->data(),
+              std::span<const uint8_t>(diff->data()->Data(),
                                        diff->data()->size()));
         }
 
@@ -136,8 +136,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
     // Because we don't take ownership of the data in the diffs, we must also
     // ensure that the underlying message is cached
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.setThreadResultLocally(
-      r->message_id(), r->return_value(), message);
+    sch.setThreadResultLocally(r->message_id(), r->return_value(), message);
 
     return std::make_unique<faabric::EmptyResponse>();
 }

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -40,9 +40,9 @@ void SnapshotServer::doAsyncRecv(int header, transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> SnapshotServer::doSyncRecv(
-  int header,
   transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case faabric::snapshot::SnapshotCalls::PushSnapshot: {
             return recvPushSnapshot(message.udata(), message.size());

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -25,7 +25,7 @@ SnapshotServer::SnapshotServer()
   , reg(faabric::snapshot::getSnapshotRegistry())
 {}
 
-void SnapshotServer::doAsyncRecv(transport::Message&& message)
+void SnapshotServer::doAsyncRecv(transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {
@@ -41,7 +41,7 @@ void SnapshotServer::doAsyncRecv(transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> SnapshotServer::doSyncRecv(
-  transport::Message&& message)
+  transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {
@@ -52,7 +52,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::doSyncRecv(
             return recvPushSnapshotUpdate(message.udata(), message.size());
         }
         case faabric::snapshot::SnapshotCalls::ThreadResult: {
-            return recvThreadResult(std::move(message));
+            return recvThreadResult(message);
         }
         default: {
             throw std::runtime_error(
@@ -103,7 +103,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvPushSnapshot(
 }
 
 std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
-  faabric::transport::Message&& message)
+  faabric::transport::Message& message)
 {
     const ThreadResultRequest* r =
       flatbuffers::GetRoot<ThreadResultRequest>(message.udata());
@@ -137,7 +137,7 @@ std::unique_ptr<google::protobuf::Message> SnapshotServer::recvThreadResult(
     // ensure that the underlying message is cached
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
     sch.setThreadResultLocally(
-      r->message_id(), r->return_value(), std::move(message));
+      r->message_id(), r->return_value(), message);
 
     return std::make_unique<faabric::EmptyResponse>();
 }

--- a/src/snapshot/SnapshotServer.cpp
+++ b/src/snapshot/SnapshotServer.cpp
@@ -25,8 +25,9 @@ SnapshotServer::SnapshotServer()
   , reg(faabric::snapshot::getSnapshotRegistry())
 {}
 
-void SnapshotServer::doAsyncRecv(int header, transport::Message&& message)
+void SnapshotServer::doAsyncRecv(transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case faabric::snapshot::SnapshotCalls::DeleteSnapshot: {
             recvDeleteSnapshot(message.udata(), message.size());

--- a/src/state/StateServer.cpp
+++ b/src/state/StateServer.cpp
@@ -21,13 +21,13 @@ StateServer::StateServer(State& stateIn)
   , state(stateIn)
 {}
 
-void StateServer::doAsyncRecv(transport::Message&& message)
+void StateServer::doAsyncRecv(transport::Message& message)
 {
     throw std::runtime_error("State server does not support async recv");
 }
 
 std::unique_ptr<google::protobuf::Message> StateServer::doSyncRecv(
-  transport::Message&& message)
+  transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {

--- a/src/state/StateServer.cpp
+++ b/src/state/StateServer.cpp
@@ -27,9 +27,9 @@ void StateServer::doAsyncRecv(int header, transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> StateServer::doSyncRecv(
-  int header,
   transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case faabric::state::StateCalls::Pull: {
             return recvPull(message.udata(), message.size());

--- a/src/state/StateServer.cpp
+++ b/src/state/StateServer.cpp
@@ -21,7 +21,7 @@ StateServer::StateServer(State& stateIn)
   , state(stateIn)
 {}
 
-void StateServer::doAsyncRecv(int header, transport::Message&& message)
+void StateServer::doAsyncRecv(transport::Message&& message)
 {
     throw std::runtime_error("State server does not support async recv");
 }

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -9,6 +9,8 @@ Message::Message(size_t size)
 
 Message::Message(Message&& other) noexcept
   : buffer(std::move(other.buffer))
+  , responseCode(other.responseCode)
+  , _header(other._header)
 {}
 
 Message::Message(MessageResponseCode responseCodeIn)
@@ -18,6 +20,8 @@ Message::Message(MessageResponseCode responseCodeIn)
 Message& Message::operator=(Message&& other)
 {
     buffer = std::move(other.buffer);
+    responseCode = other.responseCode;
+    _header = other._header;
 
     return *this;
 }

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -3,9 +3,9 @@
 
 namespace faabric::transport {
 
-Message::Message(size_t size):
-    buffer(size) {
-}
+Message::Message(size_t size)
+  : buffer(size)
+{}
 
 Message::Message(Message&& other) noexcept
   : buffer(std::move(other.buffer))

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -5,7 +5,6 @@ namespace faabric::transport {
 
 Message::Message(zmq::message_t&& msgIn)
   : msg(std::move(msgIn))
-  , _more(msg.more())
 {}
 
 char* Message::data()
@@ -31,6 +30,6 @@ int Message::size()
 
 bool Message::more()
 {
-    return _more;
+    return msg.more();
 }
 }

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -7,24 +7,9 @@ Message::Message(size_t size)
   : buffer(size)
 {}
 
-Message::Message(Message&& other) noexcept
-  : buffer(std::move(other.buffer))
-  , responseCode(other.responseCode)
-  , _header(other._header)
-{}
-
 Message::Message(MessageResponseCode responseCodeIn)
   : responseCode(responseCodeIn)
 {}
-
-Message& Message::operator=(Message&& other)
-{
-    buffer = std::move(other.buffer);
-    responseCode = other.responseCode;
-    _header = other._header;
-
-    return *this;
-}
 
 char* Message::data()
 {

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -3,48 +3,42 @@
 
 namespace faabric::transport {
 
-Message::Message(zmq::message_t&& msgIn)
-  : msg(std::move(msgIn))
-{}
+Message::Message(size_t size):
+    buffer(size) {
+}
 
 Message::Message(Message&& other) noexcept
-  : Message(std::move(other.msg))
+  : buffer(std::move(other.buffer))
 {}
 
-Message::Message(MessageResponseCode failCodeIn)
-  : failCode(failCodeIn)
+Message::Message(MessageResponseCode responseCodeIn)
+  : responseCode(responseCodeIn)
 {}
 
 Message& Message::operator=(Message&& other)
 {
-    msg.move(other.msg);
+    buffer = std::move(other.buffer);
 
     return *this;
 }
 
 char* Message::data()
 {
-    return reinterpret_cast<char*>(msg.data());
+    return reinterpret_cast<char*>(buffer.data());
 }
 
 uint8_t* Message::udata()
 {
-    return reinterpret_cast<uint8_t*>(msg.data());
+    return buffer.data();
 }
 
 std::vector<uint8_t> Message::dataCopy()
 {
-    return std::vector<uint8_t>(BYTES(msg.data()),
-                                BYTES(msg.data()) + msg.size());
+    return std::vector<uint8_t>(buffer.begin(), buffer.end());
 }
 
 int Message::size()
 {
-    return msg.size();
-}
-
-bool Message::more()
-{
-    return msg.more();
+    return buffer.size();
 }
 }

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -287,12 +287,11 @@ Message MessageEndpoint::recvMessage(zmq::socket_t& socket, bool async)
 
     SPDLOG_TRACE("Received body size {} on {}", body.size(), getAddress());
 
-    return Message(std::move(body));
+    return body;
 }
 
 Message MessageEndpoint::recvBuffer(zmq::socket_t& socket, size_t size)
 {
-    // Pre-allocate message to avoid copying
     Message msg(size);
 
     CATCH_ZMQ_ERR(
@@ -324,7 +323,7 @@ Message MessageEndpoint::recvBuffer(zmq::socket_t& socket, size_t size)
       },
       "recv_buffer")
 
-    return Message(std::move(msg));
+    return msg;
 }
 
 void MessageEndpoint::sendBuffer(zmq::socket_t& socket,
@@ -424,7 +423,7 @@ Message SyncSendMessageEndpoint::sendAwaitResponse(uint8_t header,
         throw MessageTimeoutException("Error on waiting for response.");
     }
 
-    return Message(std::move(msg));
+    return msg;
 }
 
 // ----------------------------------------------

--- a/src/transport/MessageEndpointClient.cpp
+++ b/src/transport/MessageEndpointClient.cpp
@@ -30,8 +30,7 @@ void MessageEndpointClient::asyncSend(int header,
                                       const uint8_t* buffer,
                                       size_t bufferSize)
 {
-    asyncEndpoint.sendHeader(header);
-
+    asyncEndpoint.sendHeader(header, bufferSize);
     asyncEndpoint.send(buffer, bufferSize);
 }
 
@@ -53,8 +52,7 @@ void MessageEndpointClient::syncSend(int header,
                                      const size_t bufferSize,
                                      google::protobuf::Message* response)
 {
-    syncEndpoint.sendHeader(header);
-
+    syncEndpoint.sendHeader(header, bufferSize);
     Message responseMsg = syncEndpoint.sendAwaitResponse(buffer, bufferSize);
 
     // Deserialise response

--- a/src/transport/MessageEndpointClient.cpp
+++ b/src/transport/MessageEndpointClient.cpp
@@ -30,8 +30,7 @@ void MessageEndpointClient::asyncSend(int header,
                                       const uint8_t* buffer,
                                       size_t bufferSize)
 {
-    asyncEndpoint.sendHeader(header, bufferSize);
-    asyncEndpoint.send(buffer, bufferSize);
+    asyncEndpoint.send(header, buffer, bufferSize);
 }
 
 void MessageEndpointClient::syncSend(int header,
@@ -52,8 +51,8 @@ void MessageEndpointClient::syncSend(int header,
                                      const size_t bufferSize,
                                      google::protobuf::Message* response)
 {
-    syncEndpoint.sendHeader(header, bufferSize);
-    Message responseMsg = syncEndpoint.sendAwaitResponse(buffer, bufferSize);
+    Message responseMsg =
+      syncEndpoint.sendAwaitResponse(header, buffer, bufferSize);
 
     // Deserialise response
     if (!response->ParseFromArray(responseMsg.data(), responseMsg.size())) {

--- a/src/transport/MessageEndpointServer.cpp
+++ b/src/transport/MessageEndpointServer.cpp
@@ -15,8 +15,6 @@
 
 namespace faabric::transport {
 
-static const std::vector<uint8_t> shutdownHeader = { 0, 0, 1, 1 };
-
 MessageEndpointServerHandler::MessageEndpointServerHandler(
   MessageEndpointServer* serverIn,
   bool asyncIn,
@@ -74,11 +72,11 @@ void MessageEndpointServerHandler::start(
                     while (true) {
                         if (async) {
                             // Server-specific async handling
-                            server->doAsyncRecv(header, std::move(body));
+                            server->doAsyncRecv(std::move(body));
                         } else {
                             // Server-specific sync handling
                             std::unique_ptr<google::protobuf::Message> resp =
-                              server->doSyncRecv(header, std::move(body));
+                              server->doSyncRecv(std::move(body));
 
                             size_t respSize = resp->ByteSizeLong();
 

--- a/src/transport/MessageEndpointServer.cpp
+++ b/src/transport/MessageEndpointServer.cpp
@@ -81,11 +81,11 @@ void MessageEndpointServerHandler::start(
 
                         if (async) {
                             // Server-specific async handling
-                            server->doAsyncRecv(std::move(body));
+                            server->doAsyncRecv(body);
                         } else {
                             // Server-specific sync handling
                             std::unique_ptr<google::protobuf::Message> resp =
-                              server->doSyncRecv(std::move(body));
+                              server->doSyncRecv(body);
 
                             size_t respSize = resp->ByteSizeLong();
 

--- a/src/transport/MpiMessageEndpoint.cpp
+++ b/src/transport/MpiMessageEndpoint.cpp
@@ -16,7 +16,7 @@ void MpiMessageEndpoint::sendMpiMessage(
   const std::shared_ptr<faabric::MPIMessage>& msg)
 {
     SERIALISE_MSG_PTR(msg)
-    sendSocket.send(serialisedBuffer, serialisedSize, false);
+    sendSocket.send(NO_HEADER, serialisedBuffer, serialisedSize);
 }
 
 std::shared_ptr<faabric::MPIMessage> MpiMessageEndpoint::recvMpiMessage()

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -530,7 +530,7 @@ void PointToPointBroker::sendMessage(int groupId,
                      recvIdx,
                      sendEndpoints[label]->getAddress());
 
-        sendEndpoints[label]->send(buffer, bufferSize);
+        sendEndpoints[label]->send(NO_HEADER, buffer, bufferSize);
 
     } else {
         auto cli = getClient(host);

--- a/src/transport/PointToPointServer.cpp
+++ b/src/transport/PointToPointServer.cpp
@@ -19,7 +19,7 @@ PointToPointServer::PointToPointServer()
   , broker(getPointToPointBroker())
 {}
 
-void PointToPointServer::doAsyncRecv(transport::Message&& message)
+void PointToPointServer::doAsyncRecv(transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {
@@ -59,7 +59,7 @@ void PointToPointServer::doAsyncRecv(transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> PointToPointServer::doSyncRecv(
-  transport::Message&& message)
+  transport::Message& message)
 {
     uint8_t header = message.getHeader();
     switch (header) {

--- a/src/transport/PointToPointServer.cpp
+++ b/src/transport/PointToPointServer.cpp
@@ -19,8 +19,9 @@ PointToPointServer::PointToPointServer()
   , broker(getPointToPointBroker())
 {}
 
-void PointToPointServer::doAsyncRecv(int header, transport::Message&& message)
+void PointToPointServer::doAsyncRecv(transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case (faabric::transport::PointToPointCall::MESSAGE): {
             PARSE_MSG(
@@ -58,9 +59,9 @@ void PointToPointServer::doAsyncRecv(int header, transport::Message&& message)
 }
 
 std::unique_ptr<google::protobuf::Message> PointToPointServer::doSyncRecv(
-  int header,
   transport::Message&& message)
 {
+    uint8_t header = message.getHeader();
     switch (header) {
         case (faabric::transport::PointToPointCall::MAPPING): {
             return doRecvMappings(message.udata(), message.size());

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -1109,7 +1109,7 @@ TEST_CASE_METHOD(DummyExecutorFixture,
         sch.registerThread(msgId);
 
         // Set result along with the message to cache
-        sch.setThreadResultLocally(msgId, 0, std::move(msg));
+        sch.setThreadResultLocally(msgId, 0, msg);
     }
 
     // Now check that it's cached

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -1086,26 +1086,23 @@ TEST_CASE_METHOD(DummyExecutorFixture,
 {
     // In here we want to check that data cached in the scheduler from a message
     // will survive the original message going out of scope
-    uint8_t* zmqData = nullptr;
+    uint8_t* msgData = nullptr;
     int bufferSize = 100;
 
     REQUIRE(sch.getCachedMessageCount() == 0);
 
     // Do everything in a nested scope
     {
-        // Create a zmq message
-        zmq::message_t zmqMsg(bufferSize);
+        // Create a message
+        faabric::transport::Message msg(bufferSize);
 
         // Get a pointer to the message data
-        zmqData = (uint8_t*)zmqMsg.data();
+        msgData = msg.udata();
 
         // Write something
-        zmqData[0] = 1;
-        zmqData[1] = 2;
-        zmqData[2] = 3;
-
-        // Create a message wrapper
-        faabric::transport::Message msg(std::move(zmqMsg));
+        msgData[0] = 1;
+        msgData[1] = 2;
+        msgData[2] = 3;
 
         // Register a thread
         uint32_t msgId = 123;
@@ -1119,8 +1116,8 @@ TEST_CASE_METHOD(DummyExecutorFixture,
     REQUIRE(sch.getCachedMessageCount() == 1);
 
     // Check we can still read from the message
-    REQUIRE(zmqData[0] == 1);
-    REQUIRE(zmqData[1] == 2);
-    REQUIRE(zmqData[2] == 3);
+    REQUIRE(msgData[0] == 1);
+    REQUIRE(msgData[1] == 2);
+    REQUIRE(msgData[2] == 3);
 }
 }

--- a/tests/test/transport/test_message.cpp
+++ b/tests/test/transport/test_message.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch.hpp>
+
+#include "faabric_utils.h"
+
+#include <thread>
+
+#include <faabric/transport/Message.h>
+#include <faabric/transport/common.h>
+#include <faabric/util/logging.h>
+#include <faabric/util/macros.h>
+
+using namespace faabric::transport;
+
+namespace tests {
+
+TEST_CASE("Test message moving", "[transport]")
+{
+    size_t msgSize = 100;
+
+    faabric::transport::Message m(msgSize);
+    uint8_t* dataPtr = m.udata();
+
+    // Set some data
+    dataPtr[0] = 1;
+    dataPtr[1] = 2;
+    dataPtr[2] = 3;
+
+    // Create moved copy
+    faabric::transport::Message mB(std::move(m));
+
+    // Check we can still access the pointer
+    REQUIRE(mB.udata() == dataPtr);
+
+    REQUIRE(dataPtr[0] == 1);
+    REQUIRE(dataPtr[1] == 2);
+    REQUIRE(dataPtr[2] == 3);
+}
+}

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -27,12 +27,14 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     AsyncRecvMessageEndpoint dst(TEST_PORT);
 
     // Send message
+    uint8_t dummyHeader = 8;
     std::string expectedMsg = "Hello world!";
     const uint8_t* msg = BYTES_CONST(expectedMsg.c_str());
-    src.send(msg, expectedMsg.size());
+    src.send(dummyHeader, msg, expectedMsg.size());
 
     // Receive message
     faabric::transport::Message recvMsg = dst.recv();
+    REQUIRE(recvMsg.getHeader() == dummyHeader);
     REQUIRE(recvMsg.size() == expectedMsg.size());
     std::string actualMsg(recvMsg.data(), recvMsg.size());
     REQUIRE(actualMsg == expectedMsg);
@@ -61,8 +63,9 @@ TEST_CASE_METHOD(SchedulerTestFixture,
         assert(actualMsg == expectedMsg);
     });
 
+    uint8_t dummyHeader = 8;
     const uint8_t* msg = BYTES_CONST(expectedMsg.c_str());
-    src.send(msg, expectedMsg.size());
+    src.send(dummyHeader, msg, expectedMsg.size());
     latch->wait();
 
     if (recvThread.joinable()) {
@@ -86,7 +89,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test await response", "[transport]")
                                      expectedMsg.size());
 
         faabric::transport::Message recvMsg =
-          src.sendAwaitResponse(bytes.data(), bytes.size());
+          src.sendAwaitResponse(NO_HEADER, bytes.data(), bytes.size());
 
         // Block waiting for a response
         assert(recvMsg.size() == expectedResponse.size());
@@ -103,7 +106,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test await response", "[transport]")
 
     // Send response
     const uint8_t* msg = BYTES_CONST(expectedResponse.c_str());
-    dst.sendResponse(msg, expectedResponse.size());
+    dst.sendResponse(NO_HEADER, msg, expectedResponse.size());
 
     // Wait for sender thread
     if (senderThread.joinable()) {
@@ -117,14 +120,15 @@ TEST_CASE_METHOD(SchedulerTestFixture,
 {
     int numMessages = 10000;
     std::string baseMsg = "Hello ";
+    uint8_t dummyHeader = 8;
 
-    std::thread senderThread([numMessages, baseMsg] {
+    std::thread senderThread([numMessages, dummyHeader, baseMsg] {
         // Open the source endpoint client
         AsyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
         for (int i = 0; i < numMessages; i++) {
             std::string msgData = baseMsg + std::to_string(i);
             const uint8_t* msg = BYTES_CONST(msgData.c_str());
-            src.send(msg, msgData.size());
+            src.send(dummyHeader, msg, msgData.size());
         }
     });
 
@@ -137,6 +141,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
         if ((i % (numMessages / 10)) == 0) {
             std::string expectedMsg = baseMsg + std::to_string(i);
             REQUIRE(recvMsg.size() == expectedMsg.size());
+            REQUIRE(recvMsg.getHeader() == dummyHeader);
             std::string actualMsg(recvMsg.data(), recvMsg.size());
             REQUIRE(actualMsg == expectedMsg);
         }
@@ -158,14 +163,17 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     std::vector<std::thread> senderThreads;
     const uint8_t* msg = BYTES_CONST(expectedMsg.c_str());
 
+    uint8_t dummyHeader = 5;
+
     for (int j = 0; j < numSenders; j++) {
-        senderThreads.emplace_back(std::thread([msg, numMessages, expectedMsg] {
-            // Open the source endpoint client
-            AsyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
-            for (int i = 0; i < numMessages; i++) {
-                src.send(msg, expectedMsg.size());
-            }
-        }));
+        senderThreads.emplace_back(
+          std::thread([msg, dummyHeader, numMessages, expectedMsg] {
+              // Open the source endpoint client
+              AsyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
+              for (int i = 0; i < numMessages; i++) {
+                  src.send(dummyHeader, msg, expectedMsg.size());
+              }
+          }));
     }
 
     // Receive messages
@@ -175,6 +183,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
         // Check just a subset of the messages
         if ((i % numMessages) == 0) {
             REQUIRE(recvMsg.size() == expectedMsg.size());
+            REQUIRE(recvMsg.getHeader() == dummyHeader);
             std::string actualMsg(recvMsg.data(), recvMsg.size());
             REQUIRE(actualMsg == expectedMsg);
         }
@@ -236,24 +245,18 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test direct messaging", "[transport]")
       "direct-test-" + std::to_string(faabric::util::generateGid());
 
     // Send the message
+    uint8_t dummyHeader = 7;
     AsyncDirectSendEndpoint sender(inprocLabel);
-    sender.send(msg, expected.size());
+    sender.send(dummyHeader, msg, expected.size());
 
     AsyncDirectRecvEndpoint receiver(inprocLabel);
 
     std::string actual;
-    SECTION("Recv with size")
-    {
-        faabric::transport::Message recvMsg = receiver.recv(expected.size());
-        actual = std::string(recvMsg.data(), recvMsg.size());
-    }
+    faabric::transport::Message recvMsg = receiver.recv();
 
-    SECTION("Recv no size")
-    {
-        faabric::transport::Message recvMsg = receiver.recv();
-        actual = std::string(recvMsg.data(), recvMsg.size());
-    }
+    REQUIRE(recvMsg.getHeader() == dummyHeader);
 
+    actual = std::string(recvMsg.data(), recvMsg.size());
     REQUIRE(actual == expected);
 }
 
@@ -263,6 +266,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
 {
     int nMessages = 1000;
     int nPairs = 3;
+    uint8_t dummyHeader = 2;
     std::string inprocLabel = "direct-test-";
 
     std::shared_ptr<faabric::util::Latch> startLatch =
@@ -272,27 +276,28 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     std::vector<std::thread> receivers;
 
     for (int i = 0; i < nPairs; i++) {
-        senders.emplace_back([i, nMessages, inprocLabel, &startLatch] {
-            std::string thisLabel = inprocLabel + std::to_string(i);
-            AsyncDirectSendEndpoint sender(thisLabel);
+        senders.emplace_back(
+          [i, dummyHeader, nMessages, inprocLabel, &startLatch] {
+              std::string thisLabel = inprocLabel + std::to_string(i);
+              AsyncDirectSendEndpoint sender(thisLabel);
 
-            for (int m = 0; m < nMessages; m++) {
-                std::string expected =
-                  "Direct hello " + std::to_string(i) + "_" + std::to_string(m);
-                const uint8_t* msg = BYTES_CONST(expected.c_str());
-                sender.send(msg, expected.size());
+              for (int m = 0; m < nMessages; m++) {
+                  std::string expected = "Direct hello " + std::to_string(i) +
+                                         "_" + std::to_string(m);
+                  const uint8_t* msg = BYTES_CONST(expected.c_str());
+                  sender.send(dummyHeader, msg, expected.size());
 
-                if (m % 100 == 0) {
-                    SLEEP_MS(10);
-                }
+                  if (m % 100 == 0) {
+                      SLEEP_MS(10);
+                  }
 
-                // Make main thread wait until messages are queued (to check no
-                // issue with connecting before binding)
-                if (m == 10) {
-                    startLatch->wait();
-                }
-            }
-        });
+                  // Make main thread wait until messages are queued (to check
+                  // no issue with connecting before binding)
+                  if (m == 10) {
+                      startLatch->wait();
+                  }
+              }
+          });
     }
 
     // Wait for queued messages

--- a/tests/test/transport/test_message_server.cpp
+++ b/tests/test/transport/test_message_server.cpp
@@ -26,13 +26,12 @@ class DummyServer final : public MessageEndpointServer
     std::atomic<int> messageCount = 0;
 
   private:
-    void doAsyncRecv(int header, transport::Message&& message) override
+    void doAsyncRecv(transport::Message&& message) override
     {
         messageCount++;
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override
     {
         messageCount++;

--- a/tests/test/transport/test_message_server.cpp
+++ b/tests/test/transport/test_message_server.cpp
@@ -26,10 +26,10 @@ class DummyServer final : public MessageEndpointServer
     std::atomic<int> messageCount = 0;
 
   private:
-    void doAsyncRecv(transport::Message&& message) override { messageCount++; }
+    void doAsyncRecv(transport::Message& message) override { messageCount++; }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override
+      transport::Message& message) override
     {
         messageCount++;
 
@@ -45,13 +45,13 @@ class EchoServer final : public MessageEndpointServer
     {}
 
   protected:
-    void doAsyncRecv(transport::Message&& message) override
+    void doAsyncRecv(transport::Message& message) override
     {
         throw std::runtime_error("Echo server not expecting async recv");
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override
+      transport::Message& message) override
     {
         SPDLOG_TRACE("Echo server received {} bytes", message.size());
 
@@ -72,13 +72,13 @@ class SleepServer final : public MessageEndpointServer
     {}
 
   protected:
-    void doAsyncRecv(transport::Message&& message) override
+    void doAsyncRecv(transport::Message& message) override
     {
         throw std::runtime_error("Sleep server not expecting async recv");
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override
+      transport::Message& message) override
     {
         int* sleepTimeMs = (int*)message.udata();
         SPDLOG_DEBUG("Sleep server sleeping for {}ms", *sleepTimeMs);
@@ -99,13 +99,13 @@ class BlockServer final : public MessageEndpointServer
     {}
 
   protected:
-    void doAsyncRecv(transport::Message&& message) override
+    void doAsyncRecv(transport::Message& message) override
     {
         throw std::runtime_error("Lock server not expecting async recv");
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      transport::Message&& message) override
+      transport::Message& message) override
     {
         // Wait on the latch, requires multiple threads executing in parallel to
         // get a response.

--- a/tests/test/transport/test_message_server.cpp
+++ b/tests/test/transport/test_message_server.cpp
@@ -48,13 +48,12 @@ class EchoServer final : public MessageEndpointServer
     {}
 
   protected:
-    void doAsyncRecv(int header, transport::Message&& message) override
+    void doAsyncRecv(transport::Message&& message) override
     {
         throw std::runtime_error("Echo server not expecting async recv");
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override
     {
         SPDLOG_TRACE("Echo server received {} bytes", message.size());
@@ -76,13 +75,12 @@ class SleepServer final : public MessageEndpointServer
     {}
 
   protected:
-    void doAsyncRecv(int header, transport::Message&& message) override
+    void doAsyncRecv(transport::Message&& message) override
     {
         throw std::runtime_error("Sleep server not expecting async recv");
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override
     {
         int* sleepTimeMs = (int*)message.udata();
@@ -104,13 +102,12 @@ class BlockServer final : public MessageEndpointServer
     {}
 
   protected:
-    void doAsyncRecv(int header, transport::Message&& message) override
+    void doAsyncRecv(transport::Message&& message) override
     {
         throw std::runtime_error("Lock server not expecting async recv");
     }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
-      int header,
       transport::Message&& message) override
     {
         // Wait on the latch, requires multiple threads executing in parallel to

--- a/tests/test/transport/test_message_server.cpp
+++ b/tests/test/transport/test_message_server.cpp
@@ -26,10 +26,7 @@ class DummyServer final : public MessageEndpointServer
     std::atomic<int> messageCount = 0;
 
   private:
-    void doAsyncRecv(transport::Message&& message) override
-    {
-        messageCount++;
-    }
+    void doAsyncRecv(transport::Message&& message) override { messageCount++; }
 
     std::unique_ptr<google::protobuf::Message> doSyncRecv(
       transport::Message&& message) override


### PR DESCRIPTION
The bug was introduced by https://github.com/faasm/faabric/pull/244, but was a little hard to diagnose. That PR switched to using the memory allocated by 0MQ directly when handling messages. However, using this memory directly for flatbuffers caused undefined sanitiser errors as the memory is usually not aligned correctly for the datatypes held in the flatbuffer.

This is a problem that's been discussed [here](https://github.com/zeromq/libzmq/issues/3448) and [here](https://github.com/zeromq/libzmq/issues/3316). The solution is to allocate our own data buffers, make sure they're aligned, and pass these to 0MQ.

Changes:

- Send a message size along with the "header", i.e. tell the recipient what size and type of message to expect by default every time.
- Use the information in this first message, to always receive a message of fixed size into a pre-allocated buffer (which we align).
- Refactor everything to fit this model (causing a big diff, apologies).
- Delete `transport::Message` copying constructor and assignment, only allow moving.