### PR TITLE
Route worker flush requests through planner

### DIFF
--- a/include/faabric/planner/Planner.h
+++ b/include/faabric/planner/Planner.h
@@ -10,6 +10,7 @@ enum FlushType
 {
     NoFlushType = 0,
     Hosts = 1,
+    Executors = 2,
 };
 
 /* The planner is a standalone component that has a global view of the state
@@ -67,6 +68,8 @@ class Planner
     PlannerConfig config;
 
     void flushHosts();
+
+    void flushExecutors();
 
     // Check if a host's registration timestamp has expired
     bool isHostExpired(std::shared_ptr<Host> host, long epochTimeMs = 0);

--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -259,8 +259,6 @@ class Scheduler
       const std::string& function,
       bool acquireLock = true);
 
-    void broadcastFlush();
-
     void flushLocally();
 
     // ----------------------------------

--- a/src/endpoint/FaabricEndpointHandler.cpp
+++ b/src/endpoint/FaabricEndpointHandler.cpp
@@ -68,12 +68,6 @@ void FaabricEndpointHandler::onRequest(
               sched.getFunctionExecGraph(msg);
             response.result(beast::http::status::ok);
             response.body() = faabric::scheduler::execGraphToJson(execGraph);
-
-        } else if (msg.type() == faabric::Message_MessageType_FLUSH) {
-            SPDLOG_DEBUG("Broadcasting flush request");
-            sched.broadcastFlush();
-            response.result(beast::http::status::ok);
-            response.body() = std::string("Flush sent");
         } else {
             executeFunction(
               std::move(ctx), std::move(response), std::move(req), 0);

--- a/src/planner/PlannerEndpointHandler.cpp
+++ b/src/planner/PlannerEndpointHandler.cpp
@@ -72,6 +72,19 @@ void PlannerEndpointHandler::onRequest(
             }
             return ctx.sendFunction(std::move(response));
         }
+        case faabric::planner::HttpMessage_Type_FLUSH_EXECUTORS: {
+            bool success = faabric::planner::getPlanner().flush(
+              faabric::planner::FlushType::Executors);
+            if (success) {
+                response.result(beast::http::status::ok);
+                response.body() = std::string("Flushed executors!");
+            } else {
+                // TODO: can we actually ever be here?
+                response.result(beast::http::status::internal_server_error);
+                response.body() = std::string("Failed flushing executors!");
+            }
+            return ctx.sendFunction(std::move(response));
+        }
         case faabric::planner::HttpMessage_Type_GET_CONFIG: {
             auto config = faabric::planner::getPlanner().getConfig();
             std::string responseStr;

--- a/src/planner/PlannerEndpointHandler.cpp
+++ b/src/planner/PlannerEndpointHandler.cpp
@@ -79,7 +79,6 @@ void PlannerEndpointHandler::onRequest(
                 response.result(beast::http::status::ok);
                 response.body() = std::string("Flushed executors!");
             } else {
-                // TODO: can we actually ever be here?
                 response.result(beast::http::status::internal_server_error);
                 response.body() = std::string("Failed flushing executors!");
             }

--- a/src/planner/planner.proto
+++ b/src/planner/planner.proto
@@ -36,10 +36,11 @@ message HttpMessage {
         NO_TYPE = 0;
         RESET = 1;
         FLUSH_HOSTS = 2;
-        GET_CONFIG = 3;
+        FLUSH_EXECUTORS = 3;
+        GET_CONFIG = 4;
     }
 
-    Type type = 1;
+    Type type = 1 [json_name = "http_type"];
 }
 
 // ---------------------------------------------

--- a/src/planner/planner_server.cpp
+++ b/src/planner/planner_server.cpp
@@ -21,7 +21,6 @@ int main()
 
     // The faabric endpoint starts in the foreground
     SPDLOG_INFO("Starting planner endpoint");
-    SPDLOG_WARN("Hellooo");
     // We get the port from the global config, but the number of threads from
     // the planner config
     faabric::endpoint::FaabricEndpoint endpoint(

--- a/src/planner/planner_server.cpp
+++ b/src/planner/planner_server.cpp
@@ -21,6 +21,7 @@ int main()
 
     // The faabric endpoint starts in the foreground
     SPDLOG_INFO("Starting planner endpoint");
+    SPDLOG_WARN("Hellooo");
     // We get the port from the global config, but the number of threads from
     // the planner config
     faabric::endpoint::FaabricEndpoint endpoint(

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -1107,24 +1107,6 @@ std::string Scheduler::getThisHost()
     return thisHost;
 }
 
-void Scheduler::broadcastFlush()
-{
-    faabric::util::FullLock lock(mx);
-    // Get all hosts
-    std::set<std::string> allHosts = getAvailableHosts();
-
-    // Remove this host from the set
-    allHosts.erase(thisHost);
-
-    // Dispatch flush message to all other hosts
-    for (const auto& otherHost : allHosts) {
-        getFunctionCallClient(otherHost)->sendFlush();
-    }
-
-    lock.unlock();
-    flushLocally();
-}
-
 void Scheduler::flushLocally()
 {
     SPDLOG_INFO("Flushing host {}",

--- a/tests/dist/dist_test_fixtures.h
+++ b/tests/dist/dist_test_fixtures.h
@@ -53,10 +53,7 @@ class DistTestsFixture
 class MpiDistTestsFixture : public DistTestsFixture
 {
   public:
-    MpiDistTestsFixture()
-    {
-        SLEEP_MS(INTER_MPI_TEST_SLEEP);
-    }
+    MpiDistTestsFixture() { SLEEP_MS(INTER_MPI_TEST_SLEEP); }
 
     ~MpiDistTestsFixture() = default;
 

--- a/tests/dist/dist_test_fixtures.h
+++ b/tests/dist/dist_test_fixtures.h
@@ -55,8 +55,6 @@ class MpiDistTestsFixture : public DistTestsFixture
   public:
     MpiDistTestsFixture()
     {
-        // Flush before each execution to ensure a clean start
-        sch.broadcastFlush();
         SLEEP_MS(INTER_MPI_TEST_SLEEP);
     }
 

--- a/tests/test/planner/test_planner_endpoint.cpp
+++ b/tests/test/planner/test_planner_endpoint.cpp
@@ -139,12 +139,6 @@ TEST_CASE_METHOD(FaabricPlannerEndpointTestFixture,
 {
     faabric::util::setMockMode(true);
 
-    // faabric::scheduler::FunctionCallServer functionCallServer;
-    // faabric::scheduler::FunctionCallClient functionCallClient(LOCALHOST);
-
-    // TODO: start function client/server
-    // functionCallServer.start();
-
     std::string hostA = "alpha";
     std::string hostB = "beta";
     std::string hostC = "gamma";

--- a/tests/test/scheduler/test_function_client_server.cpp
+++ b/tests/test/scheduler/test_function_client_server.cpp
@@ -105,38 +105,6 @@ TEST_CASE_METHOD(FunctionClientServerTestFixture,
 }
 
 TEST_CASE_METHOD(FunctionClientServerTestFixture,
-                 "Test broadcasting flush message",
-                 "[scheduler]")
-{
-    faabric::util::setMockMode(true);
-
-    std::string hostA = "alpha";
-    std::string hostB = "beta";
-    std::string hostC = "gamma";
-
-    std::vector<std::string> expectedHosts = { hostA, hostB, hostC };
-
-    sch.addHostToGlobalSet(hostA);
-    sch.addHostToGlobalSet(hostB);
-    sch.addHostToGlobalSet(hostC);
-
-    // Broadcast the flush
-    sch.broadcastFlush();
-
-    // Make sure messages have been sent
-    auto calls = faabric::scheduler::getFlushCalls();
-    REQUIRE(calls.size() == 3);
-
-    std::vector<std::string> actualHosts;
-    for (auto c : calls) {
-        actualHosts.emplace_back(c.first);
-    }
-
-    faabric::util::setMockMode(false);
-    faabric::scheduler::clearMockRequests();
-}
-
-TEST_CASE_METHOD(FunctionClientServerTestFixture,
                  "Test client batch execution request",
                  "[scheduler]")
 {

--- a/tests/utils/faabric_utils.h
+++ b/tests/utils/faabric_utils.h
@@ -94,5 +94,7 @@ std::pair<int, std::string> postToUrl(const std::string& host,
                                       int port,
                                       const std::string& body);
 
+void flushPlannerWorkers();
+
 void resetPlanner();
 }

--- a/tests/utils/planner_utils.cpp
+++ b/tests/utils/planner_utils.cpp
@@ -15,4 +15,16 @@ void resetPlanner()
       postToUrl(conf.plannerHost, conf.plannerPort, jsonStr);
     assert(result.first == 200);
 }
+
+void flushPlannerWorkers()
+{
+    faabric::planner::HttpMessage msg;
+    msg.set_type(faabric::planner::HttpMessage_Type_FLUSH_EXECUTORS);
+    std::string jsonStr = faabric::util::messageToJson(msg);
+
+    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    std::pair<int, std::string> result =
+      postToUrl(conf.plannerHost, conf.plannerPort, jsonStr);
+    assert(result.first == 200);
+}
 }


### PR DESCRIPTION
In this PR I route all flush requests through the planner's HTTP endpoint. The planner then broadcasts the flush to all the registered workers.