### PR TITLE
gha: try explicitly setting cache mount source

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         sanitiser: [None, Address, Thread, Undefined]
     env:
+      CONAN_CACHE_MOUNT_SOURCE: ~/.conan/
       HOST_TYPE: ci
       REDIS_QUEUE_HOST: redis
       REDIS_STATE_HOST: redis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
         password: ${{ secrets.ACR_SERVICE_PRINCIPAL_PASSWORD }}
     steps:
       - uses: faasm/conan-cache-action@v1
+      - name: "Build Conan deps to be shared by all runs"
+        run: ./bin/inv_wrapper.sh dev.cmake --build Debug --clean
 
   docs:
     if: github.event.pull_request.draft == false
@@ -71,7 +73,6 @@ jobs:
       matrix:
         sanitiser: [None, Address, Thread, Undefined]
     env:
-      CONAN_CACHE_MOUNT_SOURCE: ~/.conan/
       HOST_TYPE: ci
       REDIS_QUEUE_HOST: redis
       REDIS_STATE_HOST: redis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         password: ${{ secrets.ACR_SERVICE_PRINCIPAL_PASSWORD }}
     steps:
       - uses: faasm/conan-cache-action@v1
-      - name: "Build Conan deps to be shared by all runs"
+      - name: "Build Conan CMake deps to be shared by all runs"
         run: ./bin/inv_wrapper.sh dev.cmake --build Debug --clean
 
   docs:


### PR DESCRIPTION
The tests were not re-using the Conan cache, and instead they were re-building the CMake dependencies every time. In this PR we fix this issue.

The main reason why dependencies were not being cached is that [GHA's cache action does **not** upload the updated `path` if there is a cache hit](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#cache-hits-and-misses).

This, paired with the fact that we actually were not building the conan dependencies in the `conan-cache` step, meant that we had to rebuild them every time.