### PR TITLE
Route `set/getFunctionResult` through the planner

### DIFF
--- a/include/faabric/planner/Planner.h
+++ b/include/faabric/planner/Planner.h
@@ -37,7 +37,7 @@ class Planner
     bool flush(faabric::planner::FlushType flushType);
 
     // ----------
-    // Host membership management
+    // Host membership public API
     // ----------
 
     std::vector<std::shared_ptr<Host>> getAvailableHosts();
@@ -46,6 +46,17 @@ class Planner
 
     // Best effort host removal. Don't fail if we can't
     void removeHost(const Host& hostIn);
+
+    // ----------
+    // Request scheduling public API
+    // ----------
+
+    // Setters/getters for individual message results
+
+    void setMessageResult(std::shared_ptr<faabric::Message> msg);
+
+    std::shared_ptr<faabric::Message> getMessageResult(
+      std::shared_ptr<faabric::Message> msg);
 
   private:
     // There's a singleton instance of the planner running, but it must allow

--- a/include/faabric/planner/PlannerApi.h
+++ b/include/faabric/planner/PlannerApi.h
@@ -13,7 +13,5 @@ enum PlannerCalls
     // Scheduling calls
     SetMessageResult = 8,
     GetMessageResult = 9,
-    // TODO: probably not here
-    // GetBatchMessages = 10,
 };
 }

--- a/include/faabric/planner/PlannerApi.h
+++ b/include/faabric/planner/PlannerApi.h
@@ -4,9 +4,16 @@ namespace faabric::planner {
 enum PlannerCalls
 {
     NoPlanerCall = 0,
+    // Util
     Ping = 1,
+    // Host-membership calls
     GetAvailableHosts = 2,
     RegisterHost = 3,
     RemoveHost = 4,
+    // Scheduling calls
+    SetMessageResult = 8,
+    GetMessageResult = 9,
+    // TODO: probably not here
+    // GetBatchMessages = 10,
 };
 }

--- a/include/faabric/planner/PlannerClient.h
+++ b/include/faabric/planner/PlannerClient.h
@@ -34,11 +34,24 @@ class PlannerClient final : public faabric::transport::MessageEndpointClient
 
     void ping();
 
+    // ------
+    // Host membership calls
+    // ------
+
     std::vector<Host> getAvailableHosts();
 
     // Registering a host returns the keep-alive timeout for heartbeats
     int registerHost(std::shared_ptr<RegisterHostRequest> req);
 
     void removeHost(std::shared_ptr<RemoveHostRequest> req);
+
+    // ------
+    // Scheduling calls
+    // ------
+
+    void setMessageResult(std::shared_ptr<faabric::Message> msg);
+
+    std::shared_ptr<faabric::Message> getMessageResult(
+      std::shared_ptr<faabric::Message> msg);
 };
 }

--- a/include/faabric/planner/PlannerServer.h
+++ b/include/faabric/planner/PlannerServer.h
@@ -27,6 +27,12 @@ class PlannerServer final : public faabric::transport::MessageEndpointServer
     std::unique_ptr<google::protobuf::Message> recvRemoveHost(
       std::span<const uint8_t> buffer);
 
+    std::unique_ptr<google::protobuf::Message> recvSetMessageResult(
+      std::span<const uint8_t> buffer);
+
+    std::unique_ptr<google::protobuf::Message> recvGetMessageResult(
+      std::span<const uint8_t> buffer);
+
   private:
     faabric::planner::Planner& planner;
 };

--- a/include/faabric/planner/PlannerState.h
+++ b/include/faabric/planner/PlannerState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <faabric/planner/planner.pb.h>
+#include <faabric/proto/faabric.pb.h>
 
 #include <map>
 
@@ -13,5 +14,14 @@ struct PlannerState
     // We deliberately use the host's IP as unique key, but assign a unique host
     // id for redundancy
     std::map<std::string, std::shared_ptr<Host>> hostMap;
+
+    // Double-map holding the message results. The first key is the app id. For
+    // each app id, we keep a map of the message id, and the actual message
+    // result
+    std::map<int, std::map<int, std::shared_ptr<faabric::Message>>> appResults;
+
+    // Map holding the hosts that have registered interest in getting an app
+    // result
+    std::map<int, std::vector<std::string>> appResultWaiters;
 };
 }

--- a/include/faabric/scheduler/FunctionCallApi.h
+++ b/include/faabric/scheduler/FunctionCallApi.h
@@ -8,6 +8,7 @@ enum FunctionCalls
     Flush = 2,
     Unregister = 3,
     GetResources = 4,
-    PendingMigrations = 5
+    PendingMigrations = 5,
+    SetMessageResult = 6,
 };
 }

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -28,6 +28,8 @@ getPendingMigrationsRequests();
 std::vector<std::pair<std::string, faabric::UnregisterRequest>>
 getUnregisterRequests();
 
+std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>> getMessageResults();
+
 void queueResourceResponse(const std::string& host,
                            faabric::HostResources& res);
 

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -28,7 +28,8 @@ getPendingMigrationsRequests();
 std::vector<std::pair<std::string, faabric::UnregisterRequest>>
 getUnregisterRequests();
 
-std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>> getMessageResults();
+std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>>
+getMessageResults();
 
 void queueResourceResponse(const std::string& host,
                            faabric::HostResources& res);

--- a/include/faabric/scheduler/FunctionCallClient.h
+++ b/include/faabric/scheduler/FunctionCallClient.h
@@ -50,5 +50,7 @@ class FunctionCallClient : public faabric::transport::MessageEndpointClient
     void executeFunctions(std::shared_ptr<faabric::BatchExecuteRequest> req);
 
     void unregister(faabric::UnregisterRequest& req);
+
+    void setMessageResult(std::shared_ptr<faabric::Message> msg);
 };
 }

--- a/include/faabric/scheduler/FunctionCallServer.h
+++ b/include/faabric/scheduler/FunctionCallServer.h
@@ -32,5 +32,7 @@ class FunctionCallServer final
     void recvExecuteFunctions(std::span<const uint8_t> buffer);
 
     void recvUnregister(std::span<const uint8_t> buffer);
+
+    void recvSetMessageResult(std::span<const uint8_t> buffer);
 };
 }

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -268,7 +268,7 @@ class Scheduler
     // ----------------------------------
     void setFunctionResult(faabric::Message& msg);
 
-    void setMessageResult(std::shared_ptr<faabric::Message> msg);
+    void setMessageResultLocally(std::shared_ptr<faabric::Message> msg);
 
     faabric::Message getFunctionResult(const faabric::Message& msg,
                                        int timeoutMs);

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -263,6 +263,9 @@ class Scheduler
 
     void flushLocally();
 
+    // ----------------------------------
+    // Message results
+    // ----------------------------------
     void setFunctionResult(faabric::Message& msg);
 
     void setMessageResult(std::shared_ptr<faabric::Message> msg);
@@ -270,6 +273,9 @@ class Scheduler
     faabric::Message getFunctionResult(const faabric::Message& msg,
                                        int timeoutMs);
 
+    faabric::Message getFunctionResult(int appId, int msgId, int timeoutMs);
+
+    // TODO: delete this method
     void getFunctionResultAsync(const faabric::Message& msg,
                                 int timeoutMs,
                                 asio::io_context& ioc,
@@ -348,12 +354,12 @@ class Scheduler
     // ----------------------------------
     // Exec graph
     // ----------------------------------
-    void logChainedFunction(const faabric::Message& parentMessage,
+    void logChainedFunction(faabric::Message& parentMessage,
                             const faabric::Message& chainedMessage);
 
-    std::set<unsigned int> getChainedFunctions(unsigned int msgId);
+    std::set<unsigned int> getChainedFunctions(const faabric::Message& msg);
 
-    ExecGraph getFunctionExecGraph(unsigned int msgId);
+    ExecGraph getFunctionExecGraph(const faabric::Message& msg);
 
     // ----------------------------------
     // Function Migration
@@ -406,8 +412,12 @@ class Scheduler
     std::mutex localResultsMutex;
 
     // TODO: can we remove localResultsMutex ?
+    // ---- Message results ----
     std::unordered_map<uint32_t, MessageResultPromisePtr> plannerResults;
     std::mutex plannerResultsMutex;
+    faabric::Message doGetFunctionResult(
+      std::shared_ptr<faabric::Message> msgPtr,
+      int timeoutMs);
 
     // ---- Host resources and hosts ----
     faabric::HostResources thisHostResources;
@@ -451,7 +461,7 @@ class Scheduler
     std::vector<std::pair<std::string, faabric::Message>>
       recordedMessagesShared;
 
-    ExecGraphNode getFunctionExecGraphNode(unsigned int msgId);
+    ExecGraphNode getFunctionExecGraphNode(int appId, int msgId);
 
     // ---- Point-to-point ----
     faabric::transport::PointToPointBroker& broker;

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -31,6 +31,8 @@ namespace faabric::scheduler {
 typedef std::pair<std::shared_ptr<BatchExecuteRequest>,
                   std::shared_ptr<faabric::util::SchedulingDecision>>
   InFlightPair;
+typedef std::promise<std::shared_ptr<faabric::Message>> MessageResultPromise;
+typedef std::shared_ptr<MessageResultPromise> MessageResultPromisePtr;
 
 class Scheduler;
 
@@ -263,6 +265,8 @@ class Scheduler
 
     void setFunctionResult(faabric::Message& msg);
 
+    void setMessageResult(std::shared_ptr<faabric::Message> msg);
+
     faabric::Message getFunctionResult(const faabric::Message& msg,
                                        int timeoutMs);
 
@@ -400,6 +404,10 @@ class Scheduler
     std::unordered_map<std::string, std::set<std::string>> pushedSnapshotsMap;
 
     std::mutex localResultsMutex;
+
+    // TODO: can we remove localResultsMutex ?
+    std::unordered_map<uint32_t, MessageResultPromisePtr> plannerResults;
+    std::mutex plannerResultsMutex;
 
     // ---- Host resources and hosts ----
     faabric::HostResources thisHostResources;

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -275,13 +275,6 @@ class Scheduler
 
     faabric::Message getFunctionResult(int appId, int msgId, int timeoutMs);
 
-    // TODO: delete this method
-    void getFunctionResultAsync(const faabric::Message& msg,
-                                int timeoutMs,
-                                asio::io_context& ioc,
-                                asio::any_io_executor& executor,
-                                std::function<void(faabric::Message&)> handler);
-
     void setThreadResult(const faabric::Message& msg,
                          int32_t returnValue,
                          const std::string& key,
@@ -404,14 +397,8 @@ class Scheduler
     std::unordered_map<uint32_t, faabric::transport::Message>
       threadResultMessages;
 
-    std::unordered_map<uint32_t, std::shared_ptr<MessageLocalResult>>
-      localResults;
-
     std::unordered_map<std::string, std::set<std::string>> pushedSnapshotsMap;
 
-    std::mutex localResultsMutex;
-
-    // TODO: can we remove localResultsMutex ?
     // ---- Message results ----
     std::unordered_map<uint32_t, MessageResultPromisePtr> plannerResults;
     std::mutex plannerResultsMutex;

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -127,7 +127,7 @@ void FaabricEndpointHandler::executeFunction(
     // Await result on global bus (may have been executed on a different worker)
     if (msg.isasync()) {
         response.result(beast::http::status::ok);
-        response.body() = faabric::util::buildAsyncResponse(msg);
+        response.body() = faabric::util::messageToJson(msg);
         return ctx.sendFunction(std::move(response));
     }
 

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -92,7 +92,9 @@ void FaabricEndpointHandler::executeFunction(
   size_t messageIndex)
 {
     faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-    faabric::Message& msg = *ber->mutable_messages(messageIndex);
+    // Deliberately make a copy here to avoid data races. The BER message will
+    // be used for execution, the message copy to wait on the function result
+    faabric::Message msg = ber->messages(messageIndex);
 
     if (msg.user().empty()) {
         response.result(beast::http::status::bad_request);

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -65,7 +65,7 @@ void FaabricEndpointHandler::onRequest(
         } else if (msg.isexecgraphrequest()) {
             SPDLOG_DEBUG("Processing execution graph request");
             faabric::scheduler::ExecGraph execGraph =
-              sched.getFunctionExecGraph(msg.id());
+              sched.getFunctionExecGraph(msg);
             response.result(beast::http::status::ok);
             response.body() = faabric::scheduler::execGraphToJson(execGraph);
 

--- a/src/mpi/MpiWorld.cpp
+++ b/src/mpi/MpiWorld.cpp
@@ -116,6 +116,7 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
       faabric::util::batchExecFactory(user, function, size - 1);
     for (int i = 0; i < req->messages_size(); i++) {
         faabric::Message& msg = req->mutable_messages()->at(i);
+        msg.set_appid(call.appid());
         msg.set_ismpi(true);
         msg.set_mpiworldid(id);
         msg.set_mpirank(i + 1);

--- a/src/planner/Planner.cpp
+++ b/src/planner/Planner.cpp
@@ -198,6 +198,7 @@ void Planner::setMessageResult(std::shared_ptr<faabric::Message> msg)
     auto& sch = faabric::scheduler::getScheduler();
     if (state.appResultWaiters.find(msgId) != state.appResultWaiters.end()) {
         for (const auto& host : state.appResultWaiters[msgId]) {
+            SPDLOG_INFO("Sending result to waiting host: {}", host);
             sch.getFunctionCallClient(host)->setMessageResult(msg);
         }
     }

--- a/src/planner/PlannerClient.cpp
+++ b/src/planner/PlannerClient.cpp
@@ -112,4 +112,23 @@ void PlannerClient::removeHost(std::shared_ptr<RemoveHostRequest> req)
     faabric::EmptyResponse response;
     syncSend(PlannerCalls::RemoveHost, req.get(), &response);
 }
+
+void PlannerClient::setMessageResult(std::shared_ptr<faabric::Message> msg)
+{
+    faabric::EmptyResponse response;
+    syncSend(PlannerCalls::SetMessageResult, msg.get(), &response);
+}
+
+std::shared_ptr<faabric::Message> PlannerClient::getMessageResult(
+  std::shared_ptr<faabric::Message> msg)
+{
+    faabric::Message responseMsg;
+    syncSend(PlannerCalls::GetMessageResult, msg.get(), &responseMsg);
+
+    if (responseMsg.id() == 0 && responseMsg.appid() == 0) {
+        return nullptr;
+    }
+
+    return std::make_shared<faabric::Message>(responseMsg);
+}
 }

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -120,14 +120,15 @@ message Message {
 
     // Exec-graph utils
     bool recordExecGraph = 35 [json_name = "record_exec_graph"];
-    map<string, int32> intExecGraphDetails = 36;
-    map<string, string> execGraphDetails = 37;
+    repeated int32 chainedMsgIds = 36;
+    map<string, int32> intExecGraphDetails = 37;
+    map<string, string> execGraphDetails = 38;
 
     // Function migration
-    int32 migrationCheckPeriod = 38 [json_name = "migration_check_period"];
+    int32 migrationCheckPeriod = 39 [json_name = "migration_check_period"];
 
     // Scheduling
-    string topologyHint = 39 [json_name = "topology_hint"];
+    string topologyHint = 40 [json_name = "topology_hint"];
 }
 
 // ---------------------------------------------

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -391,7 +391,7 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
 {
     SPDLOG_DEBUG("Thread pool thread {}:{} starting up", id, threadPoolIdx);
 
-    const auto& conf = faabric::util::getSystemConfig();
+    const auto conf = faabric::util::getSystemConfig();
 
     // We terminate these threads by sending a shutdown message, but having this
     // check means they won't hang infinitely if destructed.

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -35,7 +35,8 @@ static std::vector<
 static std::vector<std::pair<std::string, faabric::UnregisterRequest>>
   unregisterRequests;
 
-static std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>> messageResults;
+static std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>>
+  messageResults;
 
 std::vector<std::pair<std::string, faabric::Message>> getFunctionCalls()
 {
@@ -77,7 +78,8 @@ getUnregisterRequests()
     return unregisterRequests;
 }
 
-std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>> getMessageResults()
+std::vector<std::pair<std::string, std::shared_ptr<faabric::Message>>>
+getMessageResults()
 {
     faabric::util::UniqueLock lock(mockMutex);
     return messageResults;
@@ -196,7 +198,8 @@ void FunctionCallClient::setMessageResult(std::shared_ptr<faabric::Message> msg)
         faabric::util::UniqueLock lock(mockMutex);
         messageResults.emplace_back(host, msg);
     } else {
-        asyncSend(faabric::scheduler::FunctionCalls::SetMessageResult, msg.get());
+        asyncSend(faabric::scheduler::FunctionCalls::SetMessageResult,
+                  msg.get());
     }
 }
 }

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -180,4 +180,9 @@ void FunctionCallClient::unregister(faabric::UnregisterRequest& req)
         asyncSend(faabric::scheduler::FunctionCalls::Unregister, &req);
     }
 }
+
+void FunctionCallClient::setMessageResult(std::shared_ptr<faabric::Message> msg)
+{
+    asyncSend(faabric::scheduler::FunctionCalls::SetMessageResult, msg.get());
+}
 }

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -29,6 +29,10 @@ void FunctionCallServer::doAsyncRecv(transport::Message& message)
             recvUnregister(message.udata());
             break;
         }
+        case faabric::scheduler::FunctionCalls::SetMessageResult: {
+            recvSetMessageResult(message.udata());
+            break;
+        }
         default: {
             throw std::runtime_error(
               fmt::format("Unrecognized async call header: {}", header));
@@ -112,5 +116,11 @@ FunctionCallServer::recvPendingMigrations(std::span<const uint8_t> buffer)
     scheduler.addPendingMigration(msgPtr);
 
     return std::make_unique<faabric::EmptyResponse>();
+}
+
+void FunctionCallServer::recvSetMessageResult(std::span<const uint8_t> buffer)
+{
+    PARSE_MSG(faabric::Message, buffer.data(), buffer.size())
+    scheduler.setMessageResult(std::make_shared<faabric::Message>(parsedMsg));
 }
 }

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -121,6 +121,7 @@ FunctionCallServer::recvPendingMigrations(std::span<const uint8_t> buffer)
 void FunctionCallServer::recvSetMessageResult(std::span<const uint8_t> buffer)
 {
     PARSE_MSG(faabric::Message, buffer.data(), buffer.size())
-    scheduler.setMessageResult(std::make_shared<faabric::Message>(parsedMsg));
+    scheduler.setMessageResultLocally(
+      std::make_shared<faabric::Message>(parsedMsg));
 }
 }

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1376,6 +1376,9 @@ faabric::Message Scheduler::doGetFunctionResult(
         if (status == std::future_status::timeout) {
             msgResult.set_type(faabric::Message_MessageType_EMPTY);
         } else {
+            // Acquire a lock to read the value of the promise to avoid data
+            // races
+            faabric::util::UniqueLock lock(plannerResultsMutex);
             msgResult = *fut.get();
         }
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1199,7 +1199,6 @@ void Scheduler::setMessageResult(std::shared_ptr<faabric::Message> msg)
     // are waiting for this result locally, thus it sets the result before
     // notifying the planner
     try {
-        SPDLOG_DEBUG("msg return value: {}", msg->returnvalue());
         plannerResults.at(msg->id())->set_value(msg);
     } catch (const std::future_error& e) {
         SPDLOG_DEBUG("Result already set (id: {}, app: {})", msg->id(), msg->appid());
@@ -1383,6 +1382,7 @@ faabric::Message Scheduler::getFunctionResult(const faabric::Message& msg,
     }
 
     while (true) {
+        SPDLOG_WARN("here");
         auto status = fut.wait_for(std::chrono::milliseconds(timeoutMs));
         if (status == std::future_status::timeout) {
             faabric::Message msgResult;
@@ -1390,6 +1390,7 @@ faabric::Message Scheduler::getFunctionResult(const faabric::Message& msg,
             return msgResult;
         }
 
+        SPDLOG_WARN("here too");
         auto resultPtr = fut.get();
         {
             // Remove the result promise

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -202,6 +202,7 @@ void Scheduler::reset()
     // Reset resources
     thisHostResources = faabric::HostResources();
     thisHostResources.set_slots(faabric::util::getUsableCores());
+    thisHostResources.set_usedslots(0);
 
     // Reset scheduler state
     availableHostsCache.clear();

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -30,8 +30,7 @@
 #include <unordered_set>
 
 #define FLUSH_TIMEOUT_MS 10000
-#define GET_EXEC_GRAPH_SLEEP_MS 500
-#define MAX_GET_EXEC_GRAPH_RETRIES 3
+#define EXEC_GRAPH_TIMEOUT_MS 1000
 
 using namespace faabric::util;
 using namespace faabric::snapshot;
@@ -90,8 +89,6 @@ Scheduler::Scheduler()
 
     // Start the reaper thread
     reaperThread.start(conf.reaperIntervalSeconds);
-
-    SPDLOG_WARN("Scheduler initialised!!");
 }
 
 Scheduler::~Scheduler()
@@ -1551,8 +1548,7 @@ std::set<unsigned int> Scheduler::getChainedFunctions(
 {
     // Note that we can't get the chained functions until the result for the
     // parent message has been set
-    // TODO: what timeout?
-    auto resultMsg = getFunctionResult(msg, 1000);
+    auto resultMsg = getFunctionResult(msg, EXEC_GRAPH_TIMEOUT_MS);
     std::set<unsigned int> chainedIds(
       resultMsg.mutable_chainedmsgids()->begin(),
       resultMsg.mutable_chainedmsgids()->end());
@@ -1570,8 +1566,7 @@ ExecGraph Scheduler::getFunctionExecGraph(const faabric::Message& msg)
 
 ExecGraphNode Scheduler::getFunctionExecGraphNode(int appId, int msgId)
 {
-    // TODO: what timeout?
-    faabric::Message resultMsg = getFunctionResult(appId, msgId, 1000);
+    auto resultMsg = getFunctionResult(appId, msgId, EXEC_GRAPH_TIMEOUT_MS);
     if (resultMsg.type() == faabric::Message_MessageType_EMPTY) {
         SPDLOG_ERROR(
           "Timed-out getting exec graph node for msg id: {} (app: {})",

--- a/src/util/network.cpp
+++ b/src/util/network.cpp
@@ -2,18 +2,27 @@
 
 #include <arpa/inet.h>
 #include <ifaddrs.h>
+#include <mutex>
 #include <net/if.h>
 #include <netdb.h>
 #include <stdexcept>
 #include <unordered_map>
 
+#include <faabric/util/locks.h>
 #include <faabric/util/string_tools.h>
 
 namespace faabric::util {
 static std::unordered_map<std::string, std::string> ipMap;
+static std::mutex hostnameMx;
 
 std::string getIPFromHostname(const std::string& hostname)
 {
+    // Concurrent calls to gethostbyname-style syscalls is not thread-safe, so
+    // we protect it with a mutex. We are overly cautious with the locking, as
+    // this is not performance critical. This function is usually called once
+    // during initialisation (it may affect throughput measurements, though)
+    faabric::util::UniqueLock lock(hostnameMx);
+
     hostent* record = gethostbyname(hostname.c_str());
 
     if (record == nullptr) {
@@ -21,7 +30,7 @@ std::string getIPFromHostname(const std::string& hostname)
         throw std::runtime_error(errorMsg);
     }
 
-    auto address = (in_addr*)record->h_addr;
+    auto* address = (in_addr*)record->h_addr;
     std::string ipAddress = inet_ntoa(*address);
 
     return ipAddress;

--- a/src/util/network.cpp
+++ b/src/util/network.cpp
@@ -17,7 +17,7 @@ static std::mutex hostnameMx;
 
 std::string getIPFromHostname(const std::string& hostname)
 {
-    // Concurrent calls to gethostbyname-style syscalls is not thread-safe, so
+    // Concurrent calls to gethostbyname-style syscalls are not thread-safe, so
     // we protect it with a mutex. We are overly cautious with the locking, as
     // this is not performance critical. This function is usually called once
     // during initialisation (it may affect throughput measurements, though)

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -6,6 +6,10 @@ from tasks.util.env import FAABRIC_STATIC_BUILD_DIR, PROJ_ROOT
 
 TEST_ENV = {
     "LOG_LEVEL": "info",
+    "PLANNER_HOST": "localhost",
+    "REDIS_QUEUE_HOST": "redis",
+    "REDIS_STATE_HOST": "redis",
+    "TERM": "xterm-256color",
     "ASAN_OPTIONS": "verbosity=1:halt_on_error=1",
     "TSAN_OPTIONS": " ".join(
         [

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -6,10 +6,6 @@ from tasks.util.env import FAABRIC_STATIC_BUILD_DIR, PROJ_ROOT
 
 TEST_ENV = {
     "LOG_LEVEL": "info",
-    "PLANNER_HOST": "localhost",
-    "REDIS_QUEUE_HOST": "redis",
-    "REDIS_STATE_HOST": "redis",
-    "TERM": "xterm-256color",
     "ASAN_OPTIONS": "verbosity=1:halt_on_error=1",
     "TSAN_OPTIONS": " ".join(
         [

--- a/tests/dist/dist_test_fixtures.h
+++ b/tests/dist/dist_test_fixtures.h
@@ -13,10 +13,10 @@
 
 namespace tests {
 class DistTestsFixture
-  : public SchedulerTestFixture
-  , public ConfTestFixture
-  , public SnapshotTestFixture
-  , public PointToPointTestFixture
+  : public SchedulerFixture
+  , public ConfFixture
+  , public SnapshotRegistryFixture
+  , public PointToPointBrokerFixture
 {
   public:
     DistTestsFixture()

--- a/tests/dist/dist_test_fixtures.h
+++ b/tests/dist/dist_test_fixtures.h
@@ -146,7 +146,7 @@ class MpiDistTestsFixture : public DistTestsFixture
         REQUIRE(result.returnvalue() == 0);
         SLEEP_MS(1000);
         if (!skipExecGraphCheck) {
-            auto execGraph = sch.getFunctionExecGraph(msg.id());
+            auto execGraph = sch.getFunctionExecGraph(msg);
             checkSchedulingFromExecGraph(execGraph);
         }
     }
@@ -161,7 +161,7 @@ class MpiDistTestsFixture : public DistTestsFixture
         faabric::Message result = sch.getFunctionResult(msg, timeoutMs);
         REQUIRE(result.returnvalue() == 0);
         SLEEP_MS(1000);
-        auto execGraph = sch.getFunctionExecGraph(msg.id());
+        auto execGraph = sch.getFunctionExecGraph(msg);
         checkSchedulingFromExecGraph(
           execGraph, expectedHostsBefore, expectedHostsAfter);
     }

--- a/tests/dist/mpi/test_multiple_mpi_worlds.cpp
+++ b/tests/dist/mpi/test_multiple_mpi_worlds.cpp
@@ -66,8 +66,7 @@ TEST_CASE_METHOD(MpiDistTestsFixture,
     checkAllocationAndResult(req2, 15000, skipExecGraphCheck);
 
     // Check exec graph for first request
-    auto execGraph1 =
-      sch.getFunctionExecGraph(req1->mutable_messages()->at(0).id());
+    auto execGraph1 = sch.getFunctionExecGraph(req1->mutable_messages()->at(0));
     std::vector<std::string> expectedHosts1 = {
         getMasterIP(), getMasterIP(), getWorkerIP(), getWorkerIP()
     };
@@ -75,8 +74,7 @@ TEST_CASE_METHOD(MpiDistTestsFixture,
             faabric::scheduler::getMpiRankHostsFromExecGraph(execGraph1));
 
     // Check exec graph for second request
-    auto execGraph2 =
-      sch.getFunctionExecGraph(req2->mutable_messages()->at(0).id());
+    auto execGraph2 = sch.getFunctionExecGraph(req2->mutable_messages()->at(0));
     std::vector<std::string> expectedHosts2 = { getWorkerIP(), getWorkerIP(),
                                                 getMasterIP(), getMasterIP(),
                                                 getWorkerIP(), getWorkerIP() };

--- a/tests/dist/scheduler/test_exec_graph.cpp
+++ b/tests/dist/scheduler/test_exec_graph.cpp
@@ -39,7 +39,7 @@ TEST_CASE_METHOD(DistTestsFixture,
         // Wait for the result, and immediately after query for the execution
         // graph
         faabric::Message result = sch.getFunctionResult(m, 1000);
-        auto execGraph = sch.getFunctionExecGraph(m.id());
+        auto execGraph = sch.getFunctionExecGraph(m);
         REQUIRE(countExecGraphNodes(execGraph) == nFuncs);
 
         REQUIRE(execGraph.rootNode.msg.id() == m.id());

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -69,7 +69,7 @@ class EndpointApiTestExecutorFactory : public ExecutorFactory
     }
 };
 
-class EndpointApiTestFixture : public SchedulerTestFixture
+class EndpointApiTestFixture : public ClientServerFixture
 {
   public:
     EndpointApiTestFixture()

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -69,7 +69,9 @@ class EndpointApiTestExecutorFactory : public ExecutorFactory
     }
 };
 
-class EndpointApiTestFixture : public ClientServerFixture
+class EndpointApiTestFixture
+  : public FunctionCallClientServerFixture
+  , public SchedulerFixture
 {
   public:
     EndpointApiTestFixture()

--- a/tests/test/endpoint/test_endpoint_api.cpp
+++ b/tests/test/endpoint/test_endpoint_api.cpp
@@ -161,15 +161,18 @@ TEST_CASE_METHOD(EndpointApiTestFixture,
     std::string body = faabric::util::messageToJson(msg);
 
     std::pair<int, std::string> result = postToUrl(LOCALHOST, port, body);
+    faabric::Message response;
+    faabric::util::jsonToMessage(result.second, &response);
 
     REQUIRE(result.first == 200);
-    REQUIRE(result.second == std::to_string(msg.id()));
+    REQUIRE(response.id() == msg.id());
 
     // Make a status request, should still be running
     faabric::Message statusMsg;
     statusMsg.set_user("foo");
     statusMsg.set_function("blah");
     statusMsg.set_id(msg.id());
+    statusMsg.set_appid(msg.appid());
     statusMsg.set_isstatusrequest(true);
 
     std::string statusBody = faabric::util::messageToJson(statusMsg);

--- a/tests/test/endpoint/test_handler.cpp
+++ b/tests/test/endpoint/test_handler.cpp
@@ -87,7 +87,9 @@ TEST_CASE_METHOD(EndpointHandlerTestFixture,
     sch.getFunctionResult(actualCall, 2000);
 }
 
-TEST_CASE_METHOD(EndpointHandlerTestFixture, "Test empty invocation", "[endpoint]")
+TEST_CASE_METHOD(EndpointHandlerTestFixture,
+                 "Test empty invocation",
+                 "[endpoint]")
 {
     std::shared_ptr handler =
       std::make_shared<endpoint::FaabricEndpointHandler>();
@@ -98,7 +100,9 @@ TEST_CASE_METHOD(EndpointHandlerTestFixture, "Test empty invocation", "[endpoint
     REQUIRE(actual.second == "Empty request");
 }
 
-TEST_CASE_METHOD(EndpointHandlerTestFixture, "Test empty JSON invocation", "[endpoint]")
+TEST_CASE_METHOD(EndpointHandlerTestFixture,
+                 "Test empty JSON invocation",
+                 "[endpoint]")
 {
     faabric::Message call;
     call.set_isasync(true);

--- a/tests/test/endpoint/test_handler.cpp
+++ b/tests/test/endpoint/test_handler.cpp
@@ -11,7 +11,9 @@
 
 namespace tests {
 
-class EndpointHandlerTestFixture : public ClientServerFixture
+class EndpointHandlerTestFixture
+  : public FunctionCallClientServerFixture
+  , public SchedulerFixture
 {
   protected:
     // Taking in a shared_ptr by reference to ensure the handler was constructed

--- a/tests/test/endpoint/test_handler.cpp
+++ b/tests/test/endpoint/test_handler.cpp
@@ -11,44 +11,32 @@
 
 namespace tests {
 
-class EndpointHandlerTestFixture : public SchedulerTestFixture
+class EndpointHandlerTestFixture : public ClientServerFixture
 {
-  public:
-    EndpointHandlerTestFixture()
-    {
-        executorFactory =
-          std::make_shared<faabric::scheduler::DummyExecutorFactory>();
-        setExecutorFactory(executorFactory);
-    }
-
-    ~EndpointHandlerTestFixture() { executorFactory->reset(); }
-
   protected:
-    std::shared_ptr<faabric::scheduler::DummyExecutorFactory> executorFactory;
+    // Taking in a shared_ptr by reference to ensure the handler was constructed
+    // with std::make_shared
+    static std::pair<int, std::string> synchronouslyHandleFunction(
+      std::shared_ptr<endpoint::FaabricEndpointHandler>& handler,
+      std::string requestStr)
+    {
+        asio::io_context ioc(1);
+        asio::strand strand = asio::make_strand(ioc);
+        faabric::util::BeastHttpResponse response;
+        faabric::util::BeastHttpRequest req(beast::http::verb::get, "/", 10);
+        req.body() = requestStr;
+        faabric::endpoint::HttpRequestContext ctx{
+            ioc,
+            strand,
+            [&](faabric::util::BeastHttpResponse&& resp) {
+                response = std::move(resp);
+            }
+        };
+        handler->onRequest(std::move(ctx), std::move(req));
+        ioc.run();
+        return std::make_pair(response.result_int(), response.body());
+    }
 };
-
-// Taking in a shared_ptr by reference to ensure the handler was constructed
-// with std::make_shared
-std::pair<int, std::string> synchronouslyHandleFunction(
-  std::shared_ptr<endpoint::FaabricEndpointHandler>& handler,
-  std::string requestStr)
-{
-    asio::io_context ioc(1);
-    asio::strand strand = asio::make_strand(ioc);
-    faabric::util::BeastHttpResponse response;
-    faabric::util::BeastHttpRequest req(beast::http::verb::get, "/", 10);
-    req.body() = requestStr;
-    faabric::endpoint::HttpRequestContext ctx{
-        ioc,
-        strand,
-        [&](faabric::util::BeastHttpResponse&& resp) {
-            response = std::move(resp);
-        }
-    };
-    handler->onRequest(std::move(ctx), std::move(req));
-    ioc.run();
-    return std::make_pair(response.result_int(), response.body());
-}
 
 TEST_CASE_METHOD(EndpointHandlerTestFixture,
                  "Test valid calls to endpoint",
@@ -66,6 +54,7 @@ TEST_CASE_METHOD(EndpointHandlerTestFixture,
         actualInput = "foobar";
         call.set_inputdata(actualInput);
     }
+
     SECTION("No input") {}
 
     call.set_user(user);
@@ -80,7 +69,8 @@ TEST_CASE_METHOD(EndpointHandlerTestFixture,
       synchronouslyHandleFunction(handler, requestStr);
 
     REQUIRE(response.first == 200);
-    std::string responseStr = response.second;
+    faabric::Message responseMsg;
+    faabric::util::jsonToMessage(response.second, &responseMsg);
 
     // Check actual call has right details including the ID returned to the
     // caller
@@ -89,14 +79,15 @@ TEST_CASE_METHOD(EndpointHandlerTestFixture,
     faabric::Message actualCall = msgs.at(0);
     REQUIRE(actualCall.user() == call.user());
     REQUIRE(actualCall.function() == call.function());
-    REQUIRE(actualCall.id() == std::stoi(responseStr));
+    REQUIRE(actualCall.id() == responseMsg.id());
     REQUIRE(actualCall.inputdata() == actualInput);
 
     // Wait for the result
+    actualCall.set_appid(responseMsg.appid());
     sch.getFunctionResult(actualCall, 2000);
 }
 
-TEST_CASE("Test empty invocation", "[endpoint]")
+TEST_CASE_METHOD(EndpointHandlerTestFixture, "Test empty invocation", "[endpoint]")
 {
     std::shared_ptr handler =
       std::make_shared<endpoint::FaabricEndpointHandler>();
@@ -107,7 +98,7 @@ TEST_CASE("Test empty invocation", "[endpoint]")
     REQUIRE(actual.second == "Empty request");
 }
 
-TEST_CASE("Test empty JSON invocation", "[endpoint]")
+TEST_CASE_METHOD(EndpointHandlerTestFixture, "Test empty JSON invocation", "[endpoint]")
 {
     faabric::Message call;
     call.set_isasync(true);

--- a/tests/test/planner/test_planner_client_server.cpp
+++ b/tests/test/planner/test_planner_client_server.cpp
@@ -96,7 +96,8 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
                  "[planner]")
 {
     faabric::util::setMockMode(true);
-    auto msgPtr = std::make_shared<faabric::Message>(faabric::util::messageFactory("foo", "bar"));
+    auto msgPtr = std::make_shared<faabric::Message>(
+      faabric::util::messageFactory("foo", "bar"));
 
     // If we try to get the message result before setting it first, nothing
     // happens
@@ -116,7 +117,8 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
     // request to the host that tried to get the result before
     auto msgResults = faabric::scheduler::getMessageResults();
     REQUIRE(msgResults.size() == 1);
-    REQUIRE(msgResults.at(0).first == faabric::util::getSystemConfig().endpointHost);
+    REQUIRE(msgResults.at(0).first ==
+            faabric::util::getSystemConfig().endpointHost);
 
     faabric::scheduler::clearMockRequests();
     faabric::util::setMockMode(false);

--- a/tests/test/planner/test_planner_client_server.cpp
+++ b/tests/test/planner/test_planner_client_server.cpp
@@ -90,4 +90,39 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
     availableHosts = plannerCli.getAvailableHosts();
     REQUIRE(availableHosts.empty());
 }
+
+TEST_CASE_METHOD(PlannerClientServerTestFixture,
+                 "Test setting/getting message results",
+                 "[planner]")
+{
+    faabric::util::setMockMode(true);
+    auto msgPtr = std::make_shared<faabric::Message>(faabric::util::messageFactory("foo", "bar"));
+
+    // If we try to get the message result before setting it first, nothing
+    // happens
+    auto resultMsgPtr = plannerCli.getMessageResult(msgPtr);
+    REQUIRE(resultMsgPtr == nullptr);
+
+    // If we set the message result, then we can get it
+    int expectedReturnValue = 1337;
+    msgPtr->set_returnvalue(expectedReturnValue);
+    plannerCli.setMessageResult(msgPtr);
+    resultMsgPtr = plannerCli.getMessageResult(msgPtr);
+    REQUIRE(resultMsgPtr->id() == msgPtr->id());
+    REQUIRE(resultMsgPtr->appid() == msgPtr->appid());
+    REQUIRE(resultMsgPtr->returnvalue() == expectedReturnValue);
+
+    // Also, setting the message result triggers the planner to send a
+    // request to the host that tried to get the result before
+    auto msgResults = faabric::scheduler::getMessageResults();
+    REQUIRE(msgResults.size() == 1);
+    REQUIRE(msgResults.at(0).first == faabric::util::getSystemConfig().endpointHost);
+
+    faabric::scheduler::clearMockRequests();
+    faabric::util::setMockMode(false);
+
+    // Shutdown the scheduler as we are using the function client/server (even
+    // if mocked)
+    faabric::scheduler::getScheduler().shutdown();
+}
 }

--- a/tests/test/planner/test_planner_client_server.cpp
+++ b/tests/test/planner/test_planner_client_server.cpp
@@ -11,7 +11,7 @@
 using namespace faabric::planner;
 
 namespace tests {
-TEST_CASE_METHOD(PlannerClientServerTestFixture,
+TEST_CASE_METHOD(PlannerClientServerFixture,
                  "Test sending ping to planner",
                  "[planner]")
 {
@@ -19,7 +19,7 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
     REQUIRE_NOTHROW(cli.ping());
 }
 
-TEST_CASE_METHOD(PlannerClientServerTestFixture,
+TEST_CASE_METHOD(PlannerClientServerFixture,
                  "Test registering host",
                  "[planner]")
 {
@@ -39,7 +39,7 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
     REQUIRE(newTimeout == plannerTimeout);
 }
 
-TEST_CASE_METHOD(PlannerClientServerTestFixture,
+TEST_CASE_METHOD(PlannerClientServerFixture,
                  "Test getting the available hosts",
                  "[planner]")
 {
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
     REQUIRE(availableHosts.empty());
 }
 
-TEST_CASE_METHOD(PlannerClientServerTestFixture,
+TEST_CASE_METHOD(PlannerClientServerFixture,
                  "Test removing a host",
                  "[planner]")
 {
@@ -91,7 +91,7 @@ TEST_CASE_METHOD(PlannerClientServerTestFixture,
     REQUIRE(availableHosts.empty());
 }
 
-TEST_CASE_METHOD(PlannerClientServerTestFixture,
+TEST_CASE_METHOD(PlannerClientServerFixture,
                  "Test setting/getting message results",
                  "[planner]")
 {

--- a/tests/test/planner/test_planner_endpoint.cpp
+++ b/tests/test/planner/test_planner_endpoint.cpp
@@ -15,8 +15,8 @@ using namespace faabric::planner;
 
 namespace tests {
 class FaabricPlannerEndpointTestFixture
-  : public ConfTestFixture
-  , public PlannerClientServerTestFixture
+  : public ConfFixture
+  , public PlannerClientServerFixture
 {
   public:
     FaabricPlannerEndpointTestFixture()

--- a/tests/test/runner/test_main.cpp
+++ b/tests/test/runner/test_main.cpp
@@ -15,7 +15,7 @@ using namespace faabric::scheduler;
 
 namespace tests {
 
-class MainRunnerTestFixture : public SchedulerTestFixture
+class MainRunnerTestFixture : public SchedulerFixture
 {
   public:
     MainRunnerTestFixture()

--- a/tests/test/scheduler/test_exec_graph.cpp
+++ b/tests/test/scheduler/test_exec_graph.cpp
@@ -14,7 +14,12 @@
 using namespace scheduler;
 
 namespace tests {
-TEST_CASE_METHOD(ClientServerFixture, "Test execution graph", "[scheduler]")
+class ExecGraphTestFixture
+  : public FunctionCallClientServerFixture
+  , public SchedulerFixture
+{};
+
+TEST_CASE_METHOD(ExecGraphTestFixture, "Test execution graph", "[scheduler]")
 {
     auto ber = faabric::util::batchExecFactory("demo", "echo", 7);
     faabric::Message msgA = *ber->mutable_messages(0);
@@ -74,7 +79,7 @@ TEST_CASE_METHOD(ClientServerFixture, "Test execution graph", "[scheduler]")
     checkExecGraphEquality(expected, actual);
 }
 
-TEST_CASE_METHOD(ClientServerFixture,
+TEST_CASE_METHOD(ExecGraphTestFixture,
                  "Test can't get exec graph if results are not published",
                  "[scheduler][exec-graph]")
 {
@@ -84,7 +89,7 @@ TEST_CASE_METHOD(ClientServerFixture,
       faabric::scheduler::getScheduler().getFunctionExecGraph(msg));
 }
 
-TEST_CASE_METHOD(ClientServerFixture,
+TEST_CASE_METHOD(ExecGraphTestFixture,
                  "Test get unique hosts from exec graph",
                  "[scheduler][exec-graph]")
 {
@@ -187,7 +192,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test MPI execution graph", "[scheduler]")
     checkExecGraphEquality(expected, actual);
 }
 
-TEST_CASE_METHOD(ClientServerFixture,
+TEST_CASE_METHOD(ExecGraphTestFixture,
                  "Test exec graph details",
                  "[util][exec-graph]")
 {

--- a/tests/test/scheduler/test_exec_graph.cpp
+++ b/tests/test/scheduler/test_exec_graph.cpp
@@ -14,7 +14,7 @@
 using namespace scheduler;
 
 namespace tests {
-TEST_CASE("Test execution graph", "[scheduler][exec-graph]")
+TEST_CASE_METHOD(ClientServerFixture, "Test execution graph", "[scheduler]")
 {
     faabric::Message msgA = faabric::util::messageFactory("demo", "echo");
     faabric::Message msgB1 = faabric::util::messageFactory("demo", "echo");

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -280,9 +280,7 @@ std::shared_ptr<Executor> TestExecutorFactory::createExecutor(
 }
 
 class TestExecutorFixture
-  : public SchedulerTestFixture
-  , public RedisTestFixture
-  , public ConfTestFixture
+  : public ClientServerFixture
   , public SnapshotTestFixture
 {
   public:

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -1103,6 +1103,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
     // Mock mode to avoid requests sent across hosts
     setMockMode(true);
     executeWithTestExecutorHint(req, hint);
+    setMockMode(false);
 
     // Await results on this host
     for (int i = 0; i < nMessages; i++) {
@@ -1114,8 +1115,6 @@ TEST_CASE_METHOD(TestExecutorFixture,
             REQUIRE(res.returnvalue() == expectedResult);
         }
     }
-
-    setMockMode(false);
 }
 
 TEST_CASE_METHOD(TestExecutorFixture,

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -280,8 +280,10 @@ std::shared_ptr<Executor> TestExecutorFactory::createExecutor(
 }
 
 class TestExecutorFixture
-  : public ClientServerFixture
-  , public SnapshotTestFixture
+  : public FunctionCallClientServerFixture
+  , public SnapshotRegistryFixture
+  , public ConfFixture
+  , public SchedulerFixture
 {
   public:
     TestExecutorFixture()

--- a/tests/test/scheduler/test_executor_context.cpp
+++ b/tests/test/scheduler/test_executor_context.cpp
@@ -10,9 +10,7 @@ using namespace faabric::scheduler;
 
 namespace tests {
 
-TEST_CASE_METHOD(ExecutorContextTestFixture,
-                 "Test executor context",
-                 "[scheduler]")
+TEST_CASE_METHOD(ExecutorContextFixture, "Test executor context", "[scheduler]")
 {
     REQUIRE(!ExecutorContext::isSet());
 

--- a/tests/test/scheduler/test_executor_reaping.cpp
+++ b/tests/test/scheduler/test_executor_reaping.cpp
@@ -12,8 +12,8 @@ using namespace faabric::scheduler;
 namespace tests {
 
 class SchedulerReapingTestFixture
-  : public SchedulerTestFixture
-  , public ConfTestFixture
+  : public SchedulerFixture
+  , public ConfFixture
 {
   public:
     SchedulerReapingTestFixture()

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -23,40 +23,6 @@
 using namespace faabric::scheduler;
 
 namespace tests {
-class ClientServerFixture
-  : public RedisTestFixture
-  , public SchedulerTestFixture
-  , public StateTestFixture
-  , public PointToPointTestFixture
-  , public ConfTestFixture
-{
-  protected:
-    FunctionCallServer server;
-    FunctionCallClient cli;
-
-    std::shared_ptr<DummyExecutorFactory> executorFactory;
-
-    int groupId = 123;
-    int groupSize = 2;
-
-  public:
-    ClientServerFixture()
-      : cli(LOCALHOST)
-    {
-        // Set up executor
-        executorFactory = std::make_shared<DummyExecutorFactory>();
-        setExecutorFactory(executorFactory);
-
-        server.start();
-    }
-
-    ~ClientServerFixture()
-    {
-        server.stop();
-        executorFactory->reset();
-    }
-};
-
 TEST_CASE_METHOD(ConfTestFixture,
                  "Test setting function call server threads",
                  "[scheduler]")

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -50,9 +50,9 @@ TEST_CASE_METHOD(ClientServerFixture,
 
     // Execute a couple of functions
     auto reqA = faabric::util::batchExecFactory("dummy", "foo", 1);
-    auto& msgA = *reqA->mutable_messages(0);
+    auto msgA = reqA->messages(0);
     auto reqB = faabric::util::batchExecFactory("dummy", "bar", 1);
-    auto& msgB = *reqB->mutable_messages(0);
+    auto msgB = reqB->messages(0);
     sch.callFunctions(reqA);
     sch.callFunctions(reqB);
 

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -257,11 +257,11 @@ TEST_CASE_METHOD(ClientServerFixture,
     auto latch = faabric::util::Latch::create(2);
     // This thread will block waiting for another thread to set the message
     // result
-    std::jthread waiterThread{[&]{
+    std::jthread waiterThread{ [&] {
         auto resultMsg = sch.getFunctionResult(msg, 2000);
         SPDLOG_INFO("Actual return value: {}", resultMsg.returnvalue());
         actualReturnCode = resultMsg.returnvalue();
-    }};
+    } };
 
     SLEEP_MS(500);
     msgPtr->set_returnvalue(expectedReturnCode);

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -248,18 +248,12 @@ TEST_CASE_METHOD(ClientServerFixture,
     // Setting a message result with the function call client is used when the
     // planner is notifying that a message result is ready
 
-    // If we set the message result before we have tried (and failed) to get
-    // the result through the planner first, nothing happens
-    cli.setMessageResult(msgPtr);
-
     int expectedReturnCode = 1337;
     int actualReturnCode;
-    auto latch = faabric::util::Latch::create(2);
     // This thread will block waiting for another thread to set the message
     // result
     std::jthread waiterThread{ [&] {
         auto resultMsg = sch.getFunctionResult(msg, 2000);
-        SPDLOG_INFO("Actual return value: {}", resultMsg.returnvalue());
         actualReturnCode = resultMsg.returnvalue();
     } };
 

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -254,13 +254,16 @@ TEST_CASE_METHOD(ClientServerFixture,
 
     int expectedReturnCode = 1337;
     int actualReturnCode;
+    auto latch = faabric::util::Latch::create(2);
     // This thread will block waiting for another thread to set the message
     // result
     std::jthread waiterThread{[&]{
-        sch.getFunctionResult(msg, 1000);
-        actualReturnCode = msg.returnvalue();
+        auto resultMsg = sch.getFunctionResult(msg, 2000);
+        SPDLOG_INFO("Actual return value: {}", resultMsg.returnvalue());
+        actualReturnCode = resultMsg.returnvalue();
     }};
 
+    SLEEP_MS(500);
     msgPtr->set_returnvalue(expectedReturnCode);
     cli.setMessageResult(msgPtr);
     waiterThread.join();

--- a/tests/test/scheduler/test_function_migration.cpp
+++ b/tests/test/scheduler/test_function_migration.cpp
@@ -12,7 +12,7 @@
 using namespace faabric::scheduler;
 
 namespace tests {
-class FunctionMigrationTestFixture : public SchedulerTestFixture
+class FunctionMigrationTestFixture : public SchedulerFixture
 {
   public:
     FunctionMigrationTestFixture()

--- a/tests/test/scheduler/test_function_migration.cpp
+++ b/tests/test/scheduler/test_function_migration.cpp
@@ -162,6 +162,7 @@ TEST_CASE_METHOD(
     int timeToSleep = SHORT_TEST_TIMEOUT_MS;
     req->mutable_messages()->at(0).set_inputdata(std::to_string(timeToSleep));
     uint32_t appId = req->messages().at(0).appid();
+    uint32_t msgId = req->messages().at(0).id();
 
     // Build expected pending migrations
     std::shared_ptr<faabric::PendingMigrations> expectedMigrations;
@@ -190,8 +191,7 @@ TEST_CASE_METHOD(
     checkPendingMigrationsExpectation(
       expectedMigrations, actualMigrations, hosts);
 
-    faabric::Message res =
-      sch.getFunctionResult(req->messages().at(0), 2 * timeToSleep);
+    faabric::Message res = sch.getFunctionResult(appId, msgId, 2 * timeToSleep);
     REQUIRE(res.returnvalue() == 0);
 
     // Check that after the result is set, the app can't be migrated no more
@@ -212,6 +212,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
     int timeToSleep = SHORT_TEST_TIMEOUT_MS;
     req->mutable_messages()->at(0).set_inputdata(std::to_string(timeToSleep));
     uint32_t appId = req->messages().at(0).appid();
+    uint32_t msgId = req->messages().at(0).id();
 
     // By setting the check period to a non-zero value, we are effectively
     // opting in to be considered for migration
@@ -242,8 +243,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
     checkPendingMigrationsExpectation(
       expectedMigrations, actualMigrations, hosts);
 
-    faabric::Message res =
-      sch.getFunctionResult(req->messages().at(0), 2 * timeToSleep);
+    faabric::Message res = sch.getFunctionResult(appId, msgId, 2 * timeToSleep);
     REQUIRE(res.returnvalue() == 0);
 
     // Check that after the result is set, the app can't be migrated no more
@@ -267,6 +267,7 @@ TEST_CASE_METHOD(
     int timeToSleep = SHORT_TEST_TIMEOUT_MS;
     req->mutable_messages()->at(0).set_inputdata(std::to_string(timeToSleep));
     uint32_t appId = req->messages().at(0).appid();
+    uint32_t msgId = req->messages().at(0).id();
 
     // Opt in to be considered for migration
     req->mutable_messages()->at(0).set_migrationcheckperiod(2);
@@ -297,8 +298,7 @@ TEST_CASE_METHOD(
     checkPendingMigrationsExpectation(
       expectedMigrations, actualMigrations, hosts);
 
-    faabric::Message res =
-      sch.getFunctionResult(req->messages().at(0), 2 * timeToSleep);
+    faabric::Message res = sch.getFunctionResult(appId, msgId, 2 * timeToSleep);
     REQUIRE(res.returnvalue() == 0);
 
     // Check that after the result is set, the app can't be migrated no more
@@ -323,6 +323,7 @@ TEST_CASE_METHOD(
     int timeToSleep = 4 * checkPeriodSecs * 1000;
     req->mutable_messages()->at(0).set_inputdata(std::to_string(timeToSleep));
     uint32_t appId = req->messages().at(0).appid();
+    uint32_t msgId = req->messages().at(0).id();
 
     // Opt in to be migrated
     req->mutable_messages()->at(0).set_migrationcheckperiod(checkPeriodSecs);
@@ -355,8 +356,7 @@ TEST_CASE_METHOD(
     checkPendingMigrationsExpectation(
       expectedMigrations, actualMigrations, hosts);
 
-    faabric::Message res =
-      sch.getFunctionResult(req->messages().at(0), 2 * timeToSleep);
+    faabric::Message res = sch.getFunctionResult(appId, msgId, 2 * timeToSleep);
     REQUIRE(res.returnvalue() == 0);
 
     SLEEP_MS(100);
@@ -415,6 +415,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
     firstMsg->set_mpiworldid(worldId);
     firstMsg->set_migrationcheckperiod(checkPeriodSecs);
     uint32_t appId = req->messages().at(0).appid();
+    uint32_t msgId = req->messages().at(0).id();
 
     // Call function that wil just sleep
     auto decision = sch.callFunctions(req);
@@ -455,8 +456,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
     checkPendingMigrationsExpectation(
       expectedMigrations, actualMigrations, hosts, true);
 
-    faabric::Message res =
-      sch.getFunctionResult(req->messages(0), 2 * timeToSleep);
+    faabric::Message res = sch.getFunctionResult(appId, msgId, 2 * timeToSleep);
     REQUIRE(res.returnvalue() == 0);
 
     // Clean up

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -94,8 +94,7 @@ class SlowExecutorFixture
     };
 };
 
-class DummyExecutorFixture
-  : public ClientServerFixture
+class DummyExecutorFixture : public ClientServerFixture
 {
   public:
     DummyExecutorFixture()

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -770,19 +770,19 @@ TEST_CASE_METHOD(SlowExecutorFixture,
     unsigned int chainedMsgIdC = faabric::util::setMessageId(chainedMsgC);
 
     // Check empty initially
-    REQUIRE(sch.getChainedFunctions(msg.id()).empty());
+    REQUIRE(sch.getChainedFunctions(msg).empty());
 
     // Log and check this shows up in the result
     sch.logChainedFunction(msg, chainedMsgA);
     std::set<unsigned int> expected = { chainedMsgIdA };
-    REQUIRE(sch.getChainedFunctions(msg.id()) == expected);
+    REQUIRE(sch.getChainedFunctions(msg) == expected);
 
     // Log some more and check
     sch.logChainedFunction(msg, chainedMsgA);
     sch.logChainedFunction(msg, chainedMsgB);
     sch.logChainedFunction(msg, chainedMsgC);
     expected = { chainedMsgIdA, chainedMsgIdB, chainedMsgIdC };
-    REQUIRE(sch.getChainedFunctions(msg.id()) == expected);
+    REQUIRE(sch.getChainedFunctions(msg) == expected);
 }
 
 TEST_CASE_METHOD(SlowExecutorFixture,

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -75,9 +75,7 @@ class SlowExecutorFactory : public ExecutorFactory
 };
 
 class SlowExecutorFixture
-  : public RedisTestFixture
-  , public SchedulerTestFixture
-  , public ConfTestFixture
+  : public ClientServerFixture
   , public SnapshotTestFixture
 {
   public:
@@ -97,10 +95,7 @@ class SlowExecutorFixture
 };
 
 class DummyExecutorFixture
-  : public RedisTestFixture
-  , public SchedulerTestFixture
-  , public ConfTestFixture
-  , public PointToPointTestFixture
+  : public ClientServerFixture
 {
   public:
     DummyExecutorFixture()
@@ -640,6 +635,7 @@ TEST_CASE_METHOD(SlowExecutorFixture,
 {
     int nWaiters = 10;
     int nWaiterMessages = 4;
+    conf.overrideCpuCount = nWaiters * nWaiterMessages;
 
     std::vector<std::jthread> waiterThreads;
 
@@ -647,9 +643,6 @@ TEST_CASE_METHOD(SlowExecutorFixture,
     for (int i = 0; i < nWaiters; i++) {
         waiterThreads.emplace_back([nWaiterMessages] {
             Scheduler& sch = scheduler::getScheduler();
-
-            faabric::Message msg =
-              faabric::util::messageFactory("demo", "echo");
 
             // Invoke and await
             std::shared_ptr<faabric::BatchExecuteRequest> req =

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -728,7 +728,6 @@ TEST_CASE_METHOD(SlowExecutorFixture,
                  "Check logging chained functions",
                  "[scheduler]")
 {
-    // faabric::Message msg = faabric::util::messageFactory("demo", "echo");
     auto ber = faabric::util::batchExecFactory("demo", "echo", 4);
     faabric::Message& msg = *ber->mutable_messages(0);
     faabric::Message& chainedMsgA = *ber->mutable_messages(1);

--- a/tests/test/scheduler/test_scheduling_decisions.cpp
+++ b/tests/test/scheduler/test_scheduling_decisions.cpp
@@ -9,7 +9,7 @@ using namespace faabric::scheduler;
 
 namespace tests {
 
-class SchedulingDecisionTestFixture : public SchedulerTestFixture
+class SchedulingDecisionTestFixture : public SchedulerFixture
 {
   public:
     SchedulingDecisionTestFixture()

--- a/tests/test/snapshot/test_snapshot_diffs.cpp
+++ b/tests/test/snapshot/test_snapshot_diffs.cpp
@@ -27,7 +27,7 @@ void checkSnapshotDiff(int offset,
     REQUIRE(data == actualData);
 }
 
-TEST_CASE_METHOD(SnapshotTestFixture,
+TEST_CASE_METHOD(SnapshotRegistryFixture,
                  "Test single extension diff if no merge regions and grown",
                  "[snapshot]")
 {
@@ -88,7 +88,7 @@ TEST_CASE_METHOD(SnapshotTestFixture,
     REQUIRE(actual.getData().size() == expectedData.size());
 }
 
-TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
+TEST_CASE_METHOD(SnapshotRegistryFixture, "Test snapshot diffs", "[snapshot]")
 {
     std::string snapKey = "foobar123";
     int snapPages = 5;
@@ -203,7 +203,7 @@ TEST_CASE_METHOD(SnapshotTestFixture, "Test snapshot diffs", "[snapshot]")
     checkSnapshotDiff(regionOffsetD, expectedDataD, changeDiffs.at(5));
 }
 
-TEST_CASE_METHOD(SnapshotTestFixture,
+TEST_CASE_METHOD(SnapshotRegistryFixture,
                  "Test snapshot diff and unerlying data",
                  "[snapshot]")
 {

--- a/tests/test/snapshot/test_snapshot_registry.cpp
+++ b/tests/test/snapshot/test_snapshot_registry.cpp
@@ -13,7 +13,7 @@ using namespace faabric::util;
 
 namespace tests {
 
-TEST_CASE_METHOD(SnapshotTestFixture,
+TEST_CASE_METHOD(SnapshotRegistryFixture,
                  "Test set and get snapshots",
                  "[snapshot]")
 {
@@ -106,7 +106,7 @@ TEST_CASE_METHOD(SnapshotTestFixture,
     REQUIRE(reg.getSnapshotCount() == 0);
 }
 
-TEST_CASE_METHOD(SnapshotTestFixture,
+TEST_CASE_METHOD(SnapshotRegistryFixture,
                  "Test can't get snapshot with empty key",
                  "[snapshot]")
 {

--- a/tests/test/state/test_redis_state.cpp
+++ b/tests/test/state/test_redis_state.cpp
@@ -38,7 +38,7 @@ static std::shared_ptr<StateKeyValue> setupKV(size_t size)
     return kv;
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test Redis state sizes", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test Redis state sizes", "[state]")
 {
     setUpStateMode("redis");
 
@@ -60,7 +60,7 @@ TEST_CASE_METHOD(StateTestFixture, "Test Redis state sizes", "[state]")
     REQUIRE(s.getStateSize(user, key) == bytes.size());
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test simple redis state get/set", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test simple redis state get/set", "[state]")
 {
     setUpStateMode("redis");
 
@@ -93,7 +93,7 @@ TEST_CASE_METHOD(StateTestFixture, "Test simple redis state get/set", "[state]")
     REQUIRE(redisState.get(actualKey) == values);
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test redis get/ set segment", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test redis get/ set segment", "[state]")
 {
     setUpStateMode("redis");
 
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(StateTestFixture, "Test redis get/ set segment", "[state]")
     REQUIRE(redisState.get(actualKey) == expected);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
+TEST_CASE_METHOD(StateFixture,
                  "Test redis pulls segment even when already allocated",
                  "[state]")
 {
@@ -168,9 +168,7 @@ TEST_CASE_METHOD(StateTestFixture,
     REQUIRE(actualChunk == expectedChunk);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
-                 "Test redis marking segments dirty",
-                 "[state]")
+TEST_CASE_METHOD(StateFixture, "Test redis marking segments dirty", "[state]")
 {
     setUpStateMode("redis");
 
@@ -203,7 +201,7 @@ TEST_CASE_METHOD(StateTestFixture,
     REQUIRE(actualMemory == values);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
+TEST_CASE_METHOD(StateFixture,
                  "Test redis overlaps with multiple segments dirty",
                  "[state]")
 {
@@ -258,7 +256,7 @@ TEST_CASE_METHOD(StateTestFixture,
     REQUIRE(redisState.get(key) == expected);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
+TEST_CASE_METHOD(StateFixture,
                  "Test redis partial update of doubles in state",
                  "[state]")
 {
@@ -313,7 +311,7 @@ TEST_CASE_METHOD(StateTestFixture,
     REQUIRE(expected == actualFromRedis);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
+TEST_CASE_METHOD(StateFixture,
                  "Test redis partially setting just first/ last element",
                  "[state]")
 {
@@ -353,9 +351,7 @@ TEST_CASE_METHOD(StateTestFixture,
     REQUIRE(redisState.get(actualKey) == expected);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
-                 "Test redis push partial with mask",
-                 "[state]")
+TEST_CASE_METHOD(StateFixture, "Test redis push partial with mask", "[state]")
 {
     setUpStateMode("redis");
 
@@ -415,7 +411,7 @@ TEST_CASE_METHOD(StateTestFixture,
     REQUIRE(actualDoubles2 == expected);
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test redis async pulling", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test redis async pulling", "[state]")
 {
     setUpStateMode("redis");
 
@@ -441,7 +437,7 @@ TEST_CASE_METHOD(StateTestFixture, "Test redis async pulling", "[state]")
     REQUIRE(actual == values);
 }
 
-TEST_CASE_METHOD(StateTestFixture,
+TEST_CASE_METHOD(StateFixture,
                  "Test redis pushing only happens when dirty",
                  "[state]")
 {
@@ -472,7 +468,7 @@ TEST_CASE_METHOD(StateTestFixture,
 }
 
 TEST_CASE_METHOD(
-  StateTestFixture,
+  StateFixture,
   "Test redis mapping shared memory does not pull if not initialised",
   "[state]")
 {
@@ -506,7 +502,7 @@ TEST_CASE_METHOD(
     REQUIRE(actualValue == value);
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test redis state pulling", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test redis state pulling", "[state]")
 {
     setUpStateMode("redis");
 
@@ -531,7 +527,7 @@ TEST_CASE_METHOD(StateTestFixture, "Test redis state pulling", "[state]")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test redis state deletion", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test redis state deletion", "[state]")
 {
     setUpStateMode("redis");
 

--- a/tests/test/state/test_state.cpp
+++ b/tests/test/state/test_state.cpp
@@ -22,8 +22,8 @@ namespace tests {
 static int staticCount = 0;
 
 class StateServerTestFixture
-  : public StateTestFixture
-  , ConfTestFixture
+  : public StateFixture
+  , public ConfFixture
 {
   public:
     // Set up a local server with a *different* state instance to the main
@@ -162,7 +162,7 @@ static std::shared_ptr<StateKeyValue> setupKV(size_t size)
     return kv;
 }
 
-TEST_CASE_METHOD(StateTestFixture, "Test in-memory state sizes", "[state]")
+TEST_CASE_METHOD(StateFixture, "Test in-memory state sizes", "[state]")
 {
     std::string user = "alpha";
     std::string key = "beta";
@@ -181,9 +181,7 @@ TEST_CASE_METHOD(StateTestFixture, "Test in-memory state sizes", "[state]")
     REQUIRE(state.getStateSize(user, key) == bytes.size());
 }
 
-TEST_CASE_METHOD(StateTestFixture,
-                 "Test simple in memory state get/set",
-                 "[state]")
+TEST_CASE_METHOD(StateFixture, "Test simple in memory state get/set", "[state]")
 {
     auto kv = setupKV(5);
 

--- a/tests/test/state/test_state_server.cpp
+++ b/tests/test/state/test_state_server.cpp
@@ -18,8 +18,8 @@ using namespace faabric::state;
 namespace tests {
 
 class SimpleStateServerTestFixture
-  : public StateTestFixture
-  , public ConfTestFixture
+  : public StateFixture
+  , public ConfFixture
 {
   public:
     SimpleStateServerTestFixture()
@@ -58,9 +58,7 @@ class SimpleStateServerTestFixture
     std::vector<uint8_t> dataB;
 };
 
-TEST_CASE_METHOD(ConfTestFixture,
-                 "Test setting state server threads",
-                 "[state]")
+TEST_CASE_METHOD(ConfFixture, "Test setting state server threads", "[state]")
 {
     conf.stateServerThreads = 7;
 

--- a/tests/test/transport/test_message_endpoint_client.cpp
+++ b/tests/test/transport/test_message_endpoint_client.cpp
@@ -19,9 +19,7 @@ namespace tests {
 // These tests are unstable under ThreadSanitizer
 #if !(defined(__has_feature) && __has_feature(thread_sanitizer))
 
-TEST_CASE_METHOD(SchedulerTestFixture,
-                 "Test send/recv one message",
-                 "[transport]")
+TEST_CASE_METHOD(SchedulerFixture, "Test send/recv one message", "[transport]")
 {
     AsyncSendMessageEndpoint src(LOCALHOST, TEST_PORT);
     AsyncRecvMessageEndpoint dst(TEST_PORT);
@@ -40,7 +38,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     REQUIRE(actualMsg == expectedMsg);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SchedulerFixture,
                  "Test send before recv is ready",
                  "[transport]")
 {
@@ -76,7 +74,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture, "Test await response", "[transport]")
+TEST_CASE_METHOD(SchedulerFixture, "Test await response", "[transport]")
 {
     // Prepare common message/response
     std::string expectedMsg = "Hello ";
@@ -118,7 +116,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test await response", "[transport]")
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SchedulerFixture,
                  "Test send/recv many messages",
                  "[transport]")
 {
@@ -157,7 +155,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SchedulerFixture,
                  "Test send/recv many messages from many clients",
                  "[transport]")
 {
@@ -201,7 +199,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SchedulerFixture,
                  "Test can't set invalid send/recv timeouts",
                  "[transport]")
 {
@@ -240,7 +238,7 @@ TEST_CASE_METHOD(SchedulerTestFixture,
     }
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture, "Test direct messaging", "[transport]")
+TEST_CASE_METHOD(SchedulerFixture, "Test direct messaging", "[transport]")
 {
     std::string expected = "Direct hello";
     const uint8_t* msg = BYTES_CONST(expected.c_str());
@@ -264,7 +262,7 @@ TEST_CASE_METHOD(SchedulerTestFixture, "Test direct messaging", "[transport]")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE_METHOD(SchedulerTestFixture,
+TEST_CASE_METHOD(SchedulerFixture,
                  "Stress test direct messaging",
                  "[transport]")
 {

--- a/tests/test/transport/test_point_to_point.cpp
+++ b/tests/test/transport/test_point_to_point.cpp
@@ -68,8 +68,8 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
     mappingB1->set_groupidx(groupIdxB1);
     mappingB1->set_host(hostA);
 
-    cli.sendMappings(mappingsA);
-    cli.sendMappings(mappingsB);
+    ptpClient.sendMappings(mappingsA);
+    ptpClient.sendMappings(mappingsB);
 
     REQUIRE(broker.getIdxsRegisteredForGroup(groupIdA).size() == 2);
     REQUIRE(broker.getIdxsRegisteredForGroup(groupIdB).size() == 1);
@@ -486,17 +486,17 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
     REQUIRE(group->getLockOwner(recursive) == -1);
 
     for (int i = 0; i < nCalls; i++) {
-        server.setRequestLatch();
-        cli.groupLock(appId, groupId, groupIdx, recursive);
-        server.awaitRequestLatch();
+        ptpServer.setRequestLatch();
+        ptpClient.groupLock(appId, groupId, groupIdx, recursive);
+        ptpServer.awaitRequestLatch();
     }
 
     REQUIRE(group->getLockOwner(recursive) == groupIdx);
 
     for (int i = 0; i < nCalls; i++) {
-        server.setRequestLatch();
-        cli.groupUnlock(appId, groupId, groupIdx, recursive);
-        server.awaitRequestLatch();
+        ptpServer.setRequestLatch();
+        ptpClient.groupUnlock(appId, groupId, groupIdx, recursive);
+        ptpServer.awaitRequestLatch();
     }
 
     REQUIRE(group->getLockOwner(recursive) == -1);

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -24,7 +24,7 @@ using namespace faabric::transport;
 namespace tests {
 
 class PointToPointGroupFixture
-  : public ConfTestFixture
+  : public ConfFixture
   , public PointToPointClientServerFixture
 {
   public:

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -26,6 +26,7 @@ namespace tests {
 class PointToPointGroupFixture
   : public ConfFixture
   , public PointToPointClientServerFixture
+  , public SchedulerFixture
 {
   public:
     PointToPointGroupFixture()

--- a/tests/test/util/test_dirty.cpp
+++ b/tests/test/util/test_dirty.cpp
@@ -13,7 +13,7 @@ using namespace faabric::util;
 
 namespace tests {
 
-TEST_CASE_METHOD(DirtyTrackingTestFixture,
+TEST_CASE_METHOD(DirtyTrackingFixture,
                  "Test configuring tracker",
                  "[util][dirty]")
 {
@@ -39,7 +39,7 @@ TEST_CASE_METHOD(DirtyTrackingTestFixture,
     REQUIRE(t->getType() == mode);
 }
 
-TEST_CASE_METHOD(DirtyTrackingTestFixture,
+TEST_CASE_METHOD(DirtyTrackingFixture,
                  "Test basic dirty tracking",
                  "[util][dirty]")
 {
@@ -282,7 +282,7 @@ TEST_CASE_METHOD(DirtyTrackingTestFixture,
     }
 }
 
-TEST_CASE_METHOD(DirtyTrackingTestFixture,
+TEST_CASE_METHOD(DirtyTrackingFixture,
                  "Test thread-local dirty tracking",
                  "[util][dirty]")
 {

--- a/tests/test/util/test_scheduling.cpp
+++ b/tests/test/util/test_scheduling.cpp
@@ -11,9 +11,7 @@ using namespace faabric::util;
 
 namespace tests {
 
-TEST_CASE_METHOD(ConfTestFixture,
-                 "Test building scheduling decisions",
-                 "[util]")
+TEST_CASE_METHOD(ConfFixture, "Test building scheduling decisions", "[util]")
 {
     int appId = 123;
     int groupId = 345;

--- a/tests/test/util/test_snapshot.cpp
+++ b/tests/test/util/test_snapshot.cpp
@@ -16,8 +16,8 @@ using namespace faabric::util;
 namespace tests {
 
 class SnapshotMergeTestFixture
-  : public SnapshotTestFixture
-  , public DirtyTrackingTestFixture
+  : public SnapshotRegistryFixture
+  , public DirtyTrackingFixture
 {
   public:
     SnapshotMergeTestFixture() = default;
@@ -1569,7 +1569,7 @@ TEST_CASE("Test snapshot data constructors", "[snapshot][util]")
     REQUIRE(actualConst == data);
 }
 
-TEST_CASE_METHOD(DirtyTrackingTestFixture,
+TEST_CASE_METHOD(DirtyTrackingFixture,
                  "Test snapshot mapped memory diffs",
                  "[snapshot][util]")
 {
@@ -2003,7 +2003,7 @@ TEST_CASE_METHOD(SnapshotMergeTestFixture,
     }
 }
 
-TEST_CASE_METHOD(DirtyTrackingTestFixture, "Test XOR diffs", "[util][snapshot]")
+TEST_CASE_METHOD(DirtyTrackingFixture, "Test XOR diffs", "[util][snapshot]")
 {
     int nSnapPages = 5;
     size_t snapSize = nSnapPages * HOST_PAGE_SIZE;

--- a/tests/utils/DummyExecutor.cpp
+++ b/tests/utils/DummyExecutor.cpp
@@ -31,4 +31,9 @@ int32_t DummyExecutor::executeTask(
 
     return 0;
 }
+
+std::span<uint8_t> DummyExecutor::getMemoryView()
+{
+    return {};
+}
 }

--- a/tests/utils/DummyExecutor.h
+++ b/tests/utils/DummyExecutor.h
@@ -14,6 +14,8 @@ class DummyExecutor final : public Executor
       int threadPoolIdx,
       int msgIdx,
       std::shared_ptr<faabric::BatchExecuteRequest> req) override;
+
+    std::span<uint8_t> getMemoryView() override;
 };
 
 }

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -282,6 +282,7 @@ class PointToPointClientServerFixture
 };
 
 class ExecutorContextTestFixture
+  : public SchedulerTestFixture
 {
   public:
     ExecutorContextTestFixture() {}
@@ -289,10 +290,6 @@ class ExecutorContextTestFixture
     ~ExecutorContextTestFixture()
     {
         faabric::scheduler::ExecutorContext::unset();
-        // There is a circular dependency between the executor and the
-        // scheduler, so even if we don't explicitly use the scheduler in the
-        // executor context tests we need to shut it down
-        faabric::scheduler::getScheduler().shutdown();
     }
 
     /**

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -396,30 +396,16 @@ class FunctionCallClientServerFixture
     faabric::scheduler::FunctionCallServer functionCallServer;
     faabric::scheduler::FunctionCallClient functionCallClient;
 
-    // std::shared_ptr<faabric::scheduler::DummyExecutorFactory>
-    // executorFactory;
-
-    // int groupId = 123;
-    // int groupSize = 2;
-
   public:
     FunctionCallClientServerFixture()
       : functionCallClient(LOCALHOST)
     {
-        // Set up executor
-        /* NOT HERE
-        executorFactory =
-          std::make_shared<faabric::scheduler::DummyExecutorFactory>();
-        setExecutorFactory(executorFactory);
-        */
-
         functionCallServer.start();
     }
 
     ~FunctionCallClientServerFixture()
     {
         functionCallServer.stop();
-        // executorFactory->reset();
     }
 };
 

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -403,10 +403,7 @@ class FunctionCallClientServerFixture
         functionCallServer.start();
     }
 
-    ~FunctionCallClientServerFixture()
-    {
-        functionCallServer.stop();
-    }
+    ~FunctionCallClientServerFixture() { functionCallServer.stop(); }
 };
 
 class MpiWorldRegistryFixture

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -281,8 +281,7 @@ class PointToPointClientServerFixture
     faabric::transport::PointToPointServer server;
 };
 
-class ExecutorContextTestFixture
-  : public SchedulerTestFixture
+class ExecutorContextTestFixture : public SchedulerTestFixture
 {
   public:
     ExecutorContextTestFixture() {}

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -384,13 +384,6 @@ class DirtyTrackingFixture : public ConfFixture
 };
 
 class FunctionCallClientServerFixture
-/*
-  : public RedisTestFixture
-  , public SchedulerTestFixture
-  , public StateTestFixture
-  , public PointToPointTestFixture
-  , public ConfTestFixture
-*/
 {
   protected:
     faabric::scheduler::FunctionCallServer functionCallServer;

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -281,7 +281,7 @@ class PointToPointClientServerFixture
     faabric::transport::PointToPointServer server;
 };
 
-class ExecutorContextTestFixture : public SchedulerTestFixture
+class ExecutorContextTestFixture
 {
   public:
     ExecutorContextTestFixture() {}


### PR DESCRIPTION
In this PR we move the setting/getting of function results to the planner.

When setting a function (message) result, the local scheduler just sends a request to the planner with the message result. The planner then stores it.

When getting a function result, we query the planner for the message result. Two things could happen:
1. The message result is recorded in the planner, and we return.
2. The message result is not recorded in the planner, and thus we have to wait.

In order to avoid blocking the server threads in the planner, we wait on the client side (i.e. worker thread). In situation 2, i.e. if we have asked for a message result and the message is not there, the planner registers the host's interest in the message result, and the worker waits on a result promise. When the result is finally set, the planner will notifiy all hosts that have registered interest in that message result via a `FunctionCall`.

In the process of changing this I also remove the asynchronous waiting implemented in the HTTP endpoint. The reason being twofold:
* On the one hand, function execution requests will eventually go through the planner endpoint (and not the worker endpoint), so that piece of code will not be necessary anymore.
* Given the above, and in the interest of simplifying the get/set result process, I make the HTTP endpoint thread also block while waiting for the result.

In addition, I also clean-up and simplify the base fixtures in `tests/util/fixtures.h`. I make sure that fixtures that just mimick one component don't unnecessarily inherit from other fixtures. This was creating friction with Faasm's tests, where these base fixtures are also used. This change creates a lot of noise in the diff, but doesn't change any functionality.