### PR TITLE
Re-factor tests includes

### DIFF
--- a/tests/dist/dist_test_fixtures.h
+++ b/tests/dist/dist_test_fixtures.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include "DistTestExecutor.h"
 

--- a/tests/dist/mpi/test_mpi_functions.cpp
+++ b/tests/dist/mpi/test_mpi_functions.cpp
@@ -1,7 +1,7 @@
-#include "faabric_utils.h"
 #include <catch2/catch.hpp>
 
-#include "fixtures.h"
+#include "dist_test_fixtures.h"
+#include "faabric_utils.h"
 #include "init.h"
 #include "mpi/mpi_native.h"
 

--- a/tests/dist/mpi/test_multiple_mpi_worlds.cpp
+++ b/tests/dist/mpi/test_multiple_mpi_worlds.cpp
@@ -1,7 +1,7 @@
-#include "faabric_utils.h"
 #include <catch2/catch.hpp>
 
-#include "fixtures.h"
+#include "dist_test_fixtures.h"
+#include "faabric_utils.h"
 #include "init.h"
 #include "mpi/mpi_native.h"
 

--- a/tests/dist/scheduler/test_exec_graph.cpp
+++ b/tests/dist/scheduler/test_exec_graph.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 
-#include "fixtures.h"
+#include "dist_test_fixtures.h"
 
 #include <faabric/scheduler/Scheduler.h>
 

--- a/tests/dist/scheduler/test_funcs.cpp
+++ b/tests/dist/scheduler/test_funcs.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "dist_test_fixtures.h"
 #include "faabric_utils.h"
-#include "fixtures.h"
 #include "init.h"
 
 #include <faabric/proto/faabric.pb.h>

--- a/tests/dist/scheduler/test_hosts.cpp
+++ b/tests/dist/scheduler/test_hosts.cpp
@@ -1,7 +1,7 @@
 #include "faabric_utils.h"
 #include <catch2/catch.hpp>
 
-#include "fixtures.h"
+#include "dist_test_fixtures.h"
 #include "init.h"
 
 #include <faabric/scheduler/Scheduler.h>

--- a/tests/dist/scheduler/test_snapshots.cpp
+++ b/tests/dist/scheduler/test_snapshots.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "dist_test_fixtures.h"
 #include "faabric_utils.h"
-#include "fixtures.h"
 #include "init.h"
 
 #include <sys/mman.h>

--- a/tests/dist/scheduler/test_threads.cpp
+++ b/tests/dist/scheduler/test_threads.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "dist_test_fixtures.h"
 #include "faabric_utils.h"
-#include "fixtures.h"
 #include "init.h"
 
 #include <sys/mman.h>

--- a/tests/dist/transport/test_coordination.cpp
+++ b/tests/dist/transport/test_coordination.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "dist_test_fixtures.h"
 #include "faabric_utils.h"
-#include "fixtures.h"
 #include "init.h"
 
 #include <faabric/proto/faabric.pb.h>

--- a/tests/dist/transport/test_point_to_point.cpp
+++ b/tests/dist/transport/test_point_to_point.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "dist_test_fixtures.h"
 #include "faabric_utils.h"
-#include "fixtures.h"
 #include "init.h"
 
 #include <faabric/proto/faabric.pb.h>

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -90,8 +90,7 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
 {
     port++;
 
-    faabric::endpoint::FaabricEndpoint endpoint(
-      port, 2, std::make_shared<faabric::endpoint::FaabricEndpointHandler>());
+    faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
     endpoint.start(faabric::endpoint::EndpointMode::BG_THREAD);
 
@@ -147,8 +146,7 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
                  "[endpoint]")
 {
     port++;
-    faabric::endpoint::FaabricEndpoint endpoint(
-      port, 2, std::make_shared<faabric::endpoint::FaabricEndpointHandler>());
+    faabric::endpoint::FaabricEndpoint endpoint(port, 2);
 
     endpoint.start(faabric::endpoint::EndpointMode::BG_THREAD);
 

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/endpoint/FaabricEndpoint.h>
 #include <faabric/endpoint/FaabricEndpointHandler.h>
@@ -89,7 +90,8 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
 {
     port++;
 
-    faabric::endpoint::FaabricEndpoint endpoint(port, 2);
+    faabric::endpoint::FaabricEndpoint endpoint(
+      port, 2, std::make_shared<faabric::endpoint::FaabricEndpointHandler>());
 
     endpoint.start(faabric::endpoint::EndpointMode::BG_THREAD);
 
@@ -145,7 +147,8 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
                  "[endpoint]")
 {
     port++;
-    faabric::endpoint::FaabricEndpoint endpoint(port, 2);
+    faabric::endpoint::FaabricEndpoint endpoint(
+      port, 2, std::make_shared<faabric::endpoint::FaabricEndpointHandler>());
 
     endpoint.start(faabric::endpoint::EndpointMode::BG_THREAD);
 

--- a/tests/test/endpoint/test_handler.cpp
+++ b/tests/test/endpoint/test_handler.cpp
@@ -1,9 +1,9 @@
 #include <catch2/catch.hpp>
 
+#include "DummyExecutor.h"
+#include "DummyExecutorFactory.h"
 #include "faabric_utils.h"
-
-#include <DummyExecutor.h>
-#include <DummyExecutorFactory.h>
+#include "fixtures.h"
 
 #include <faabric/endpoint/FaabricEndpointHandler.h>
 #include <faabric/scheduler/Scheduler.h>

--- a/tests/test/runner/test_main.cpp
+++ b/tests/test/runner/test_main.cpp
@@ -1,5 +1,7 @@
-#include "faabric_utils.h"
 #include <catch2/catch.hpp>
+
+#include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/runner/FaabricMain.h>

--- a/tests/test/scheduler/test_exec_graph.cpp
+++ b/tests/test/scheduler/test_exec_graph.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/MpiWorld.h>

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 
-#include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <sys/mman.h>
 

--- a/tests/test/scheduler/test_executor_context.cpp
+++ b/tests/test/scheduler/test_executor_context.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/util/func.h>

--- a/tests/test/scheduler/test_executor_reaping.cpp
+++ b/tests/test/scheduler/test_executor_reaping.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/func.h>

--- a/tests/test/scheduler/test_function_migration.cpp
+++ b/tests/test/scheduler/test_function_migration.cpp
@@ -51,12 +51,13 @@ class FunctionMigrationTestFixture : public SchedulerTestFixture
             resources.set_slots(slotsPerHost.at(i));
             resources.set_usedslots(usedSlotsPerHost.at(i));
 
+            sch.addHostToGlobalSet(registeredHosts.at(i));
+
             // If setting resources for the master host, update the scheduler.
             // Otherwise, queue the resource response
             if (i == 0) {
                 sch.setThisHostResources(resources);
             } else {
-                sch.addHostToGlobalSet(registeredHosts.at(i));
                 faabric::scheduler::queueResourceResponse(registeredHosts.at(i),
                                                           resources);
             }

--- a/tests/test/scheduler/test_function_migration.cpp
+++ b/tests/test/scheduler/test_function_migration.cpp
@@ -51,13 +51,12 @@ class FunctionMigrationTestFixture : public SchedulerTestFixture
             resources.set_slots(slotsPerHost.at(i));
             resources.set_usedslots(usedSlotsPerHost.at(i));
 
-            sch.addHostToGlobalSet(registeredHosts.at(i));
-
             // If setting resources for the master host, update the scheduler.
             // Otherwise, queue the resource response
             if (i == 0) {
                 sch.setThisHostResources(resources);
             } else {
+                sch.addHostToGlobalSet(registeredHosts.at(i));
                 faabric::scheduler::queueResourceResponse(registeredHosts.at(i),
                                                           resources);
             }
@@ -145,7 +144,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
 
 TEST_CASE_METHOD(
   FunctionMigrationTestFixture,
-  "Test migration oportunities are only detected if set in the message",
+  "Test migration opportunities are only detected if set in the message",
   "[scheduler]")
 {
     // First set resources before calling the functions: one will be allocated

--- a/tests/test/scheduler/test_mpi_context.cpp
+++ b/tests/test/scheduler/test_mpi_context.cpp
@@ -1,9 +1,11 @@
 #include <catch2/catch.hpp>
 
+#include "faabric_utils.h"
+#include "fixtures.h"
+
 #include <faabric/scheduler/MpiContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/random.h>
-#include <faabric_utils.h>
 
 using namespace faabric::scheduler;
 

--- a/tests/test/scheduler/test_mpi_exec_graph.cpp
+++ b/tests/test/scheduler/test_mpi_exec_graph.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/scheduler/MpiWorld.h>
 #include <faabric/util/exec_graph.h>

--- a/tests/test/scheduler/test_mpi_world.cpp
+++ b/tests/test/scheduler/test_mpi_world.cpp
@@ -1,12 +1,14 @@
 #include <catch2/catch.hpp>
 
+#include "faabric_utils.h"
+#include "fixtures.h"
+
 #include <faabric/mpi/mpi.h>
 #include <faabric/scheduler/MpiWorld.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/macros.h>
 #include <faabric/util/random.h>
-#include <faabric_utils.h>
 
 #include <thread>
 

--- a/tests/test/scheduler/test_multiple_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_multiple_mpi_worlds.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
-#include <faabric_utils.h>
+#include "faabric_utils.h"
+#include "fixtures.h"
 
 using namespace faabric::scheduler;
 

--- a/tests/test/scheduler/test_remote_mpi_worlds.cpp
+++ b/tests/test/scheduler/test_remote_mpi_worlds.cpp
@@ -1,13 +1,14 @@
 #include <catch2/catch.hpp>
 
+#include "faabric_utils.h"
+#include "fixtures.h"
+
 #include <faabric/mpi/mpi.h>
 #include <faabric/scheduler/MpiWorldRegistry.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/bytes.h>
-#include <faabric/util/macros.h>
-#include <faabric_utils.h>
-
 #include <faabric/util/logging.h>
+#include <faabric/util/macros.h>
 
 #include <thread>
 

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch.hpp>
 
 #include "DummyExecutorFactory.h"
-#include "faabric/util/snapshot.h"
 #include "faabric_utils.h"
 #include "fixtures.h"
 
@@ -19,6 +18,7 @@
 #include <faabric/util/logging.h>
 #include <faabric/util/macros.h>
 #include <faabric/util/scheduling.h>
+#include <faabric/util/snapshot.h>
 #include <faabric/util/testing.h>
 
 using namespace faabric::scheduler;

--- a/tests/test/snapshot/test_snapshot_client_server.cpp
+++ b/tests/test/snapshot/test_snapshot_client_server.cpp
@@ -3,8 +3,6 @@
 #include "faabric_utils.h"
 #include "fixtures.h"
 
-#include <sys/mman.h>
-
 #include <faabric/snapshot/SnapshotClient.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/snapshot/SnapshotServer.h>
@@ -17,6 +15,8 @@
 #include <faabric/util/network.h>
 #include <faabric/util/snapshot.h>
 #include <faabric/util/testing.h>
+
+#include <sys/mman.h>
 
 using namespace faabric::util;
 

--- a/tests/test/snapshot/test_snapshot_diffs.cpp
+++ b/tests/test/snapshot/test_snapshot_diffs.cpp
@@ -1,12 +1,13 @@
 #include <catch2/catch.hpp>
 
-#include "faabric/util/bytes.h"
-#include "faabric/util/snapshot.h"
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/snapshot/SnapshotRegistry.h>
+#include <faabric/util/bytes.h>
 #include <faabric/util/dirty.h>
 #include <faabric/util/memory.h>
+#include <faabric/util/snapshot.h>
 
 using namespace faabric::snapshot;
 using namespace faabric::util;

--- a/tests/test/snapshot/test_snapshot_registry.cpp
+++ b/tests/test/snapshot/test_snapshot_registry.cpp
@@ -1,11 +1,12 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
-
-#include <sys/mman.h>
+#include "fixtures.h"
 
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/util/memory.h>
+
+#include <sys/mman.h>
 
 using namespace faabric::snapshot;
 using namespace faabric::util;

--- a/tests/test/state/test_redis_state.cpp
+++ b/tests/test/state/test_redis_state.cpp
@@ -1,14 +1,15 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/redis/Redis.h>
 #include <faabric/state/State.h>
 #include <faabric/util/config.h>
+#include <faabric/util/macros.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/state.h>
 
-#include <faabric/util/macros.h>
 #include <sys/mman.h>
 
 using namespace state;

--- a/tests/test/state/test_state.cpp
+++ b/tests/test/state/test_state.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/redis/Redis.h>
 #include <faabric/state/InMemoryStateKeyValue.h>

--- a/tests/test/state/test_state_server.cpp
+++ b/tests/test/state/test_state_server.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <faabric/state/InMemoryStateKeyValue.h>
 #include <faabric/state/State.h>

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -1,4 +1,4 @@
-#include "faabric_utils.h"
+#include "fixtures.h"
 #include <catch2/catch.hpp>
 
 #include <atomic>

--- a/tests/test/transport/test_message_server.cpp
+++ b/tests/test/transport/test_message_server.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 
-#include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <thread>
 
@@ -10,6 +10,7 @@
 #include <faabric/transport/common.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/macros.h>
+#include <faabric/util/network.h>
 
 using namespace faabric::transport;
 

--- a/tests/test/transport/test_point_to_point.cpp
+++ b/tests/test/transport/test_point_to_point.cpp
@@ -2,6 +2,7 @@
 
 #include "faabric/util/latch.h"
 #include "faabric_utils.h"
+#include "fixtures.h"
 
 #include <sys/mman.h>
 

--- a/tests/test/util/test_bytes.cpp
+++ b/tests/test/util/test_bytes.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+
 #include <faabric/util/bytes.h>
 
 using namespace faabric::util;

--- a/tests/test/util/test_concurrent_map.cpp
+++ b/tests/test/util/test_concurrent_map.cpp
@@ -8,7 +8,9 @@ std::ostream& operator<<(std::ostream& os, std::pair<int, int> const& value)
 }
 
 #include <catch2/catch.hpp>
+
 #include <faabric/util/concurrent_map.h>
+
 #include <string>
 #include <thread>
 #include <utility>

--- a/tests/test/util/test_delta.cpp
+++ b/tests/test/util/test_delta.cpp
@@ -1,7 +1,8 @@
 #include <catch2/catch.hpp>
 
-#include <algorithm>
 #include <faabric/util/delta.h>
+
+#include <algorithm>
 
 using namespace faabric::util;
 

--- a/tests/test/util/test_environment.cpp
+++ b/tests/test/util/test_environment.cpp
@@ -1,5 +1,6 @@
-#include "faabric_utils.h"
 #include <catch2/catch.hpp>
+
+#include "faabric_utils.h"
 
 #include <faabric/util/config.h>
 #include <faabric/util/environment.h>

--- a/tests/test/util/test_files.cpp
+++ b/tests/test/util/test_files.cpp
@@ -1,7 +1,7 @@
-#include "faabric/util/bytes.h"
-#include "faabric/util/config.h"
 #include <catch2/catch.hpp>
 
+#include <faabric/util/bytes.h>
+#include <faabric/util/config.h>
 #include <faabric/util/files.h>
 
 using namespace faabric::util;

--- a/tests/test/util/test_func.cpp
+++ b/tests/test/util/test_func.cpp
@@ -1,10 +1,10 @@
 #include <catch2/catch.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <faabric/util/clock.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
+
+#include <boost/filesystem.hpp>
 
 using namespace boost::filesystem;
 

--- a/tests/test/util/test_json.cpp
+++ b/tests/test/util/test_json.cpp
@@ -3,7 +3,6 @@
 #include "faabric_utils.h"
 
 #include <faabric/util/json.h>
-
 #include <faabric/util/logging.h>
 
 using namespace faabric::util;

--- a/tests/test/util/test_network.cpp
+++ b/tests/test/util/test_network.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+
 #include <faabric/util/network.h>
 
 using namespace faabric::util;

--- a/tests/test/util/test_state.cpp
+++ b/tests/test/util/test_state.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+
 #include <faabric/util/state.h>
 
 using namespace faabric::util;

--- a/tests/test/util/test_strings.cpp
+++ b/tests/test/util/test_strings.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+
 #include <faabric/util/bytes.h>
 #include <faabric/util/string_tools.h>
 

--- a/tests/test/util/test_tokens.cpp
+++ b/tests/test/util/test_tokens.cpp
@@ -1,8 +1,9 @@
 #include <catch2/catch.hpp>
+
 #include <faabric/util/queue.h>
-#include <thread>
 
 #include <iostream>
+#include <thread>
 
 using namespace faabric::util;
 

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -2,8 +2,6 @@
 
 #include <catch2/catch.hpp>
 
-#include "fixtures.h"
-
 #include <faabric/scheduler/ExecGraph.h>
 #include <faabric/state/State.h>
 #include <faabric/state/StateServer.h>

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -85,68 +85,7 @@ class CachedDecisionTestFixture
     faabric::util::DecisionCache& decisionCache;
 };
 
-class ConfTestFixture
-{
-  public:
-    ConfTestFixture()
-      : conf(faabric::util::getSystemConfig()){};
-
-    ~ConfTestFixture() { conf.reset(); };
-
-  protected:
-    faabric::util::SystemConfig& conf;
-};
-
-class PlannerTestFixture
-{
-  public:
-    PlannerTestFixture()
-    {
-        // Ensure the server is reachable
-        cli.ping();
-    }
-
-    ~PlannerTestFixture() { resetPlanner(); }
-
-  protected:
-    faabric::planner::PlannerClient cli;
-
-    void resetPlanner() const
-    {
-        faabric::planner::HttpMessage msg;
-        msg.set_type(faabric::planner::HttpMessage_Type_RESET);
-        std::string jsonStr;
-        faabric::util::messageToJsonPb(msg, &jsonStr);
-
-        faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-        std::pair<int, std::string> result =
-          postToUrl(conf.plannerHost, conf.plannerPort, jsonStr);
-        assert(result.first == 200);
-    }
-
-    faabric::planner::PlannerConfig getPlannerConfig()
-    {
-        faabric::planner::HttpMessage msg;
-        msg.set_type(faabric::planner::HttpMessage_Type_GET_CONFIG);
-        std::string jsonStr;
-        faabric::util::messageToJsonPb(msg, &jsonStr);
-
-        faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-        std::pair<int, std::string> result =
-          postToUrl(conf.plannerHost, conf.plannerPort, jsonStr);
-        REQUIRE(result.first == 200);
-
-        // Check that we can de-serialise the config. Note that if there's a
-        // de-serialisation the method will throw an exception
-        faabric::planner::PlannerConfig config;
-        faabric::util::jsonToMessagePb(result.second, &config);
-        return config;
-    }
-};
-
-class SchedulerTestFixture
-  : public CachedDecisionTestFixture
-  , public PlannerTestFixture
+class SchedulerTestFixture : public CachedDecisionTestFixture
 {
   public:
     SchedulerTestFixture()
@@ -248,6 +187,18 @@ class SnapshotTestFixture
 
   protected:
     faabric::snapshot::SnapshotRegistry& reg;
+};
+
+class ConfTestFixture
+{
+  public:
+    ConfTestFixture()
+      : conf(faabric::util::getSystemConfig()){};
+
+    ~ConfTestFixture() { conf.reset(); };
+
+  protected:
+    faabric::util::SystemConfig& conf;
 };
 
 class PointToPointTestFixture

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -5,8 +5,6 @@
 #include "DummyExecutorFactory.h"
 #include "faabric_utils.h"
 
-#include <faabric/planner/PlannerClient.h>
-#include <faabric/planner/planner.pb.h>
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/redis/Redis.h>
 #include <faabric/scheduler/ExecutorContext.h>

--- a/tests/utils/http_utils.cpp
+++ b/tests/utils/http_utils.cpp
@@ -41,7 +41,7 @@ std::pair<int, std::string> postToUrl(const std::string& host,
     curl_global_init(CURL_GLOBAL_ALL);
 
     std::string fullUrl = fmt::format("{}:{}", host, port);
-    SPDLOG_TRACE("Making HTTP GET request to {}", fullUrl);
+    SPDLOG_TRACE("Making HTTP POST request to {}", fullUrl);
 
     CURL* curl = curl_easy_init();
     if (curl == nullptr) {


### PR DESCRIPTION
To use test fixtures, we currently include `faabric_utils.h` around, instead of including `fixtures.h`. This works because in the former we also include `fixtures.h`. However, `fixtures.h` is actually _not_ needed in `faabric_utils.h`, and removing it from there breaks the compilation of all the tests.

In addition, this was making the file `tests/dist/fixtures.h` use `tests/util/fixtures.h` transitively through `faabric_utils.h`. This was silently overwriting the latter with the former, what could have eventually caused compilation errors.

In this PR, I re-factor the includes in the tests to:
1. Include `fixtures.h` instead of `faabric_utils.h` when we want to use the fixtures.
2. Follow the include order we soft-enforce across the codebase.
3. Re-factor `tests/dist/fixtures.h` to `tests/dist/dist_test_fixtures.h`.

I understand that we currently don't enforce 2 strongly anywhere, but I figured out that I would still amend it here nontheless. 