### PR TITLE
Fix clang-10 formatting check

### DIFF
--- a/tasks/format_code.py
+++ b/tasks/format_code.py
@@ -51,7 +51,12 @@ def format(ctx, check=False):
         .split("\n")[:-1]
     )
 
-    clang_cmd = "clang-format-10 -i {}".format(" ".join(files_to_check))
+    if check:
+        clang_cmd = "clang-format-10 --dry-run --Werror {}".format(
+            " ".join(files_to_check)
+        )
+    else:
+        clang_cmd = "clang-format-10 -i {}".format(" ".join(files_to_check))
     run(clang_cmd, shell=True, check=True, cwd=PROJ_ROOT)
 
     # ---- Append newlines to C/C++ files if not there ----

--- a/tasks/format_code.py
+++ b/tasks/format_code.py
@@ -51,12 +51,12 @@ def format(ctx, check=False):
         .split("\n")[:-1]
     )
 
-    if check:
-        clang_cmd = "clang-format-10 --dry-run --Werror {}".format(
-            " ".join(files_to_check)
-        )
-    else:
-        clang_cmd = "clang-format-10 -i {}".format(" ".join(files_to_check))
+    clang_cmd = [
+        "clang-format-10",
+        "--dry-run --Werror" if check else "-i",
+        " ".join(files_to_check),
+    ]
+    clang_cmd = " ".join(clang_cmd)
     run(clang_cmd, shell=True, check=True, cwd=PROJ_ROOT)
 
     # ---- Append newlines to C/C++ files if not there ----


### PR DESCRIPTION
I realised that the `format-code` task wasn't working for C++ code with the `--check` flag. In this PR I fix the issue and now, with the `--check` flag,  `clang-format-10` returns an error if formatting changes are needed.