### PR TITLE
Reset executor when a function invokes threads

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -124,6 +124,7 @@ class Executor
     std::atomic<bool> claimed = false;
     std::atomic<bool> _isShutdown = false;
     std::atomic<int> batchCounter = 0;
+    std::atomic<int> threadBatchCounter = 0;
     faabric::util::TimePoint lastExec;
 
     // ---- Application threads ----

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -206,7 +206,7 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
                             std::shared_ptr<faabric::BatchExecuteRequest> req)
 {
     const std::string funcStr = faabric::util::funcToString(req);
-    SPDLOG_ERROR("{} executing {}/{} tasks of {} (single-host={})",
+    SPDLOG_TRACE("{} executing {}/{} tasks of {} (single-host={})",
                  id,
                  msgIdxs.size(),
                  req->messages_size(),
@@ -438,7 +438,7 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
               faabric::transport::PointToPointGroup::getGroup(msg.groupid());
         }
 
-        SPDLOG_WARN("Thread {}:{} executing task {} ({}, thread={}, group={})",
+        SPDLOG_TRACE("Thread {}:{} executing task {} ({}, thread={}, group={})",
                      id,
                      threadPoolIdx,
                      task.messageIndex,

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -513,7 +513,8 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
         if (isThreads) {
             oldTaskCount = threadBatchCounter.fetch_sub(1);
             isLastThreadInBatch = oldTaskCount == 1;
-            isLastThreadInExecutor = batchCounter.load(std::memory_order_release) == 0;
+            isLastThreadInExecutor =
+              batchCounter.load(std::memory_order_release) == 0;
         } else {
             oldTaskCount = batchCounter.fetch_sub(1);
             isLastThreadInExecutor = oldTaskCount == 1;

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -594,7 +594,7 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             // Threads skip the reset as they will be restored from their
             // respective snapshot on the next execution.
             if (isThreads) {
-                SPDLOG_WARN("Skipping reset for {} ({})",
+                SPDLOG_TRACE("Skipping reset for {} ({})",
                              faabric::util::funcToString(msg, true),
                              msg.appidx());
             } else {

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -1018,6 +1018,9 @@ TEST_CASE_METHOD(TestExecutorFixture,
 
     int expectedResets = 1;
 
+    std::string user = "dummy";
+    std::string function = "blah";
+
     SECTION("Threads")
     {
         requestType = faabric::BatchExecuteRequest::THREADS;
@@ -1025,10 +1028,15 @@ TEST_CASE_METHOD(TestExecutorFixture,
         expectedResets = 0;
     }
 
-    SECTION("Function") {}
+    SECTION("Simple function") {}
+
+    SECTION("Function that spawns threads")
+    {
+        function = "thread-check";
+    }
 
     std::shared_ptr<BatchExecuteRequest> req =
-      faabric::util::batchExecFactory("dummy", "blah", nMessages);
+      faabric::util::batchExecFactory(user, function, nMessages);
     req->set_type(requestType);
 
     faabric::Message& msg = req->mutable_messages()->at(0);

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -1030,10 +1030,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
 
     SECTION("Simple function") {}
 
-    SECTION("Function that spawns threads")
-    {
-        function = "thread-check";
-    }
+    SECTION("Function that spawns threads") { function = "thread-check"; }
 
     std::shared_ptr<BatchExecuteRequest> req =
       faabric::util::batchExecFactory(user, function, nMessages);


### PR DESCRIPTION
In a request of type `THREADS`, the "caller" (or main) thread (the thread that calls `executeThreads`, which is _not_ part of the `THREADS` request) [executes in the same `Executor`](https://github.com/faasm/faabric/blob/main/src/scheduler/Scheduler.cpp#L818-L843) than the "callee" threads (the threads spawned as a consequence of `executeThreads`, i.e. the `THREADS` request).

This means that the `batchCounter` atomic counter in the `Executor` will take different values:
* First, when the "caller"/main thread is invoked, it will take value 1.
* Second, when the main thread issues a `THREADS` request, it will take the value of the size of the `THREADS` request.

This is because we were overwritting the value of the atomic counter with a `store()`.

This is problematic because we use `batchCounter` to define the variable `isLastInBatch` that we use to determine when a batch is finished. A finished batch can either be:
i. The batch corresponding to the main thread.
ii. The batch corresponding to the `THREADS` request.

Each finished batch requires a different cleanup:
i. When the main thread finishes we need to `reset()` and release the claim on the the executor.
ii. When a `THREADS` batch finishes, we need to synchronise the diffs and set the results.

In addition, if the batch is a `THREADS` request and is not executing in the main host, it means that we also need to `release()` (but not `reset()`) the executor.

At the moment we are only doing (ii) and not (i). I add a regression test that fails against the current `main` branch in faabric.