### PR TITLE
Bump nng tag

### DIFF
--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -125,7 +125,7 @@ FetchContent_Declare(zstd_ext
 )
 FetchContent_Declare(nng_ext
     GIT_REPOSITORY "https://github.com/nanomsg/nng"
-    GIT_TAG "8e1836f57e8bcdb228dd5baadc71dfbf30b544e0"
+    GIT_TAG "c5e9d8acfc226418dedcf2e34a617bffae043ff6"
 )
 
 FetchContent_MakeAvailable(zstd_ext)


### PR DESCRIPTION
The sanitised tests are giving NNG panic's every now and then. I still have to find some time to fix them, in the meantime, I bump the nng tag to the latest version as some race conditions have been patched upstream.