### PR TITLE
Add `--repeats` option to tests wrapper

### DIFF
--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -84,16 +84,16 @@ wrapper scripts in the following ways:
 
 ```bash
 # Run the whole test suite
-inv tests
+inv tests [--debug]
 
 # Run just one test case
-inv tests --test-case "Test JSON contains required keys"
+inv tests --test-case "Test JSON contains required keys" [--repeats <num>]
 
 # Run all test cases defined in one file
-inv tests --filename test_json
+inv tests --test-file test_json
 
 # Run all test cases defined in one directory
-inv tests --directory util
+inv tests --test-dir util
 ```
 
 ## Distributed tests

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -28,10 +28,11 @@ TEST_ENV = {
 def tests(
     ctx,
     test_case=None,
-    filename=None,
-    directory=None,
+    test_file=None,
+    test_dir=None,
     abort=False,
     debug=False,
+    repeats=1,
 ):
     """
     Run the C++ unit tests
@@ -52,13 +53,14 @@ def tests(
 
     if test_case:
         tests_cmd.append("'{}'".format(test_case))
-    elif filename:
-        tests_cmd.append("--filenames-as-tags [#{}]".format(filename))
-    elif directory:
+    elif test_file:
+        tests_cmd.append("--filenames-as-tags [#{}]".format(test_file))
+    elif test_dir:
         tag_str = "--filenames-as-tags "
-        for file_name in listdir(join(PROJ_ROOT, "tests", "test", directory)):
+        for file_name in listdir(join(PROJ_ROOT, "tests", "test", test_dir)):
             tag_str += "[#{}],".format(file_name.split(".")[0])
         tests_cmd.append(tag_str[:-1])
 
     tests_cmd = " ".join(tests_cmd)
-    run(tests_cmd, shell=True, check=True, cwd=PROJ_ROOT, env=TEST_ENV)
+    for i in range(repeats):
+        run(tests_cmd, shell=True, check=True, cwd=PROJ_ROOT, env=TEST_ENV)


### PR DESCRIPTION
The `inv tests` wrapper has proven very useful for things like running all the tests in one directory.

After having 