### PR TITLE
Add BOOST_NO_TYPEID=1 to the conan build environment to prevent crashes.

### DIFF
--- a/conan-profile.txt
+++ b/conan-profile.txt
@@ -13,3 +13,5 @@ build_type=Release
 [env]
 CC=/usr/bin/clang-13
 CXX=/usr/bin/clang++-13
+[conf]
+tools.build:defines=["BOOST_NO_TYPEID=1"]

--- a/conan-profile.txt
+++ b/conan-profile.txt
@@ -13,5 +13,3 @@ build_type=Release
 [env]
 CC=/usr/bin/clang-13
 CXX=/usr/bin/clang++-13
-[conf]
-tools.build:defines=["BOOST_NO_TYPEID=1"]

--- a/include/faabric/endpoint/FaabricEndpoint.h
+++ b/include/faabric/endpoint/FaabricEndpoint.h
@@ -16,7 +16,7 @@ enum class EndpointMode
 };
 
 namespace detail {
-struct EndpointState;
+class EndpointState;
 }
 
 struct HttpRequestContext


### PR DESCRIPTION
Cpprestsdk uses boost::asio itself, which caused conflicting definitions to be linked together, leading to the version with RTTI enabled taking precedence during linktime.