### PR TITLE
Replace VLA usage with heap-allocated buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 
 # Top-level CMake config
-set(CMAKE_CXX_FLAGS "-Wall")
+set(CMAKE_CXX_FLAGS "-Wall -Werror=vla")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/faabric/transport/macros.h
+++ b/include/faabric/transport/macros.h
@@ -6,20 +6,6 @@
         throw std::runtime_error("Error deserialising message");               \
     }
 
-#define SERIALISE_MSG(_msg)                                                    \
-    size_t serialisedSize = _msg.ByteSizeLong();                               \
-    uint8_t serialisedBuffer[serialisedSize];                                  \
-    if (!_msg.SerializeToArray(serialisedBuffer, serialisedSize)) {            \
-        throw std::runtime_error("Error serialising message");                 \
-    }
-
-#define SERIALISE_MSG_PTR(_msg)                                                \
-    size_t serialisedSize = _msg->ByteSizeLong();                              \
-    uint8_t serialisedBuffer[serialisedSize];                                  \
-    if (!_msg->SerializeToArray(serialisedBuffer, serialisedSize)) {           \
-        throw std::runtime_error("Error serialising message");                 \
-    }
-
 #define SEND_FB_MSG(T, _mb)                                                    \
     {                                                                          \
         const uint8_t* _buffer = _mb.GetBufferPointer();                       \

--- a/src/scheduler/MpiWorld.cpp
+++ b/src/scheduler/MpiWorld.cpp
@@ -57,9 +57,18 @@ void MpiWorld::sendRemoteMpiMessage(
   int recvRank,
   const std::shared_ptr<faabric::MPIMessage>& msg)
 {
-    SERIALISE_MSG_PTR(msg);
+    std::string serialisedBuffer;
+    if (!msg->SerializeToString(&serialisedBuffer)) {
+        throw std::runtime_error("Error serialising message");
+    }
     broker.sendMessage(
-      id, sendRank, recvRank, serialisedBuffer, serialisedSize, dstHost, true);
+      id,
+      sendRank,
+      recvRank,
+      reinterpret_cast<const uint8_t*>(serialisedBuffer.data()),
+      serialisedBuffer.size(),
+      dstHost,
+      true);
 }
 
 std::shared_ptr<faabric::MPIMessage> MpiWorld::recvRemoteMpiMessage(

--- a/src/transport/MessageEndpointClient.cpp
+++ b/src/transport/MessageEndpointClient.cpp
@@ -17,14 +17,16 @@ void MessageEndpointClient::asyncSend(int header,
                                       google::protobuf::Message* msg,
                                       int sequenceNum)
 {
-    size_t msgSize = msg->ByteSizeLong();
-    uint8_t buffer[msgSize];
+    std::string buffer;
 
-    if (!msg->SerializeToArray(buffer, msgSize)) {
+    if (!msg->SerializeToString(&buffer)) {
         throw std::runtime_error("Error serialising message");
     }
 
-    asyncSend(header, buffer, msgSize, sequenceNum);
+    asyncSend(header,
+              reinterpret_cast<uint8_t*>(buffer.data()),
+              buffer.size(),
+              sequenceNum);
 }
 
 void MessageEndpointClient::asyncSend(int header,
@@ -39,13 +41,15 @@ void MessageEndpointClient::syncSend(int header,
                                      google::protobuf::Message* msg,
                                      google::protobuf::Message* response)
 {
-    size_t msgSize = msg->ByteSizeLong();
-    uint8_t buffer[msgSize];
-    if (!msg->SerializeToArray(buffer, msgSize)) {
+    std::string buffer;
+    if (!msg->SerializeToString(&buffer)) {
         throw std::runtime_error("Error serialising message");
     }
 
-    syncSend(header, buffer, msgSize, response);
+    syncSend(header,
+             reinterpret_cast<uint8_t*>(buffer.data()),
+             buffer.size(),
+             response);
 }
 
 void MessageEndpointClient::syncSend(int header,

--- a/src/transport/MessageEndpointServer.cpp
+++ b/src/transport/MessageEndpointServer.cpp
@@ -134,17 +134,18 @@ void MessageEndpointServerHandler::start(int timeoutMs)
                         std::unique_ptr<google::protobuf::Message> resp =
                           server->doSyncRecv(body);
 
-                        size_t respSize = resp->ByteSizeLong();
-
-                        uint8_t buffer[respSize];
-                        if (!resp->SerializeToArray(buffer, respSize)) {
+                        std::string buffer;
+                        if (!resp->SerializeToString(&buffer)) {
                             throw std::runtime_error(
                               "Error serialising message");
                         }
 
                         // Return the response
                         static_cast<SyncRecvMessageEndpoint*>(endpoint.get())
-                          ->sendResponse(NO_HEADER, buffer, respSize);
+                          ->sendResponse(
+                            NO_HEADER,
+                            reinterpret_cast<uint8_t*>(buffer.data()),
+                            buffer.size());
                     }
 
                     // Wait on the request latch if necessary

--- a/src/util/dirty.cpp
+++ b/src/util/dirty.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
@@ -590,8 +591,7 @@ void UffdDirtyTracker::eventThreadEntrypoint()
 {
     SPDLOG_TRACE(
       "Starting uffd event thread (uffd={}, closeFd={})", uffd, closeFd);
-    int nFds = 2;
-    struct pollfd pollfds[nFds];
+    std::array<struct pollfd, 2> pollfds;
 
     pollfds[0].fd = uffd;
     pollfds[0].events = POLLIN;
@@ -600,7 +600,7 @@ void UffdDirtyTracker::eventThreadEntrypoint()
     pollfds[1].events = POLLIN;
 
     for (;;) {
-        int nReady = poll(pollfds, nFds, -1);
+        int nReady = poll(pollfds.data(), pollfds.size(), -1);
         if (nReady == -1) {
             SPDLOG_ERROR("Poll failed: {} ({})", errno, strerror(errno));
             throw std::runtime_error("Poll failed");

--- a/src/util/random.cpp
+++ b/src/util/random.cpp
@@ -5,7 +5,7 @@
 namespace faabric::util {
 std::string randomString(int len)
 {
-    char result[len];
+    std::string result(len, '\0');
 
     static const char alphanum[] = "123456789"
                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -23,7 +23,7 @@ std::string randomString(int len)
         result[i] = alphanum[r];
     }
 
-    return std::string(result, result + len);
+    return result;
 }
 
 std::string randomStringFromSet(const std::unordered_set<std::string>& s)


### PR DESCRIPTION
Variable length arrays are a compiler extension and not part of the base c++ language, they cause dynamic stack allocations which can silently overflow the stack, causing hard-to-debug errors at runtime which I have ran into a couple of times with large network messages.

The macros.h macros were only used once, so I just replaced the macro with its contents.
This has the additional benefit that SerializeToString (string is used as a bytes container in protobuf, not text) will only compute the size of the message once unlike the previous approach which computed it twice while serializing.