### PR TITLE
Clear Point-to-Point broker

### DIFF
--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -584,11 +584,12 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             } else {
                 reset(msg);
             }
-            // Clear the thread local PTP cache
-            faabric::transport::getPointToPointBroker().resetThreadLocalCache();
 
             releaseClaim();
         }
+
+        // Clear the thread local PTP cache
+        faabric::transport::getPointToPointBroker().resetThreadLocalCache();
 
         // Return this thread index to the pool available for scheduling
         {

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -584,6 +584,8 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             } else {
                 reset(msg);
             }
+            // Clear the thread local PTP cache
+            faabric::transport::getPointToPointBroker().resetThreadLocalCache();
 
             releaseClaim();
         }

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -588,9 +588,6 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             releaseClaim();
         }
 
-        // Clear the thread local PTP cache
-        faabric::transport::getPointToPointBroker().resetThreadLocalCache();
-
         // Return this thread index to the pool available for scheduling
         {
             faabric::util::UniqueLock lock(threadsMutex);

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -120,6 +120,9 @@ void Scheduler::reset()
     }
     executors.clear();
 
+    // Clear the point to point broker
+    broker.clear();
+
     faabric::util::FullLock lock(mx);
 
     // Ensure host is set correctly

--- a/tests/test/transport/test_point_to_point.cpp
+++ b/tests/test/transport/test_point_to_point.cpp
@@ -160,6 +160,13 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
     REQUIRE(receivedDataB == sentDataB);
     REQUIRE(receivedDataC == sentDataC);
 
+    // Clear local records
+    broker.resetThreadLocalCache();
+
+    // Clear broker
+    broker.clear();
+    REQUIRE(broker.getIdxsRegisteredForGroup(groupId).empty());
+
     conf.reset();
 }
 

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -70,6 +70,28 @@ class PointToPointGroupFixture
 };
 
 TEST_CASE_METHOD(PointToPointGroupFixture,
+                 "Test removing mappings from point-to-point broker",
+                 "[transport][ptp]")
+{
+    int appId = 123;
+    int groupId = 456;
+    int groupSize = 3;
+
+    auto group = setUpGroup(appId, groupId, groupSize);
+
+    REQUIRE(broker.getIdxsRegisteredForGroup(groupId).size() == groupSize);
+
+    SECTION("Clear through broker") { broker.clear(); }
+
+    SECTION("Clear through scheduler reset")
+    {
+        faabric::scheduler::getScheduler().reset();
+    }
+
+    REQUIRE(broker.getIdxsRegisteredForGroup(groupId).empty());
+}
+
+TEST_CASE_METHOD(PointToPointGroupFixture,
                  "Test lock requests",
                  "[ptp][transport]")
 {


### PR DESCRIPTION
In this PR I add support to clean the thread-local and shared records in the Point-to-Point broker as part of the executor cleanup and scheduler reset respectively.