### PR TITLE
Debug makespan

### DIFF
--- a/src/mpi/MpiWorld.cpp
+++ b/src/mpi/MpiWorld.cpp
@@ -61,7 +61,7 @@ void MpiWorld::sendRemoteMpiMessage(std::string dstHost,
         throw std::runtime_error("Error serialising message");
     }
     broker.sendMessage(
-      id,
+      thisRankMsg->groupid(),
       sendRank,
       recvRank,
       reinterpret_cast<const uint8_t*>(serialisedBuffer.data()),
@@ -73,7 +73,8 @@ void MpiWorld::sendRemoteMpiMessage(std::string dstHost,
 std::shared_ptr<MPIMessage> MpiWorld::recvRemoteMpiMessage(int sendRank,
                                                            int recvRank)
 {
-    auto msg = broker.recvMessage(id, sendRank, recvRank, true);
+    auto msg =
+          broker.recvMessage(thisRankMsg->groupid(), sendRank, recvRank, true);
     PARSE_MSG(MPIMessage, msg.data(), msg.size());
     return std::make_shared<MPIMessage>(parsedMsg);
 }
@@ -106,8 +107,16 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
     user = call.user();
     function = call.function();
     thisRankMsg = &call;
-
     size = newSize;
+
+    // Update the first message to make sure it looks like messages >= 1
+    call.set_ismpi(true);
+    call.set_mpirank(0);
+    call.set_mpiworldid(id);
+    call.set_mpiworldsize(size);
+    call.set_groupid(call.mpiworldid());
+    call.set_groupidx(call.mpirank());
+    call.set_appidx(call.mpirank());
 
     auto& sch = faabric::scheduler::getScheduler();
 
@@ -119,12 +128,12 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
         faabric::Message& msg = req->mutable_messages()->at(i);
         msg.set_appid(call.appid());
         msg.set_ismpi(true);
-        msg.set_mpiworldid(id);
+        msg.set_mpiworldid(call.mpiworldid());
         msg.set_mpirank(i + 1);
-        msg.set_mpiworldsize(size);
+        msg.set_mpiworldsize(call.mpiworldsize());
 
         // Set group ids for remote messaging
-        msg.set_groupid(msg.mpiworldid());
+        msg.set_groupid(call.groupid());
         msg.set_groupidx(msg.mpirank());
         if (thisRankMsg != nullptr) {
             // Set message fields to allow for function migration
@@ -210,6 +219,9 @@ void MpiWorld::destroy()
         throw std::runtime_error("Destroying world with outstanding requests");
     }
 
+    // Lastly, clear-out the rank message
+    thisRankMsg = nullptr;
+
     // Clear structures used for mocking
     {
         faabric::util::UniqueLock lock(mockMutex);
@@ -223,6 +235,7 @@ void MpiWorld::initialiseFromMsg(faabric::Message& msg)
     user = msg.user();
     function = msg.function();
     size = msg.mpiworldsize();
+    thisRankMsg = &msg;
 
     // Record which ranks are local to this world, and query for all leaders
     initLocalRemoteLeaders();
@@ -258,14 +271,19 @@ void MpiWorld::initLocalRemoteLeaders()
     // keep a record of the opposite mapping, the host that each rank belongs
     // to, as it is queried frequently and asking the ptp broker involves
     // acquiring a lock.
-    auto rankIds = broker.getIdxsRegisteredForGroup(id);
+     if (thisRankMsg == nullptr) {
+        throw std::runtime_error("Rank message not set!");
+    }
+    int groupId = thisRankMsg->groupid();
+    auto rankIds = broker.getIdxsRegisteredForGroup(groupId);
     if (rankIds.size() != size) {
         SPDLOG_ERROR("rankIds != size ({} != {})", rankIds.size(), size);
+        throw std::runtime_error("MPI Group-World size mismatch!");
     }
     assert(rankIds.size() == size);
     hostForRank.resize(size);
     for (const auto& rankId : rankIds) {
-        std::string host = broker.getHostForReceiver(id, rankId);
+        std::string host = broker.getHostForReceiver(groupId, rankId);
         ranksForHost[host].push_back(rankId);
         hostForRank.at(rankId) = host;
     }

--- a/src/mpi/MpiWorld.cpp
+++ b/src/mpi/MpiWorld.cpp
@@ -7,7 +7,6 @@
 #include <faabric/util/environment.h>
 #include <faabric/util/gids.h>
 #include <faabric/util/macros.h>
-#include <faabric/util/queue.h>
 #include <faabric/util/scheduling.h>
 #include <faabric/util/testing.h>
 

--- a/src/mpi/MpiWorld.cpp
+++ b/src/mpi/MpiWorld.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<MPIMessage> MpiWorld::recvRemoteMpiMessage(int sendRank,
                                                            int recvRank)
 {
     auto msg =
-          broker.recvMessage(thisRankMsg->groupid(), sendRank, recvRank, true);
+      broker.recvMessage(thisRankMsg->groupid(), sendRank, recvRank, true);
     PARSE_MSG(MPIMessage, msg.data(), msg.size());
     return std::make_shared<MPIMessage>(parsedMsg);
 }
@@ -271,7 +271,7 @@ void MpiWorld::initLocalRemoteLeaders()
     // keep a record of the opposite mapping, the host that each rank belongs
     // to, as it is queried frequently and asking the ptp broker involves
     // acquiring a lock.
-     if (thisRankMsg == nullptr) {
+    if (thisRankMsg == nullptr) {
         throw std::runtime_error("Rank message not set!");
     }
     int groupId = thisRankMsg->groupid();

--- a/src/mpi/MpiWorld.cpp
+++ b/src/mpi/MpiWorld.cpp
@@ -1457,28 +1457,18 @@ std::shared_ptr<MPIMessage> MpiWorld::recvBatchReturnLast(int sendRank,
     if (isLocal) {
         // First receive messages that happened before us
         for (int i = 0; i < batchSize - 1; i++) {
-            try {
             SPDLOG_TRACE("MPI - pending recv {} -> {}", sendRank, recvRank);
-                auto pendingMsg = getLocalQueue(sendRank, recvRank)->dequeue();
+            auto pendingMsg = getLocalQueue(sendRank, recvRank)->dequeue();
 
-                // Put the unacked message in the UMB
-                assert(!msgIt->isAcknowledged());
-                msgIt->acknowledge(pendingMsg);
-                msgIt++;
-            } catch (faabric::util::QueueTimeoutException& e) {
-                SPDLOG_ERROR("Timed out with: MPI - pending recv {} -> {}", sendRank, recvRank);
-                throw e;
-            }
+            // Put the unacked message in the UMB
+            assert(!msgIt->isAcknowledged());
+            msgIt->acknowledge(pendingMsg);
+            msgIt++;
         }
 
         // Finally receive the message corresponding to us
         SPDLOG_TRACE("MPI - recv {} -> {}", sendRank, recvRank);
-        try {
-            ourMsg = getLocalQueue(sendRank, recvRank)->dequeue();
-        } catch (faabric::util::QueueTimeoutException& e) {
-            SPDLOG_ERROR("Timed out with: MPI - recv {} -> {}", sendRank, recvRank);
-            throw e;
-        }
+        ourMsg = getLocalQueue(sendRank, recvRank)->dequeue();
     } else {
         // First receive messages that happened before us
         for (int i = 0; i < batchSize - 1; i++) {

--- a/src/transport/Message.cpp
+++ b/src/transport/Message.cpp
@@ -7,7 +7,7 @@ namespace faabric::transport {
 
 Message::Message(size_t bufferSize)
 {
-    if (int ec = nng_msg_alloc(&nngMsg, bufferSize); ec < 0) {
+    if (int ec = nng_msg_alloc(&nngMsg, bufferSize); ec != 0) {
         SPDLOG_CRITICAL("Error allocating a message of size {}: {}",
                         bufferSize,
                         nng_strerror(ec));

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -289,12 +289,13 @@ void MessageEndpoint::sendMessage(uint8_t header,
     int ec = nng_aio_result(aio);
     nng_aio_free(aio);
     if (ec != 0) {
-        SPDLOG_ERROR("Error {} ({}) when sending messge to {} (seq: {} - ctx: {})",
-                     ec,
-                     nng_strerror(ec),
-                     address,
-                     sequenceNum,
-                     context.has_value());
+        SPDLOG_ERROR(
+          "Error {} ({}) when sending messge to {} (seq: {} - ctx: {})",
+          ec,
+          nng_strerror(ec),
+          address,
+          sequenceNum,
+          context.has_value());
         nng_msg_free(msg); // Owned by the socket if succeeded
         checkNngError(ec, "sendMessage", address);
     }

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -289,6 +289,12 @@ void MessageEndpoint::sendMessage(uint8_t header,
     int ec = nng_aio_result(aio);
     nng_aio_free(aio);
     if (ec != 0) {
+        SPDLOG_ERROR("Error {} ({}) when sending messge to {} (seq: {} - ctx: {})",
+                     ec,
+                     nng_strerror(ec),
+                     address,
+                     sequenceNum,
+                     context.has_value());
         nng_msg_free(msg); // Owned by the socket if succeeded
         checkNngError(ec, "sendMessage", address);
     }

--- a/src/transport/MessageEndpoint.cpp
+++ b/src/transport/MessageEndpoint.cpp
@@ -272,7 +272,7 @@ void MessageEndpoint::sendMessage(uint8_t header,
     std::copy_n(data, dataSize, buffer + HEADER_MSG_SIZE);
 
     nng_aio* aio = nullptr;
-    if (int ec = nng_aio_alloc(&aio, nullptr, nullptr); ec < 0) {
+    if (int ec = nng_aio_alloc(&aio, nullptr, nullptr); ec != 0) {
         nng_msg_free(msg);
         checkNngError(ec, "nng_aio_alloc", address);
     }

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -511,6 +511,10 @@ void PointToPointBroker::initSequenceCounters(int groupId)
                      currentGroupId,
                      groupId);
     }
+    if (currentGroupId == 0 || groupId == 0) {
+        SPDLOG_ERROR("Zero-ed group Id !? (current: {} - id: {})", currentGroupId, groupId);
+        throw std::runtime_error("WHATTTTTT");
+    }
     currentGroupId = groupId;
     int groupSize = getIdxsRegisteredForGroup(groupId).size();
     // We initialise both counters at the same time, as we only know once per

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -511,10 +511,6 @@ void PointToPointBroker::initSequenceCounters(int groupId)
                      currentGroupId,
                      groupId);
     }
-    if (currentGroupId == 0 || groupId == 0) {
-        SPDLOG_ERROR("Zero-ed group Id !? (current: {} - id: {})", currentGroupId, groupId);
-        throw std::runtime_error("WHATTTTTT");
-    }
     currentGroupId = groupId;
     int groupSize = getIdxsRegisteredForGroup(groupId).size();
     // We initialise both counters at the same time, as we only know once per
@@ -758,8 +754,9 @@ std::vector<uint8_t> PointToPointBroker::recvMessage(int groupId,
         if (recvMsg.getResponseCode() !=
             faabric::transport::MessageResponseCode::SUCCESS) {
             SPDLOG_WARN(
-              "Error {} when awaiting a message ({}:{} seq: {} label: {})",
+              "Error {} ({}) when awaiting a message ({}:{} seq: {} label: {})",
               static_cast<int>(recvMsg.getResponseCode()),
+              nng_strerror(static_cast<int>(recvMsg.getResponseCode())),
               sendIdx,
               recvIdx,
               expectedSeqNum,

--- a/tests/test/scheduler/test_function_migration.cpp
+++ b/tests/test/scheduler/test_function_migration.cpp
@@ -423,7 +423,12 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
     // Manually create the world, and trigger a second function invocation in
     // the remote host
     faabric::mpi::MpiWorld world;
-    world.create(*firstMsg, worldId, worldSize);
+    // Note that we deliberately pass a copy of the message. The `world.create`
+    // method modifies the passed message, which can race with the thread pool
+    // thread executing the message. Note that, normally, the thread pool
+    // thread _would_ be calling world.create itself, thus not racing
+    auto firstMsgCopy = req->messages(0);
+    world.create(firstMsgCopy, worldId, worldSize);
 
     // Update host resources so that a migration opportunity appears
     updateLocalResources(4, 2);


### PR DESCRIPTION
In this PR I preemptively fix some sources of inconsistencies in the MPI remote messaging subsystem. I am observing some sporadic failures when threads are re-used to execute a different MPI application, so I am making sure everything is cleaned-up properly, and we are using the PTP semantics around to comunicate.

After this patch, I now see a different kind of errors, where an NNG `sendMessage` operation fails due to `NNG_ENOMEM` out of memory error. Hence why I slightly tweak the transport's error message reporting. I will work on the out-of-memory issue in a subsequent PR. On this same line, I fix two error checks that checked for `ec < 0` but in NNG error checking is always (?) `ec != 0`. (PS: I don't know if always, but at least for the two functions I changed it is).