### PR TITLE
Remove `callFunction` signature

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -228,8 +228,6 @@ class Scheduler
       faabric::util::SchedulingTopologyHint topologyHint =
         faabric::util::SchedulingTopologyHint::NONE);
 
-    void callFunction(faabric::Message& msg, bool forceLocal = false);
-
     faabric::util::SchedulingDecision callFunctions(
       std::shared_ptr<faabric::BatchExecuteRequest> req);
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1003,23 +1003,6 @@ void Scheduler::broadcastSnapshotDelete(const faabric::Message& msg,
     }
 }
 
-void Scheduler::callFunction(faabric::Message& msg, bool forceLocal)
-{
-    // TODO - avoid this copy
-    auto req = faabric::util::batchExecFactory();
-    *req->add_messages() = msg;
-
-    // Specify that this is a normal function, not a thread
-    req->set_type(req->FUNCTIONS);
-
-    if (forceLocal) {
-        req->mutable_messages()->at(0).set_topologyhint("FORCE_LOCAL");
-    }
-
-    // Make the call
-    callFunctions(req);
-}
-
 void Scheduler::clearRecordedMessages()
 {
     faabric::util::FullLock lock(mx);

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -83,10 +83,12 @@ TEST_CASE_METHOD(ClientServerFixture,
     REQUIRE(state.getKVCount() == 2);
 
     // Execute a couple of functions
-    faabric::Message msgA = faabric::util::messageFactory("dummy", "foo");
-    faabric::Message msgB = faabric::util::messageFactory("dummy", "bar");
-    sch.callFunction(msgA);
-    sch.callFunction(msgB);
+    auto reqA = faabric::util::batchExecFactory("dummy", "foo", 1);
+    auto& msgA = *reqA->mutable_messages(0);
+    auto reqB = faabric::util::batchExecFactory("dummy", "bar", 1);
+    auto& msgB = *reqA->mutable_messages(0);
+    sch.callFunctions(reqA);
+    sch.callFunctions(reqB);
 
     // Check messages passed
     std::vector<faabric::Message> msgs = sch.getRecordedMessagesAll();
@@ -232,9 +234,10 @@ TEST_CASE_METHOD(ClientServerFixture, "Test unregister request", "[scheduler]")
     faabric::scheduler::queueResourceResponse(otherHost, otherResources);
 
     // Request a function and check the other host is registered
-    faabric::Message msg = faabric::util::messageFactory("foo", "bar");
+    auto funcReq = faabric::util::batchExecFactory("foo", "bar", 1);
+    auto& msg = *funcReq->mutable_messages(0);
     sch.addHostToGlobalSet(otherHost);
-    sch.callFunction(msg);
+    sch.callFunctions(funcReq);
 
     REQUIRE(sch.getFunctionRegisteredHostCount(msg) == 1);
 

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -86,7 +86,7 @@ TEST_CASE_METHOD(ClientServerFixture,
     auto reqA = faabric::util::batchExecFactory("dummy", "foo", 1);
     auto& msgA = *reqA->mutable_messages(0);
     auto reqB = faabric::util::batchExecFactory("dummy", "bar", 1);
-    auto& msgB = *reqA->mutable_messages(0);
+    auto& msgB = *reqB->mutable_messages(0);
     sch.callFunctions(reqA);
     sch.callFunctions(reqB);
 

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -586,9 +586,9 @@ TEST_CASE_METHOD(SlowExecutorFixture, "Check test mode", "[scheduler]")
     auto reqA = faabric::util::batchExecFactory("demo", "echo", 1);
     auto& msgA = *reqA->mutable_messages(0);
     auto reqB = faabric::util::batchExecFactory("demo", "echo", 1);
-    auto& msgB = *reqA->mutable_messages(0);
+    auto& msgB = *reqB->mutable_messages(0);
     auto reqC = faabric::util::batchExecFactory("demo", "echo", 1);
-    auto& msgC = *reqA->mutable_messages(0);
+    auto& msgC = *reqC->mutable_messages(0);
 
     SECTION("No test mode")
     {


### PR DESCRIPTION
We can now invoke a function execution by calling either `callFunctions` or `callFunction` each taking a `faabric::BatchExecuteRequest` or a `faabric::Message` respectively.

In this PR I remove the `callFunction` signature, primarily to enforce that all interaction with the execution/scheduler happens through `BatchExecuteRequest`s and not `Message`s.

See also faasm/faasm#750