### PR TITLE
Set threshold for CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,11 @@ ignore:
     - "include/faabric/flat"
     # We exclude the tests from the coverage results
     - "tests"
+
+# Don't report actions as failed unless there's more than a 1% decrease in
+# coverage
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
Amend the `codecov.yml` file to configure the threshold for CodeCov to report an action as failed.

Before, CodeCov was reporting PRs as failed if the coverage reduced by 0.01% (which ends up being a resolution issue).

We set the threshold to 1%.