### PR TITLE
Various MPI fixes

### DIFF
--- a/include/faabric/scheduler/ExecGraph.h
+++ b/include/faabric/scheduler/ExecGraph.h
@@ -24,6 +24,10 @@ std::set<std::string> getExecGraphHosts(const ExecGraph& graph);
 
 std::vector<std::string> getMpiRankHostsFromExecGraph(const ExecGraph& graph);
 
+void getMigratedMpiRankHostsFromExecGraph(const ExecGraph& graph,
+                                          std::vector<std::string>& hostsBefore,
+                                          std::vector<std::string>& hostsAfter);
+
 std::string execNodeToJson(const ExecGraphNode& node);
 
 std::string execGraphToJson(const ExecGraph& graph);

--- a/include/faabric/scheduler/ExecGraph.h
+++ b/include/faabric/scheduler/ExecGraph.h
@@ -24,9 +24,8 @@ std::set<std::string> getExecGraphHosts(const ExecGraph& graph);
 
 std::vector<std::string> getMpiRankHostsFromExecGraph(const ExecGraph& graph);
 
-void getMigratedMpiRankHostsFromExecGraph(const ExecGraph& graph,
-                                          std::vector<std::string>& hostsBefore,
-                                          std::vector<std::string>& hostsAfter);
+std::pair<std::vector<std::string>, std::vector<std::string>>
+getMigratedMpiRankHostsFromExecGraph(const ExecGraph& graph);
 
 std::string execNodeToJson(const ExecGraphNode& node);
 

--- a/include/faabric/transport/context.h
+++ b/include/faabric/transport/context.h
@@ -8,6 +8,7 @@
 // https://zguide.zeromq.org/docs/chapter2/#I-O-Threads
 
 #define ZMQ_CONTEXT_IO_THREADS 1
+#define FAASM_ZMQ_MAX_SOCKETS 1024 * 1024
 
 namespace faabric::transport {
 

--- a/src/scheduler/ExecGraph.cpp
+++ b/src/scheduler/ExecGraph.cpp
@@ -99,6 +99,7 @@ getMigratedMpiRankHostsFromExecGraph(const ExecGraph& graph)
             if (hostsBefore.at(rank).empty()) {
                 hostsBefore.at(rank) = executedHost;
             }
+
             hostsAfter.at(rank) = executedHost;
         } else if (returnValue == MIGRATED_FUNCTION_RETURN_VALUE) {
             // When we process a message that has been migrated we always

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -123,7 +123,12 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
             msg.set_cmdline(thisRankMsg->cmdline());
             msg.set_inputdata(thisRankMsg->inputdata());
             msg.set_migrationcheckperiod(thisRankMsg->migrationcheckperiod());
-            msg.set_topologyhint(thisRankMsg->topologyhint());
+            // To run migration experiments easily, we may want to propagate
+            // the `UNDERFULL` topology hint. In general however, we don't
+            // need to propagate this field
+            if (msg.topologyhint() == "UNDERFULL") {
+                msg.set_topologyhint(thisRankMsg->topologyhint());
+            }
             // Log chained functions to generate execution graphs
             if (thisRankMsg->recordexecgraph()) {
                 sch.logChainedFunction(call.id(), msg.id());

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -124,11 +124,12 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
             msg.set_inputdata(thisRankMsg->inputdata());
             msg.set_migrationcheckperiod(thisRankMsg->migrationcheckperiod());
             // To run migration experiments easily, we may want to propagate
-            // the `UNDERFULL` topology hint. In general however, we don't
+            // the UNDERFULL topology hint. In general however, we don't
             // need to propagate this field
             if (thisRankMsg->topologyhint() == "UNDERFULL") {
                 msg.set_topologyhint(thisRankMsg->topologyhint());
             }
+
             // Log chained functions to generate execution graphs
             if (thisRankMsg->recordexecgraph()) {
                 sch.logChainedFunction(call.id(), msg.id());

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -126,7 +126,7 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
             // To run migration experiments easily, we may want to propagate
             // the `UNDERFULL` topology hint. In general however, we don't
             // need to propagate this field
-            if (msg.topologyhint() == "UNDERFULL") {
+            if (thisRankMsg->topologyhint() == "UNDERFULL") {
                 msg.set_topologyhint(thisRankMsg->topologyhint());
             }
             // Log chained functions to generate execution graphs

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -123,6 +123,7 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
             msg.set_cmdline(thisRankMsg->cmdline());
             msg.set_inputdata(thisRankMsg->inputdata());
             msg.set_migrationcheckperiod(thisRankMsg->migrationcheckperiod());
+            msg.set_topologyhint(thisRankMsg->topologyhint());
             // Log chained functions to generate execution graphs
             if (thisRankMsg->recordexecgraph()) {
                 sch.logChainedFunction(call.id(), msg.id());

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -432,7 +432,6 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
         // Work out how many we can handle locally
         int slots = thisHostResources.slots();
         if (topologyHint == faabric::util::SchedulingTopologyHint::UNDERFULL) {
-            SPDLOG_WARN("Underfilling local slots according to topology hint");
             slots = slots / 2;
         }
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -432,6 +432,7 @@ faabric::util::SchedulingDecision Scheduler::doSchedulingDecision(
         // Work out how many we can handle locally
         int slots = thisHostResources.slots();
         if (topologyHint == faabric::util::SchedulingTopologyHint::UNDERFULL) {
+            SPDLOG_WARN("Underfilling local slots according to topology hint");
             slots = slots / 2;
         }
 
@@ -1529,6 +1530,7 @@ Scheduler::doCheckForMigrationOpportunities(
 
         // If we have already recorded a pending migration for this req,
         // skip
+        // TODO - we may want to change this
         if (getPendingAppMigrations(originalDecision.appId) != nullptr) {
             SPDLOG_TRACE("Skipping app {} as migration opportunity has "
                          "already been recorded",

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1530,7 +1530,6 @@ Scheduler::doCheckForMigrationOpportunities(
 
         // If we have already recorded a pending migration for this req,
         // skip
-        // TODO - we may want to change this
         if (getPendingAppMigrations(originalDecision.appId) != nullptr) {
             SPDLOG_TRACE("Skipping app {} as migration opportunity has "
                          "already been recorded",

--- a/src/transport/context.cpp
+++ b/src/transport/context.cpp
@@ -16,7 +16,8 @@ void initGlobalMessageContext()
     }
 
     SPDLOG_TRACE("Initialising global ZeroMQ context");
-    instance = std::make_shared<zmq::context_t>(ZMQ_CONTEXT_IO_THREADS, FAASM_ZMQ_MAX_SOCKETS);
+    instance = std::make_shared<zmq::context_t>(ZMQ_CONTEXT_IO_THREADS,
+                                                FAASM_ZMQ_MAX_SOCKETS);
 }
 
 std::shared_ptr<zmq::context_t> getGlobalMessageContext()

--- a/src/transport/context.cpp
+++ b/src/transport/context.cpp
@@ -16,7 +16,7 @@ void initGlobalMessageContext()
     }
 
     SPDLOG_TRACE("Initialising global ZeroMQ context");
-    instance = std::make_shared<zmq::context_t>(ZMQ_CONTEXT_IO_THREADS);
+    instance = std::make_shared<zmq::context_t>(ZMQ_CONTEXT_IO_THREADS, FAASM_ZMQ_MAX_SOCKETS);
 }
 
 std::shared_ptr<zmq::context_t> getGlobalMessageContext()

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -128,16 +128,11 @@ class MpiDistTestsFixture : public DistTestsFixture
       const std::vector<std::string> expectedHostsBefore,
       const std::vector<std::string> expectedHostsAfter)
     {
-        std::vector<std::string> actualHostsBefore(
-          execGraph.rootNode.msg.mpiworldsize());
-        std::vector<std::string> actualHostsAfter(
-          execGraph.rootNode.msg.mpiworldsize());
+        auto actualHostsBeforeAndAfter =
+          faabric::scheduler::getMigratedMpiRankHostsFromExecGraph(execGraph);
 
-        faabric::scheduler::getMigratedMpiRankHostsFromExecGraph(
-          execGraph, actualHostsBefore, actualHostsAfter);
-
-        REQUIRE(actualHostsBefore == expectedHostsBefore);
-        REQUIRE(actualHostsAfter == expectedHostsAfter);
+        REQUIRE(actualHostsBeforeAndAfter.first == expectedHostsBefore);
+        REQUIRE(actualHostsBeforeAndAfter.second == expectedHostsAfter);
     }
 
     void checkAllocationAndResult(

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -133,39 +133,8 @@ class MpiDistTestsFixture : public DistTestsFixture
         std::vector<std::string> actualHostsAfter(
           execGraph.rootNode.msg.mpiworldsize());
 
-        std::queue<faabric::scheduler::ExecGraphNode> nodeList;
-        nodeList.push(execGraph.rootNode);
-        while (!nodeList.empty()) {
-            // Process the node at the front
-            auto node = nodeList.front();
-            int returnValue = node.msg.returnvalue();
-            int rank = node.msg.mpirank();
-            std::string executedHost = node.msg.executedhost();
-            if (returnValue == 0) {
-                // We don't know if this particular rank has been migrated or
-                // not. Thus we only write in the before vector if no-one has
-                // written to that rank before
-                if (actualHostsBefore.at(rank).empty()) {
-                    actualHostsBefore.at(rank) = executedHost;
-                }
-                actualHostsAfter.at(rank) = executedHost;
-            } else if (returnValue == MIGRATED_FUNCTION_RETURN_VALUE) {
-                // When we process a message that has been migrated we always
-                // overwrite the contents of the before vector
-                actualHostsBefore.at(rank) = executedHost;
-            } else {
-                SPDLOG_ERROR("Unexpected return value {} for message id {}",
-                             returnValue,
-                             node.msg.id());
-                throw std::runtime_error("Unexpected return value");
-            }
-            nodeList.pop();
-
-            // Add children to the queue
-            for (auto c : node.children) {
-                nodeList.push(c);
-            }
-        }
+        faabric::scheduler::getMigratedMpiRankHostsFromExecGraph(
+          execGraph, actualHostsBefore, actualHostsAfter);
 
         REQUIRE(actualHostsBefore == expectedHostsBefore);
         REQUIRE(actualHostsAfter == expectedHostsAfter);

--- a/tests/dist/mpi/test_mpi_functions.cpp
+++ b/tests/dist/mpi/test_mpi_functions.cpp
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(MpiDistTestsFixture, "Test MPI all to all many times", "[mpi]")
     nLocalSlots = 4;
     int worldSize = 8;
     for (int i = 0; i < numRuns; i++) {
-        SPDLOG_INFO("Starting run {}/{}", i + 1, numRuns);
+        SPDLOG_DEBUG("Starting run {}/{}", i + 1, numRuns);
         // Set up this host's resources
         setLocalSlots(nLocalSlots, worldSize);
         auto req = setRequest("alltoall");
@@ -61,8 +61,6 @@ TEST_CASE_METHOD(MpiDistTestsFixture, "Test MPI all to all many times", "[mpi]")
         sch.callFunctions(req);
 
         checkAllocationAndResult(req);
-
-        SLEEP_MS(500);
     }
 
     nLocalSlots = oldNumLocalSlots;

--- a/tests/dist/mpi/test_mpi_functions.cpp
+++ b/tests/dist/mpi/test_mpi_functions.cpp
@@ -45,6 +45,29 @@ TEST_CASE_METHOD(MpiDistTestsFixture, "Test MPI all to all", "[mpi]")
     checkAllocationAndResult(req);
 }
 
+TEST_CASE_METHOD(MpiDistTestsFixture, "Test MPI all to all many times", "[mpi]")
+{
+    int numRuns = 50;
+    int oldNumLocalSlots = nLocalSlots;
+    nLocalSlots = 4;
+    int worldSize = 8;
+    for (int i = 0; i < numRuns; i++) {
+        SPDLOG_INFO("Starting run {}/{}", i + 1, numRuns);
+        // Set up this host's resources
+        setLocalSlots(nLocalSlots, worldSize);
+        auto req = setRequest("alltoall");
+
+        // Call the functions
+        sch.callFunctions(req);
+
+        checkAllocationAndResult(req);
+
+        SLEEP_MS(500);
+    }
+
+    nLocalSlots = oldNumLocalSlots;
+}
+
 TEST_CASE_METHOD(MpiDistTestsFixture, "Test MPI all to all and sleep", "[mpi]")
 {
     // Set up this host's resources


### PR DESCRIPTION
In this PR I fix a couple of issues that I ran into whilst reproducing the MPI results.
* Failing test and workaround for #266. The current solution is only a patch, and we should address it properly in a separate PR.
* Propagate `UNDERFULL` topology hint in MPI to deliberately missplace MPI functions for a migration opportunity to appear.
* Fix race condition in MPI migration.