### PR TITLE
Not stop tracking changes if never started

### DIFF
--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -560,6 +560,7 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
         // If this is not a threads request and last in its batch, it may be
         // the main function in a threaded application, in which case we
         // want to stop any tracking and delete the main thread snapshot
+        /* TODO: This is causing tracking to stop, even if it never started
         if (!isThreads && isLastInBatch) {
             // Stop tracking memory
             std::span<uint8_t> memView = getMemoryView();
@@ -572,6 +573,7 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
                 deleteMainThreadSnapshot(msg);
             }
         }
+        */
 
         // If this batch is finished, reset the executor and release its
         // claim. Note that we have to release the claim _after_ resetting,


### PR DESCRIPTION
We start tracking for memory changes if (i) we are executing threads and (ii) the execution is not in a single host.

Thus, we call `startTracking`:
* When resetting one thread (`Executor.cpp#L195`): memory tracking and thread-local tracking.
* When starting the execution of a threaded task that is not single host (`Executor.cpp#L255`): only global tracking.

Yet, we call `stopTracking`:
* When we are the last thread in a batch and not single-host (`Executor.cpp#L522`): global tracking.
* When we finish a thread's execution (`Executor.cpp#L142`) both memory and thread-local tracking.
* When we finish _any_ non-threaded execution (see commented lines). According to the comment, this is for the main function of threaded applications. 

AFAICT, in the situations that the last point is trying to catch we never start tracking for memory changes. This means that we are calling `stopTracking` virtually every execution, without `startTracking` before.

This is a problem because `stopTracking` calls `mprotect`, which requires memory to be `mmap`-ed before (not `malloc`-ed). `mprotect` is not available inside SGX (and it may make sense to disable it in WAMR as well to have the same configuration). I can patch this by returning an empty `memoryView` from the `WasmModule` implementation for the corresponding `WASM_VM`, but I am wondering if this is the expected behaviour and not a bug.

The failures in the tests should be fixed with #293.