### PR TITLE
Use `std::jthread` instead of `std::thread`

### DIFF
--- a/include/faabric/scheduler/FunctionMigrationThread.h
+++ b/include/faabric/scheduler/FunctionMigrationThread.h
@@ -18,7 +18,7 @@ class FunctionMigrationThread
     int wakeUpPeriodSeconds;
 
   private:
-    std::unique_ptr<std::thread> workThread = nullptr;
+    std::unique_ptr<std::jthread> workThread = nullptr;
     std::mutex mx;
     std::condition_variable mustStopCv;
     std::atomic<bool> isShutdown;

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -114,8 +114,8 @@ class Executor
 
     // ---- Function execution thread pool ----
     std::mutex threadsMutex;
-    std::vector<std::shared_ptr<std::thread>> threadPoolThreads;
-    std::vector<std::shared_ptr<std::thread>> deadThreads;
+    std::vector<std::shared_ptr<std::jthread>> threadPoolThreads;
+    std::vector<std::shared_ptr<std::jthread>> deadThreads;
     std::set<int> availablePoolThreads;
 
     std::vector<faabric::util::Queue<ExecutorTask>> threadTaskQueues;

--- a/include/faabric/transport/MessageEndpointServer.h
+++ b/include/faabric/transport/MessageEndpointServer.h
@@ -33,9 +33,9 @@ class MessageEndpointServerHandler
     const std::string inprocLabel;
     int nThreads;
 
-    std::thread receiverThread;
+    std::jthread receiverThread;
 
-    std::vector<std::thread> workerThreads;
+    std::vector<std::jthread> workerThreads;
 
     std::unique_ptr<SyncFanInMessageEndpoint> syncFanIn = nullptr;
     std::unique_ptr<SyncFanOutMessageEndpoint> syncFanOut = nullptr;

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -319,7 +319,7 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
 
         // Lazily create the thread
         if (threadPoolThreads.at(threadPoolIdx) == nullptr) {
-            threadPoolThreads.at(threadPoolIdx) = std::make_shared<std::thread>(
+            threadPoolThreads.at(threadPoolIdx) = std::make_shared<std::jthread>(
               &Executor::threadPoolThread, this, threadPoolIdx);
         }
     }
@@ -632,7 +632,7 @@ void Executor::threadPoolThread(int threadPoolIdx)
         bool isFinished = true;
         {
             faabric::util::UniqueLock threadsLock(threadsMutex);
-            std::shared_ptr<std::thread> thisThread =
+            std::shared_ptr<std::jthread> thisThread =
               threadPoolThreads.at(threadPoolIdx);
             deadThreads.emplace_back(thisThread);
 

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -319,8 +319,9 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
 
         // Lazily create the thread
         if (threadPoolThreads.at(threadPoolIdx) == nullptr) {
-            threadPoolThreads.at(threadPoolIdx) = std::make_shared<std::jthread>(
-              &Executor::threadPoolThread, this, threadPoolIdx);
+            threadPoolThreads.at(threadPoolIdx) =
+              std::make_shared<std::jthread>(
+                &Executor::threadPoolThread, this, threadPoolIdx);
         }
     }
 }

--- a/src/scheduler/FunctionMigrationThread.cpp
+++ b/src/scheduler/FunctionMigrationThread.cpp
@@ -11,7 +11,7 @@ void FunctionMigrationThread::start(int wakeUpPeriodSecondsIn)
     isShutdown.store(false, std::memory_order_release);
 
     // Main work loop
-    workThread = std::make_unique<std::thread>([&] {
+    workThread = std::make_unique<std::jthread>([&] {
         // As we only check for migration opportunities every (possibly user-
         // defined) timeout, we also support stopping the main thread through
         // a condition variable.

--- a/src/transport/MessageEndpointServer.cpp
+++ b/src/transport/MessageEndpointServer.cpp
@@ -36,7 +36,7 @@ void MessageEndpointServerHandler::start(
     // For push/ pull we receive on a pull socket, then proxy with another push
     // to multiple downstream pull sockets
     // In both cases, the downstream fan-out is done over inproc sockets.
-    receiverThread = std::thread([this, latch] {
+    receiverThread = std::jthread([this, latch] {
         int port = async ? server->asyncPort : server->syncPort;
 
         if (async) {

--- a/src/util/dirty.cpp
+++ b/src/util/dirty.cpp
@@ -448,7 +448,7 @@ static bool uffdWriteProtect = false;
 static bool uffdSigbus = false;
 
 static int closeFd = -1;
-static std::shared_ptr<std::thread> eventThread = nullptr;
+static std::shared_ptr<std::jthread> eventThread = nullptr;
 
 UffdDirtyTracker::UffdDirtyTracker(const std::string& modeIn)
   : DirtyTracker(modeIn)
@@ -544,7 +544,7 @@ void UffdDirtyTracker::initUffd()
         }
 
         // Start event thread
-        eventThread = std::make_shared<std::thread>(
+        eventThread = std::make_shared<std::jthread>(
           &UffdDirtyTracker::eventThreadEntrypoint);
     }
 

--- a/src/util/environment.cpp
+++ b/src/util/environment.cpp
@@ -41,7 +41,7 @@ unsigned int getUsableCores()
     unsigned int nCores;
 
     if (conf.overrideCpuCount == 0) {
-        nCores = std::thread::hardware_concurrency();
+        nCores = std::jthread::hardware_concurrency();
     } else {
         nCores = conf.overrideCpuCount;
     }

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -88,7 +88,7 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
 
     faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
-    std::thread serverThread([&endpoint]() { endpoint.start(false); });
+    std::jthread serverThread([&endpoint]() { endpoint.start(false); });
 
     // Wait for the server to start
     SLEEP_MS(2000);
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
     port++;
     faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
-    std::thread serverThread([&endpoint]() { endpoint.start(false); });
+    std::jthread serverThread([&endpoint]() { endpoint.start(false); });
 
     // Wait for the server to start
     SLEEP_MS(2000);

--- a/tests/test/redis/test_redis.cpp
+++ b/tests/test/redis/test_redis.cpp
@@ -518,7 +518,7 @@ TEST_CASE("Test dequeue after enqueue", "[redis]")
 
     SECTION("Nonzero timeout") { timeout = 500; }
 
-    std::thread t([&redisQueue, &success, &timeout] {
+    std::jthread t([&redisQueue, &success, &timeout] {
         std::string res = redisQueue.dequeue("foobar", timeout);
         success = res == "baz";
     });
@@ -537,7 +537,7 @@ TEST_CASE("Test enqueue after blocking dequeue")
 
     // Start thread blocking on dequeue
     bool success = false;
-    std::thread t([&success] {
+    std::jthread t([&success] {
         Redis& rq = Redis::getQueue();
         std::string res = rq.dequeue("foobar");
         success = res == "baz";

--- a/tests/test/scheduler/test_mpi_exec_graph.cpp
+++ b/tests/test/scheduler/test_mpi_exec_graph.cpp
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture,
     std::vector<int> messageData = { 0, 1, 2 };
     auto bufferAllocation = std::make_unique<int[]>(messageData.size());
     auto buffer = bufferAllocation.get();
-    std::thread otherWorldThread([&messageData, &otherMsg, rank, otherRank] {
+    std::jthread otherWorldThread([&messageData, &otherMsg, rank, otherRank] {
         faabric::scheduler::MpiWorld& otherWorld =
           faabric::scheduler::getMpiWorldRegistry().getOrInitialiseWorld(
             otherMsg);

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -169,7 +169,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test local barrier", "[mpi]")
     std::vector<int> sendData = { 0, 1, 2 };
     std::vector<int> recvData = { -1, -1, -1 };
 
-    std::thread senderThread([&world, rankA1, rankA2, &sendData, &recvData] {
+    std::jthread senderThread([&world, rankA1, rankA2, &sendData, &recvData] {
         world.send(
           rankA1, rankA2, BYTES(sendData.data()), MPI_INT, sendData.size());
 
@@ -270,7 +270,7 @@ TEST_CASE_METHOD(MpiTestFixture, "Test sendrecv", "[mpi]")
 
     // sendRecv is blocking, so we run two threads.
     // Run sendrecv from A
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     threads.emplace_back([&] {
         world.sendRecv(BYTES(messageDataAB.data()),
                        messageDataAB.size(),
@@ -318,7 +318,7 @@ TEST_CASE_METHOD(MpiTestFixture, "Test ring sendrecv", "[mpi]")
     MPI_Status status{};
 
     // Run shift operator. In a ring, send to right receive from left.
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int i = 0; i < ranks.size(); i++) {
         int rank = ranks[i];
         int left = rank > 0 ? rank - 1 : ranks.size() - 1;
@@ -663,7 +663,7 @@ void doReduceTest(scheduler::MpiWorld& world,
 
     // ---- Allreduce ----
     // Run all as threads
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int r = 0; r < thisWorldSize; r++) {
         threads.emplace_back([&, r, inPlace] {
             std::vector<T> thisRankData = rankData[r];
@@ -1116,7 +1116,7 @@ TEST_CASE_METHOD(MpiTestFixture, "Test gather and allgather", "[mpi]")
         SECTION("Not in place") { isInPlace = false; }
 
         // Run allgather in threads
-        std::vector<std::thread> threads;
+        std::vector<std::jthread> threads;
         for (int r = 0; r < worldSize; r++) {
             threads.emplace_back([&, r, isInPlace] {
                 if (isInPlace) {
@@ -1233,7 +1233,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test all-to-all", "[mpi]")
         { 6, 7, 16, 17, 26, 27, 36, 37 },
     };
 
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int r = 0; r < worldSize; r++) {
         threads.emplace_back([&, r] {
             std::vector<int> actual(8, 0);

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -66,7 +66,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture, "Test rank allocation", "[mpi]")
     thisWorld.broadcastHostsToRanks();
 
     // Background thread to receive the allocation
-    std::thread otherWorldThread([this] {
+    std::jthread otherWorldThread([this] {
         otherWorld.initialiseFromMsg(msg);
 
         assert(otherWorld.getHostForRank(0) == thisHost);
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture, "Test send across hosts", "[mpi]")
     thisWorld.broadcastHostsToRanks();
 
     // Start the "remote" world in the background
-    std::thread otherWorldThread([this, rankA, rankB, &messageData] {
+    std::jthread otherWorldThread([this, rankA, rankB, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
         // Receive the message for the given rank
@@ -150,7 +150,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     faabric::util::setMockMode(false);
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread(
+    std::jthread otherWorldThread(
       [this, rankA, rankB, &messageData, &messageData2] {
           otherWorld.initialiseFromMsg(msg);
 
@@ -221,7 +221,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
 
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread([this, rankA, rankB, numMessages] {
+    std::jthread otherWorldThread([this, rankA, rankB, numMessages] {
         otherWorld.initialiseFromMsg(msg);
 
         for (int i = 0; i < numMessages; i++) {
@@ -260,7 +260,7 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
 
     std::vector<int> messageData = { 0, 1, 2 };
 
-    std::thread otherWorldThread([this, &messageData] {
+    std::jthread otherWorldThread([this, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
         // Broadcast a message from the root first
@@ -334,7 +334,7 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
     std::vector<int> messageData = { 0, 1, 2 };
     int recvRank = 0;
 
-    std::thread otherWorldThread([this, recvRank, &messageData] {
+    std::jthread otherWorldThread([this, recvRank, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
         // Call reduce from two non-local-leader ranks (they just send)
@@ -421,7 +421,7 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
     int recvRank = 0;
     int numRepeats = 10;
 
-    std::thread otherWorldThread([this, recvRank, numRepeats, &messageData] {
+    std::jthread otherWorldThread([this, recvRank, numRepeats, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
         std::vector<int> sendRanksInOrder = { 4, 5, 3 };
@@ -498,7 +498,7 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
         messageData[i] = i;
     }
 
-    std::thread otherWorldThread([this, nPerRank, &messageData] {
+    std::jthread otherWorldThread([this, nPerRank, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
         // Do the scatter (when send rank == recv rank)
@@ -641,7 +641,7 @@ TEST_CASE_METHOD(RemoteCollectiveTestFixture,
         orderedLocalGatherRanks = { 1, 2, 0 };
     }
 
-    std::thread otherWorldThread([this, root, &rankData, nPerRank] {
+    std::jthread otherWorldThread([this, root, &rankData, nPerRank] {
         otherWorld.initialiseFromMsg(msg);
 
         std::vector<int> orderedRemoteGatherRanks = { 4, 5, 3 };
@@ -711,7 +711,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     faabric::util::setMockMode(false);
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread([this, sendRank, recvRank, &messageData] {
+    std::jthread otherWorldThread([this, sendRank, recvRank, &messageData] {
         otherWorld.initialiseFromMsg(msg);
 
         // Send message twice
@@ -777,7 +777,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     faabric::util::setMockMode(false);
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread([this, sendRank, recvRank] {
+    std::jthread otherWorldThread([this, sendRank, recvRank] {
         otherWorld.initialiseFromMsg(msg);
 
         // Send different messages
@@ -841,7 +841,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     faabric::util::setMockMode(false);
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread([this, worldSize] {
+    std::jthread otherWorldThread([this, worldSize] {
         std::vector<int> otherHostRanks = { 1, 2 };
         otherWorld.initialiseFromMsg(msg);
 
@@ -911,7 +911,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture,
     faabric::util::setMockMode(false);
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread(
+    std::jthread otherWorldThread(
       [this, rankA, rankB, &messageData, &messageData2] {
           otherWorld.initialiseFromMsg(msg);
 
@@ -1014,7 +1014,7 @@ TEST_CASE_METHOD(RemoteMpiTestFixture, "Test UMB creation", "[mpi]")
     faabric::util::setMockMode(false);
     thisWorld.broadcastHostsToRanks();
 
-    std::thread otherWorldThread([this,
+    std::jthread otherWorldThread([this,
                                   thisWorldRank,
                                   otherWorldRank1,
                                   otherWorldRank2,

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -1015,11 +1015,11 @@ TEST_CASE_METHOD(RemoteMpiTestFixture, "Test UMB creation", "[mpi]")
     thisWorld.broadcastHostsToRanks();
 
     std::jthread otherWorldThread([this,
-                                  thisWorldRank,
-                                  otherWorldRank1,
-                                  otherWorldRank2,
-                                  &messageData,
-                                  &messageData2] {
+                                   thisWorldRank,
+                                   otherWorldRank1,
+                                   otherWorldRank2,
+                                   &messageData,
+                                   &messageData2] {
         otherWorld.initialiseFromMsg(msg);
 
         // Send message from one rank

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -642,7 +642,7 @@ TEST_CASE_METHOD(SlowExecutorFixture,
     int nWaiters = 10;
     int nWaiterMessages = 4;
 
-    std::vector<std::thread> waiterThreads;
+    std::vector<std::jthread> waiterThreads;
 
     // Create waiters that will submit messages and await their results
     for (int i = 0; i < nWaiters; i++) {

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -435,12 +435,12 @@ TEST_CASE_METHOD(SnapshotClientServerFixture,
     int rB = 0;
 
     // Set up two threads to await the results
-    std::thread tA([&rA, threadIdA] {
+    std::jthread tA([&rA, threadIdA] {
         faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
         rA = sch.awaitThreadResult(threadIdA);
     });
 
-    std::thread tB([&rB, threadIdB] {
+    std::jthread tB([&rB, threadIdB] {
         faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
         rB = sch.awaitThreadResult(threadIdB);
     });

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -50,7 +50,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
 
     auto latch = faabric::util::Latch::create(2);
 
-    std::thread recvThread([&latch, expectedMsg] {
+    std::jthread recvThread([&latch, expectedMsg] {
         // Make sure this only runs once the send has been done
         latch->wait();
 
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test await response", "[transport]")
     std::string expectedMsg = "Hello ";
     std::string expectedResponse = "world!";
 
-    std::thread senderThread([expectedMsg, expectedResponse] {
+    std::jthread senderThread([expectedMsg, expectedResponse] {
         // Open the source endpoint client
         SyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
 
@@ -122,7 +122,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     std::string baseMsg = "Hello ";
     uint8_t dummyHeader = 8;
 
-    std::thread senderThread([numMessages, dummyHeader, baseMsg] {
+    std::jthread senderThread([numMessages, dummyHeader, baseMsg] {
         // Open the source endpoint client
         AsyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
         for (int i = 0; i < numMessages; i++) {
@@ -160,14 +160,14 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     int numMessages = 10000;
     int numSenders = 10;
     std::string expectedMsg = "Hello from client";
-    std::vector<std::thread> senderThreads;
+    std::vector<std::jthread> senderThreads;
     const uint8_t* msg = BYTES_CONST(expectedMsg.c_str());
 
     uint8_t dummyHeader = 5;
 
     for (int j = 0; j < numSenders; j++) {
         senderThreads.emplace_back(
-          std::thread([msg, dummyHeader, numMessages, expectedMsg] {
+          std::jthread([msg, dummyHeader, numMessages, expectedMsg] {
               // Open the source endpoint client
               AsyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
               for (int i = 0; i < numMessages; i++) {
@@ -272,8 +272,8 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     std::shared_ptr<faabric::util::Latch> startLatch =
       faabric::util::Latch::create(nPairs + 1);
 
-    std::vector<std::thread> senders;
-    std::vector<std::thread> receivers;
+    std::vector<std::jthread> senders;
+    std::vector<std::jthread> receivers;
 
     for (int i = 0; i < nPairs; i++) {
         senders.emplace_back(

--- a/tests/test/transport/test_message_server.cpp
+++ b/tests/test/transport/test_message_server.cpp
@@ -173,12 +173,12 @@ TEST_CASE("Test multiple clients talking to one server", "[transport]")
     EchoServer server;
     server.start();
 
-    std::vector<std::thread> clientThreads;
+    std::vector<std::jthread> clientThreads;
     int numClients = 10;
     int numMessages = 1000;
 
     for (int i = 0; i < numClients; i++) {
-        clientThreads.emplace_back(std::thread([i, numMessages] {
+        clientThreads.emplace_back(std::jthread([i, numMessages] {
             // Prepare client
             MessageEndpointClient cli(
               LOCALHOST, TEST_PORT_ASYNC, TEST_PORT_SYNC);
@@ -274,7 +274,7 @@ TEST_CASE("Test blocking requests in multi-threaded server", "[transport]")
     bool successes[2] = { false, false };
 
     // Create two background threads to make the blocking requests
-    std::thread tA([&successes] {
+    std::jthread tA([&successes] {
         MessageEndpointClient cli(LOCALHOST, TEST_PORT_ASYNC, TEST_PORT_SYNC);
 
         std::string expectedMsg = "Background thread A";
@@ -293,7 +293,7 @@ TEST_CASE("Test blocking requests in multi-threaded server", "[transport]")
         }
     });
 
-    std::thread tB([&successes] {
+    std::jthread tB([&successes] {
         MessageEndpointClient cli(LOCALHOST, TEST_PORT_ASYNC, TEST_PORT_SYNC);
 
         std::string expectedMsg = "Background thread B";

--- a/tests/test/transport/test_point_to_point.cpp
+++ b/tests/test/transport/test_point_to_point.cpp
@@ -117,7 +117,7 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
     // async handling
     broker.sendMessage(groupId, idxA, idxB, sentDataA.data(), sentDataA.size());
 
-    std::thread t([groupId, idxA, idxB, &receivedDataA, &sentDataB] {
+    std::jthread t([groupId, idxA, idxB, &receivedDataA, &sentDataB] {
         PointToPointBroker& broker = getPointToPointBroker();
 
         // Receive the first message
@@ -279,7 +279,7 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
 
     // Background thread that will eventually enable the app and change the
     // shared integer
-    std::thread t([this, &decision, &sharedInt] {
+    std::jthread t([this, &decision, &sharedInt] {
         SLEEP_MS(1000);
 
         sharedInt.fetch_add(100);

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -197,7 +197,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
 
     // Create high contention on the critical var that will be detected if
     // locking isn't working.
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int i = 0; i < nThreads; i++) {
         threads.emplace_back(
           [useLocal, recursive, i, nLoops, &group, &criticalVar, &success] {
@@ -268,7 +268,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
     // Spawn n-1 child threads to add to shared sums over several barriers so
     // that the main thread can check all threads have completed after each.
     std::vector<std::atomic<int>> sharedSums(nSums);
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int i = 1; i < nThreads; i++) {
         threads.emplace_back([&group, i, nSums, &sharedSums] {
             for (int s = 0; s < nSums; s++) {
@@ -350,7 +350,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
     auto group = setUpGroup(appId, groupId, nThreads);
 
     // Run threads in background to force a wait from the master
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int i = 1; i < nThreads; i++) {
         threads.emplace_back([&group, i, &actual] {
             SLEEP_MS(1000);

--- a/tests/test/util/test_barrier.cpp
+++ b/tests/test/util/test_barrier.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Test barrier operation", "[util]")
 
     // Have n-1 threads iterating through sums, adding, then waiting on the
     // barrier
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     for (int i = 1; i < nThreads; i++) {
         threads.emplace_back([nSums, &b, &sums]() {
             for (int s = 0; s < nSums; s++) {

--- a/tests/test/util/test_dirty.cpp
+++ b/tests/test/util/test_dirty.cpp
@@ -329,7 +329,7 @@ TEST_CASE_METHOD(DirtyTrackingTestFixture,
         // Start global tracking
         tracker->startTracking(memView);
 
-        std::vector<std::thread> threads;
+        std::vector<std::jthread> threads;
         threads.reserve(nThreads);
         for (int i = 0; i < nThreads; i++) {
             threads.emplace_back(

--- a/tests/test/util/test_gids.cpp
+++ b/tests/test/util/test_gids.cpp
@@ -19,9 +19,9 @@ TEST_CASE("Test multithreaded gid generation", "[util]")
 
     std::vector<unsigned int> generated;
     std::mutex mx;
-    std::vector<std::thread> threads(nThreads);
+    std::vector<std::jthread> threads(nThreads);
     for (int i = 0; i < nThreads; i++) {
-        threads.emplace_back(std::thread([&generated, &mx, nLoops] {
+        threads.emplace_back(std::jthread([&generated, &mx, nLoops] {
             for (int j = 0; j < nLoops; j++) {
                 faabric::util::UniqueLock lock(mx);
                 generated.push_back(faabric::util::generateGid());

--- a/tests/test/util/test_latch.cpp
+++ b/tests/test/util/test_latch.cpp
@@ -16,8 +16,8 @@ TEST_CASE("Test latch operation", "[util]")
 {
     auto l = Latch::create(3);
 
-    auto t1 = std::thread([l] { l->wait(); });
-    auto t2 = std::thread([l] { l->wait(); });
+    auto t1 = std::jthread([l] { l->wait(); });
+    auto t2 = std::jthread([l] { l->wait(); });
 
     l->wait();
 

--- a/tests/test/util/test_locks.cpp
+++ b/tests/test/util/test_locks.cpp
@@ -1,9 +1,10 @@
 #include <catch2/catch.hpp>
-#include <faabric/util/latch.h>
 
 #include <faabric/util/latch.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/macros.h>
+
+#include <thread>
 
 using namespace faabric::util;
 
@@ -25,8 +26,8 @@ TEST_CASE("Test wait flag", "[util]")
     std::vector<int> expectedUnset(nThreads, 0);
     std::vector<int> expectedSet;
 
-    std::vector<std::thread> threadsA;
-    std::vector<std::thread> threadsB;
+    std::vector<std::jthread> threadsA;
+    std::vector<std::jthread> threadsB;
 
     std::vector<int> resultsA(nThreads, 0);
     std::vector<int> resultsB(nThreads, 0);

--- a/tests/test/util/test_queue.cpp
+++ b/tests/test/util/test_queue.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Test wait for draining queue with elements", "[util]")
     }
 
     // Background thread to consume elements
-    std::thread t([&q, &dequeued, nElems] {
+    std::jthread t([&q, &dequeued, nElems] {
         for (int i = 0; i < nElems; i++) {
             SLEEP_MS(100);
 
@@ -125,8 +125,8 @@ TEMPLATE_TEST_CASE("Test queue on non-copy-constructible object",
     q.enqueue(std::move(a));
     q.enqueue(std::move(b));
 
-    std::thread ta([&q] { q.dequeue().set_value(1); });
-    std::thread tb([&q] {
+    std::jthread ta([&q] { q.dequeue().set_value(1); });
+    std::jthread tb([&q] {
         SLEEP_MS(SHORT_TEST_TIMEOUT_MS);
         q.dequeue().set_value(2);
     });
@@ -174,7 +174,7 @@ TEST_CASE("Test fixed capacity queue", "[util]")
     FixedCapIntQueue q(2);
     auto latch = faabric::util::Latch::create(2);
 
-    std::thread consumerThread([&latch, &q] {
+    std::jthread consumerThread([&latch, &q] {
         // Make sure we consume once to make one slot in the queue
         latch->wait();
         q.dequeue();
@@ -197,8 +197,8 @@ TEST_CASE("Stress test fixed capacity queue", "[util]")
 {
     int numThreadPairs = 10;
     int numMessages = 1000;
-    std::vector<std::thread> producerThreads;
-    std::vector<std::thread> consumerThreads;
+    std::vector<std::jthread> producerThreads;
+    std::vector<std::jthread> consumerThreads;
     std::vector<std::unique_ptr<FixedCapIntQueue>> queues;
     auto startLatch = faabric::util::Latch::create(2 * numThreadPairs + 1);
 
@@ -245,7 +245,7 @@ TEST_CASE("Test fixed capacity queue with asymetric consume/produce rates",
 
     // Fast producer
     bool producerSuccess = false;
-    std::thread producerThread([&q, nMessages, &producerSuccess] {
+    std::jthread producerThread([&q, nMessages, &producerSuccess] {
         for (int i = 0; i < nMessages; i++) {
             SLEEP_MS(1);
             q.enqueue(i);
@@ -256,7 +256,7 @@ TEST_CASE("Test fixed capacity queue with asymetric consume/produce rates",
 
     // Slow consumer
     bool consumerSuccess = false;
-    std::thread consumerThread([&q, nMessages, &consumerSuccess] {
+    std::jthread consumerThread([&q, nMessages, &consumerSuccess] {
         for (int i = 0; i < nMessages; i++) {
             SLEEP_MS(50);
             int res = q.dequeue();

--- a/tests/test/util/test_tokens.cpp
+++ b/tests/test/util/test_tokens.cpp
@@ -46,24 +46,24 @@ TEST_CASE("Test token pool operation with some threads", "[util]")
     std::vector<int> expected;
     REQUIRE(vars::acquiredTokens.empty());
 
-    std::thread t1(getTokenTask);
+    std::jthread t1(getTokenTask);
     t1.join();
     expected.push_back(0);
     REQUIRE(vars::acquiredTokens == expected);
 
-    std::thread t2(getTokenTask);
+    std::jthread t2(getTokenTask);
     t2.join();
     expected.push_back(1);
     REQUIRE(vars::acquiredTokens == expected);
 
-    std::thread t3(getTokenTask);
+    std::jthread t3(getTokenTask);
     t3.join();
     expected.push_back(2);
     REQUIRE(vars::acquiredTokens == expected);
 
     vars::sharedPool.releaseToken(1);
 
-    std::thread t4(getTokenTask);
+    std::jthread t4(getTokenTask);
     t4.join();
     expected.push_back(1);
     REQUIRE(vars::acquiredTokens == expected);


### PR DESCRIPTION
The majority of threading we do is to create background workers, and we often don't need to explicitly wait for these workers to finish. In some places, having to explicitly join threads introduces memory leaks, as with the `deadExecutors` and `deadThreads` in the `Scheduler` and `Executor` respectively.

This makes [`std::jthread`](https://en.cppreference.com/w/cpp/thread/jthread) a better choice than `std::thread`, as it exposes the same API, but doesn't require an explicit join, and we can take advantage of its `std::stop_token` to stop workers where we currently use condition variables. 

This is an initial PR to find-and-replace `std::thread` with `std::jthread`, and more will come to remove joining where possible, remove dead executors, and handle shutdowns.