### PR TITLE
Remove unused MessageLocalResult

### DIFF
--- a/include/faabric/scheduler/Scheduler.h
+++ b/include/faabric/scheduler/Scheduler.h
@@ -172,40 +172,6 @@ class FunctionMigrationThread : public faabric::util::PeriodicBackgroundThread
 };
 
 /**
- * A promise for a future message result with an associated eventfd for use with
- * asio.
- */
-class MessageLocalResult final
-{
-  public:
-    std::promise<std::unique_ptr<faabric::Message>> promise;
-    int eventFd = -1;
-
-    MessageLocalResult();
-
-    MessageLocalResult(const MessageLocalResult&) = delete;
-
-    inline MessageLocalResult(MessageLocalResult&& other)
-    {
-        this->operator=(std::move(other));
-    }
-
-    MessageLocalResult& operator=(const MessageLocalResult&) = delete;
-
-    inline MessageLocalResult& operator=(MessageLocalResult&& other)
-    {
-        this->promise = std::move(other.promise);
-        this->eventFd = other.eventFd;
-        other.eventFd = -1;
-        return *this;
-    }
-
-    ~MessageLocalResult();
-
-    void setValue(std::unique_ptr<faabric::Message>&& msg);
-};
-
-/**
  * Background thread that periodically checks to see if any executors have
  * become stale (i.e. not handled any requests in a given timeout). If any are
  * found, they are removed.

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -52,24 +52,6 @@ static faabric::util::
   ConcurrentMap<std::string, std::shared_ptr<faabric::planner::PlannerClient>>
     plannerClient;
 
-MessageLocalResult::MessageLocalResult()
-{
-    eventFd = eventfd(0, EFD_CLOEXEC);
-}
-
-MessageLocalResult::~MessageLocalResult()
-{
-    if (eventFd >= 0) {
-        close(eventFd);
-    }
-}
-
-void MessageLocalResult::setValue(std::unique_ptr<faabric::Message>&& msg)
-{
-    this->promise.set_value(std::move(msg));
-    eventfd_write(this->eventFd, (eventfd_t)1);
-}
-
 Scheduler& getScheduler()
 {
     static Scheduler sch;


### PR DESCRIPTION
In advance of implementing the planner scheduling, I am cleaning up the `Scheduler.h` header and have come accross this class that was no longer used.

The class became obsolete when moving setting/getting results to the planner in #317 