### PR TITLE
Test wrapper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,13 +72,8 @@ jobs:
         sanitiser: [None, Address, Thread, Undefined]
     env:
       HOST_TYPE: ci
-      LOG_LEVEL: info
-      PLANNER_HOST: localhost
       REDIS_QUEUE_HOST: redis
       REDIS_STATE_HOST: redis
-      ASAN_OPTIONS: verbosity=1:halt_on_error=1
-      TSAN_OPTIONS: "verbosity=1 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=4"
-      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
     container:
       image: faasm.azurecr.io/faabric:0.4.4
       credentials:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
       - name: "Build tests"
         run: ./bin/inv_wrapper.sh dev.cc faabric_tests
       - name: "Run tests"
-        run: /build/faabric/static/bin/faabric_tests
+        run: ./bin/inv_wrapper.sh tests
 
   dist-tests:
     if: github.event.pull_request.draft == false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,6 @@ services:
       - REDIS_STATE_HOST=redis
       - REDIS_QUEUE_HOST=redis
       - OVERRIDE_CPU_COUNT=${OVERRIDE_CPU_COUNT:-0}
-      - ASAN_OPTIONS=verbosity=1:halt_on_error=1
-      - TSAN_OPTIONS=verbosity=1 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=4
-      - UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
     depends_on:
       - planner
       - redis

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -21,7 +21,7 @@ inv dev.cmake
 inv dev.cc faabric_tests
 
 # Run the tests
-faabric_tests
+inv tests
 ```
 
 To stop the `faabric`-related containers run:
@@ -77,6 +77,24 @@ Note that Faabric provides its own `.gdbinit` file which will ensure segfaults
 
 We have some standard tests using [Catch2](https://github.com/catchorg/Catch2)
 under the `faabric_tests` target.
+
+We add a wrapper script around the tests target to set the right environment
+variables, and capture idiomatic ways to call the tests. You can use the
+wrapper scripts in the following ways:
+
+```bash
+# Run the whole test suite
+inv tests
+
+# Run just one test case
+inv tests --test-case "Test JSON contains required keys"
+
+# Run all test cases defined in one file
+inv tests --filename test_json
+
+# Run all test cases defined in one directory
+inv tests --directory util
+```
 
 ## Distributed tests
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,6 +7,7 @@ from . import docs
 from . import examples
 from . import git
 from . import format_code
+from . import tests
 
 ns = Collection(
     call,
@@ -16,4 +17,5 @@ ns = Collection(
     examples,
     git,
     format_code,
+    tests,
 )

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -1,0 +1,52 @@
+from invoke import task
+from os import environ, listdir
+from os.path import join
+from subprocess import run
+from tasks.util.env import FAABRIC_STATIC_BUILD_DIR, PROJ_ROOT
+
+TEST_ENV = {
+    "PLANNER_HOST": "localhost",
+    "REDIS_QUEUE_HOST": "redis",
+    "REDIS_STATE_HOST": "redis",
+    "TERM": "xterm-256color",
+}
+
+
+@task(default=True)
+def tests(
+    ctx,
+    test_case=None,
+    filename=None,
+    directory=None,
+    abort=False,
+    debug=False,
+):
+    """
+    Run the C++ unit tests
+
+    When running this task with no arguments, the whole test suite will be
+    executed. You can specify the name of the test to run by passing the
+    --test-case variable. Additionally, you may also specify a filename to
+    run (--filename) or a directory (--directory)
+    """
+    tests_cmd = [
+        join(FAABRIC_STATIC_BUILD_DIR, "bin", "faabric_tests"),
+        "--use-colour yes",
+        "--abort" if abort else "",
+    ]
+
+    if debug:
+        TEST_ENV["LOG_LEVEL"] = "debug"
+
+    if test_case:
+        tests_cmd.append("'{}'".format(test_case))
+    elif filename:
+        tests_cmd.append("--filenames-as-tags [#{}]".format(filename))
+    elif directory:
+        tag_str = "--filenames-as-tags "
+        for file_name in listdir(join(PROJ_ROOT, "tests", "test", directory)):
+            tag_str += "[#{}],".format(file_name.split(".")[0])
+        tests_cmd.append(tag_str[:-1])
+
+    tests_cmd = " ".join(tests_cmd)
+    run(tests_cmd, shell=True, check=True, cwd=PROJ_ROOT, env=TEST_ENV)

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -5,10 +5,14 @@ from subprocess import run
 from tasks.util.env import FAABRIC_STATIC_BUILD_DIR, PROJ_ROOT
 
 TEST_ENV = {
+    "LOG_LEVEL": "info",
     "PLANNER_HOST": "localhost",
     "REDIS_QUEUE_HOST": "redis",
     "REDIS_STATE_HOST": "redis",
     "TERM": "xterm-256color",
+    "ASAN_OPTIONS": "verbosity=1:halt_on_error=1"
+    "TSAN_OPTIONS": "verbosity=1 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=4"
+    "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
 }
 
 

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -1,5 +1,5 @@
 from invoke import task
-from os import environ, listdir
+from os import listdir
 from os.path import join
 from subprocess import run
 from tasks.util.env import FAABRIC_STATIC_BUILD_DIR, PROJ_ROOT
@@ -11,7 +11,15 @@ TEST_ENV = {
     "REDIS_STATE_HOST": "redis",
     "TERM": "xterm-256color",
     "ASAN_OPTIONS": "verbosity=1:halt_on_error=1",
-    "TSAN_OPTIONS": "verbosity=1 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=4",
+    "TSAN_OPTIONS": " ".join(
+        [
+            "verbosity=1 halt_on_error=1",
+            "suppressions={}/thread-sanitizer-ignorelist.txt".format(
+                PROJ_ROOT
+            ),
+            "history_size=4",
+        ]
+    ),
     "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1",
 }
 

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -10,9 +10,9 @@ TEST_ENV = {
     "REDIS_QUEUE_HOST": "redis",
     "REDIS_STATE_HOST": "redis",
     "TERM": "xterm-256color",
-    "ASAN_OPTIONS": "verbosity=1:halt_on_error=1"
-    "TSAN_OPTIONS": "verbosity=1 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=4"
-    "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
+    "ASAN_OPTIONS": "verbosity=1:halt_on_error=1",
+    "TSAN_OPTIONS": "verbosity=1 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=4",
+    "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1",
 }
 
 


### PR DESCRIPTION
There are a number of environment variables that we need to set for the test suite to pass. This means that it is sometimes hard to have a green run of the tests in a local environment.

In this PR we fix this by adding a wrapper script to `faabric_tests` (`inv tests`), that executes the tests in an isolated enviornment and sets the right environment variables. This way, irrespective of the local environment, `inv tests` should always be green.

This also means that we don't have to set ad-hoc environment variables to neither the GHA workflow, nor the docker compose file (thus reducing duplication).

In addition, we add convinience arguments to run tests by test case, by file name, and even by directory name.