### PR TITLE
Re-factor master to main

### DIFF
--- a/include/faabric/batch-scheduler/SchedulingDecision.h
+++ b/include/faabric/batch-scheduler/SchedulingDecision.h
@@ -5,13 +5,13 @@
 namespace faabric::batch_scheduler {
 // Scheduling topology hints help the scheduler decide which host to assign new
 // requests in a batch.
-//  - NONE: bin-packs requests to slots in hosts starting from the master
-//          host, and overloadds the master if it runs out of resources.
+//  - NONE: bin-packs requests to slots in hosts starting from the main
+//          host, and overloadds the main if it runs out of resources.
 //  - FORCE_LOCAL: force local execution irrespective of the available
 //                 resources.
-//  - NEVER_ALONE: never allocates a single (non-master) request to a host
+//  - NEVER_ALONE: never allocates a single (non-main) request to a host
 //                 without other requests of the batch.
-//  - UNDERFULL: schedule up to 50% of the master hosts' capacity to force
+//  - UNDERFULL: schedule up to 50% of the main hosts' capacity to force
 //               migration opportunities to appear.
 enum SchedulingTopologyHint
 {
@@ -82,7 +82,7 @@ class SchedulingDecision
     /**
      * Work out if this decision is all on this host. If the decision is
      * completely on *another* host, we still count it as not being on a single
-     * host, as this host will be the master.
+     * host, as this host will be the main.
      *
      * Will always return false if single host optimisations are switched off.
      */

--- a/include/faabric/state/InMemoryStateKeyValue.h
+++ b/include/faabric/state/InMemoryStateKeyValue.h
@@ -11,8 +11,8 @@
 namespace faabric::state {
 enum InMemoryStateKeyStatus
 {
-    NOT_MASTER,
-    MASTER,
+    NOT_MAIN,
+    MAIN,
 };
 
 class AppendedInMemoryState

--- a/include/faabric/state/InMemoryStateKeyValue.h
+++ b/include/faabric/state/InMemoryStateKeyValue.h
@@ -55,7 +55,7 @@ class InMemoryStateKeyValue final : public StateKeyValue
 
   private:
     const std::string thisIP;
-    const std::string masterIP;
+    const std::string mainIP;
     InMemoryStateKeyStatus status;
 
     InMemoryStateRegistry& stateRegistry;

--- a/include/faabric/state/InMemoryStateRegistry.h
+++ b/include/faabric/state/InMemoryStateRegistry.h
@@ -22,8 +22,8 @@ class InMemoryStateRegistry
     void clear();
 
   private:
-    std::unordered_map<std::string, std::string> masterMap;
-    std::shared_mutex masterMapMutex;
+    std::unordered_map<std::string, std::string> mainMap;
+    std::shared_mutex mainMapMutex;
 };
 
 InMemoryStateRegistry& getInMemoryStateRegistry();

--- a/include/faabric/transport/PointToPointBroker.h
+++ b/include/faabric/transport/PointToPointBroker.h
@@ -17,7 +17,7 @@
 
 #define DEFAULT_DISTRIBUTED_TIMEOUT_MS 30000
 
-#define POINT_TO_POINT_MASTER_IDX 0
+#define POINT_TO_POINT_MAIN_IDX 0
 
 namespace faabric::transport {
 
@@ -63,7 +63,7 @@ class PointToPointGroup
   private:
     faabric::util::SystemConfig& conf;
 
-    std::string masterHost;
+    std::string mainHost;
     int appId = 0;
     int groupId = 0;
     int groupSize = 0;

--- a/include/faabric/util/snapshot.h
+++ b/include/faabric/util/snapshot.h
@@ -156,9 +156,9 @@ class SnapshotMergeRegion
 };
 
 /*
- * Calculates a diff value that can later be merged into the master copy of the
+ * Calculates a diff value that can later be merged into the main copy of the
  * given snapshot. It will be used on remote hosts to calculate the diffs that
- * are to be sent back to the master host.
+ * are to be sent back to the main host.
  */
 template<typename T>
 inline bool calculateDiffValue(const uint8_t* original,
@@ -210,7 +210,7 @@ inline bool calculateDiffValue(const uint8_t* original,
 }
 
 /*
- * Applies a diff value to the master copy of a snapshot, where the diff has
+ * Applies a diff value to the main copy of a snapshot, where the diff has
  * been calculated based on a change made to another copy of the same snapshot.
  */
 template<typename T>

--- a/src/mpi/MpiWorld.cpp
+++ b/src/mpi/MpiWorld.cpp
@@ -140,7 +140,7 @@ void MpiWorld::create(faabric::Message& call, int newId, int newSize)
 
     auto& sch = faabric::scheduler::getScheduler();
 
-    // Dispatch all the chained calls. With the master being rank zero, we want
+    // Dispatch all the chained calls. With the main being rank zero, we want
     // to spawn (size - 1) new functions starting with rank 1
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory(user, function, size - 1);
@@ -724,7 +724,7 @@ void MpiWorld::broadcast(int sendRank,
         }
     } else {
         // If we are neither the sending rank nor a local leader, we receive
-        // from either our leader master if the broadcast originated in a
+        // from either our local leader if the broadcast originated in a
         // different host, or the sending rank itself if we are on the same host
         int sendingRank =
           getHostForRank(sendRank) == thisHost ? sendRank : localLeader;

--- a/src/planner/Planner.cpp
+++ b/src/planner/Planner.cpp
@@ -245,9 +245,9 @@ std::shared_ptr<faabric::Message> Planner::getMessageResult(
 
     // If we are here, it means that we have not found the message result, so
     // we register the calling-host's interest if the calling-host has
-    // provided a masterhost. The masterhost is set when dispatching a message
+    // provided a main host. The main host is set when dispatching a message
     // within faabric, but not when sending an HTTP request
-    if (!msg->masterhost().empty()) {
+    if (!msg->mainhost().empty()) {
         faabric::util::FullLock lock(plannerMx);
 
         // Check again if the result is not set, as it could have been set
@@ -260,9 +260,9 @@ std::shared_ptr<faabric::Message> Planner::getMessageResult(
         // Definately the message result is not set, so we add the host to the
         // waiters list
         SPDLOG_DEBUG("Adding host {} on the waiting list for message {}",
-                     msg->masterhost(),
+                     msg->mainhost(),
                      msgId);
-        state.appResultWaiters[msgId].push_back(msg->masterhost());
+        state.appResultWaiters[msgId].push_back(msg->mainhost());
     }
 
     return nullptr;

--- a/src/planner/PlannerClient.cpp
+++ b/src/planner/PlannerClient.cpp
@@ -167,10 +167,10 @@ std::shared_ptr<faabric::Message> PlannerClient::getMessageResultFromPlanner(
 faabric::Message PlannerClient::getMessageResult(const faabric::Message& msg,
                                                  int timeoutMs)
 {
-    // Deliberately make a copy here so that we can set the masterhost when
+    // Deliberately make a copy here so that we can set the main host when
     // registering interest in the results
     auto msgPtr = std::make_shared<faabric::Message>(msg);
-    msgPtr->set_masterhost(faabric::util::getSystemConfig().endpointHost);
+    msgPtr->set_mainhost(faabric::util::getSystemConfig().endpointHost);
     return doGetMessageResult(msgPtr, timeoutMs);
 }
 
@@ -181,7 +181,7 @@ faabric::Message PlannerClient::getMessageResult(int appId,
     auto msgPtr = std::make_shared<faabric::Message>();
     msgPtr->set_appid(appId);
     msgPtr->set_id(msgId);
-    msgPtr->set_masterhost(faabric::util::getSystemConfig().endpointHost);
+    msgPtr->set_mainhost(faabric::util::getSystemConfig().endpointHost);
     return doGetMessageResult(msgPtr, timeoutMs);
 }
 

--- a/src/proto/faabric.proto
+++ b/src/proto/faabric.proto
@@ -92,7 +92,7 @@ message Message {
     // Each BER has a unique app id
     int32 appId = 2;
     int32 appIdx = 3;
-    string masterHost = 4;
+    string mainHost = 4;
 
     enum MessageType {
         CALL = 0;

--- a/src/scheduler/Executor.cpp
+++ b/src/scheduler/Executor.cpp
@@ -226,7 +226,7 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
     faabric::Message& firstMsg = req->mutable_messages()->at(0);
     std::string thisHost = faabric::util::getSystemConfig().endpointHost;
 
-    bool isMaster = firstMsg.masterhost() == thisHost;
+    bool isMaster = firstMsg.mainhost() == thisHost;
     bool isThreads = req->type() == faabric::BatchExecuteRequest::THREADS;
     bool isSingleHost = req->singlehost();
     std::string snapshotKey = firstMsg.snapshotkey();
@@ -287,7 +287,7 @@ void Executor::executeTasks(std::vector<int> msgIdxs,
             // Here all threads are still executing, so we have to overload.
             // If any tasks are blocking we risk a deadlock, and can no
             // longer guarantee the application will finish. In general if
-            // we're on the master host and this is a thread, we should
+            // we're on the main host and this is a thread, we should
             // avoid the zeroth and first pool threads as they are likely to
             // be the main thread and the zeroth in the communication group,
             // so will be blocking.

--- a/src/scheduler/FunctionCallClient.cpp
+++ b/src/scheduler/FunctionCallClient.cpp
@@ -152,7 +152,7 @@ faabric::HostResources FunctionCallClient::getResources()
     return response;
 }
 
-// This function call is used by the master host of an application to let know
+// This function call is used by the main host of an application to let know
 // other hosts running functions of the same application that a migration
 // opportunity has been found.
 void FunctionCallClient::sendPendingMigrations(

--- a/src/scheduler/FunctionCallServer.cpp
+++ b/src/scheduler/FunctionCallServer.cpp
@@ -86,7 +86,7 @@ void FunctionCallServer::recvExecuteFunctions(std::span<const uint8_t> buffer)
         // This flags were set by the old endpoint, we temporarily set them here
         parsedMsg.mutable_messages()->at(0).set_timestamp(
           faabric::util::getGlobalClock().epochMillis());
-        parsedMsg.mutable_messages()->at(0).set_masterhost(
+        parsedMsg.mutable_messages()->at(0).set_mainhost(
           faabric::util::getSystemConfig().endpointHost);
     }
     scheduler.callFunctions(

--- a/src/state/InMemoryStateKeyValue.cpp
+++ b/src/state/InMemoryStateKeyValue.cpp
@@ -63,7 +63,7 @@ InMemoryStateKeyValue::InMemoryStateKeyValue(const std::string& userIn,
   , thisIP(thisIPIn)
   , mainIP(getInMemoryStateRegistry().getMasterIP(user, key, thisIP, true))
   , status(mainIP == thisIP ? InMemoryStateKeyStatus::MAIN
-                              : InMemoryStateKeyStatus::NOT_MAIN)
+                            : InMemoryStateKeyStatus::NOT_MAIN)
   , stateRegistry(getInMemoryStateRegistry())
 {
     SPDLOG_TRACE("Creating in-memory state key-value for {}/{} size {} (this "

--- a/src/state/InMemoryStateKeyValue.cpp
+++ b/src/state/InMemoryStateKeyValue.cpp
@@ -62,8 +62,8 @@ InMemoryStateKeyValue::InMemoryStateKeyValue(const std::string& userIn,
   : StateKeyValue(userIn, keyIn, sizeIn)
   , thisIP(thisIPIn)
   , mainIP(getInMemoryStateRegistry().getMasterIP(user, key, thisIP, true))
-  , status(mainIP == thisIP ? InMemoryStateKeyStatus::MASTER
-                              : InMemoryStateKeyStatus::NOT_MASTER)
+  , status(mainIP == thisIP ? InMemoryStateKeyStatus::MAIN
+                              : InMemoryStateKeyStatus::NOT_MAIN)
   , stateRegistry(getInMemoryStateRegistry())
 {
     SPDLOG_TRACE("Creating in-memory state key-value for {}/{} size {} (this "
@@ -83,7 +83,7 @@ InMemoryStateKeyValue::InMemoryStateKeyValue(const std::string& userIn,
 
 bool InMemoryStateKeyValue::isMaster()
 {
-    return status == InMemoryStateKeyStatus::MASTER;
+    return status == InMemoryStateKeyStatus::MAIN;
 }
 
 // ----------------------------------------
@@ -92,7 +92,7 @@ bool InMemoryStateKeyValue::isMaster()
 
 void InMemoryStateKeyValue::pullFromRemote()
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         return;
     }
 
@@ -103,7 +103,7 @@ void InMemoryStateKeyValue::pullFromRemote()
 
 void InMemoryStateKeyValue::pullChunkFromRemote(long offset, size_t length)
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         return;
     }
 
@@ -115,7 +115,7 @@ void InMemoryStateKeyValue::pullChunkFromRemote(long offset, size_t length)
 
 void InMemoryStateKeyValue::pushToRemote()
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         return;
     }
 
@@ -127,7 +127,7 @@ void InMemoryStateKeyValue::pushToRemote()
 void InMemoryStateKeyValue::pushPartialToRemote(
   const std::vector<StateChunk>& chunks)
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         // Nothing to be done
     } else {
         StateClient cli(user, key, mainIP);
@@ -137,7 +137,7 @@ void InMemoryStateKeyValue::pushPartialToRemote(
 
 void InMemoryStateKeyValue::appendToRemote(const uint8_t* data, size_t length)
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         // Create new memory region to hold data
         auto dataCopy = std::make_unique<uint8_t[]>(length);
         std::copy(data, data + length, dataCopy.get());
@@ -154,7 +154,7 @@ void InMemoryStateKeyValue::pullAppendedFromRemote(uint8_t* data,
                                                    size_t length,
                                                    long nValues)
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         // Copy all appended data into buffer locally
         size_t offset = 0;
         for (int i = 0; i < nValues; i++) {
@@ -171,7 +171,7 @@ void InMemoryStateKeyValue::pullAppendedFromRemote(uint8_t* data,
 
 void InMemoryStateKeyValue::clearAppendedFromRemote()
 {
-    if (status == InMemoryStateKeyStatus::MASTER) {
+    if (status == InMemoryStateKeyStatus::MAIN) {
         // Clear appended locally
         appendedData.clear();
     } else {

--- a/src/state/InMemoryStateRegistry.cpp
+++ b/src/state/InMemoryStateRegistry.cpp
@@ -69,8 +69,7 @@ std::string InMemoryStateRegistry::getMasterIP(const std::string& user,
             throw std::runtime_error("Unable to get remote lock");
         }
 
-        SPDLOG_DEBUG(
-          "Claiming main for {} (this host {})", lookupKey, thisIP);
+        SPDLOG_DEBUG("Claiming main for {} (this host {})", lookupKey, thisIP);
 
         // Check there's still no main, if so, claim
         mainIPBytes = redis.get(mainKey);
@@ -84,10 +83,8 @@ std::string InMemoryStateRegistry::getMasterIP(const std::string& user,
 
     // Cache the result locally
     std::string mainIP = faabric::util::bytesToString(mainIPBytes);
-    SPDLOG_DEBUG("Caching main for {} as {} (this host {})",
-                 lookupKey,
-                 mainIP,
-                 thisIP);
+    SPDLOG_DEBUG(
+      "Caching main for {} as {} (this host {})", lookupKey, mainIP, thisIP);
 
     mainMap[lookupKey] = mainIP;
 

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -325,11 +325,8 @@ void PointToPointGroup::barrier(int groupIdx)
     } else {
         // Do the send
         std::vector<uint8_t> data(1, 0);
-        ptpBroker.sendMessage(groupId,
-                              groupIdx,
-                              POINT_TO_POINT_MAIN_IDX,
-                              data.data(),
-                              data.size());
+        ptpBroker.sendMessage(
+          groupId, groupIdx, POINT_TO_POINT_MAIN_IDX, data.data(), data.size());
 
         // Await the response
         ptpBroker.recvMessage(groupId, POINT_TO_POINT_MAIN_IDX, groupIdx);
@@ -350,11 +347,8 @@ void PointToPointGroup::notify(int groupIdx)
     } else {
         std::vector<uint8_t> data(1, 0);
         SPDLOG_TRACE("Notifying group {} from index {}", groupId, groupIdx);
-        ptpBroker.sendMessage(groupId,
-                              groupIdx,
-                              POINT_TO_POINT_MAIN_IDX,
-                              data.data(),
-                              data.size());
+        ptpBroker.sendMessage(
+          groupId, groupIdx, POINT_TO_POINT_MAIN_IDX, data.data(), data.size());
     }
 }
 

--- a/src/transport/PointToPointClient.cpp
+++ b/src/transport/PointToPointClient.cpp
@@ -84,7 +84,7 @@ void PointToPointClient::makeCoordinationRequest(
     req.set_appid(appId);
     req.set_groupid(groupId);
     req.set_sendidx(groupIdx);
-    req.set_recvidx(POINT_TO_POINT_MASTER_IDX);
+    req.set_recvidx(POINT_TO_POINT_MAIN_IDX);
 
     switch (call) {
         case (faabric::transport::PointToPointCall::LOCK_GROUP): {

--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<faabric::Message> messageFactoryShared(
     setMessageId(*ptr);
 
     std::string thisHost = faabric::util::getSystemConfig().endpointHost;
-    ptr->set_masterhost(thisHost);
+    ptr->set_mainhost(thisHost);
 
     ptr->set_recordexecgraph(false);
 
@@ -76,7 +76,7 @@ faabric::Message messageFactory(const std::string& user,
     setMessageId(msg);
 
     std::string thisHost = faabric::util::getSystemConfig().endpointHost;
-    msg.set_masterhost(thisHost);
+    msg.set_mainhost(thisHost);
 
     msg.set_recordexecgraph(false);
 

--- a/tests/dist/dist_test_fixtures.h
+++ b/tests/dist/dist_test_fixtures.h
@@ -47,7 +47,7 @@ class DistTestsFixture
 
   private:
     std::string workerIP;
-    std::string masterIP;
+    std::string mainIP;
 };
 
 class MpiDistTestsFixture : public DistTestsFixture
@@ -105,7 +105,7 @@ class MpiDistTestsFixture : public DistTestsFixture
         for (int i = 0; i < allocateRemotely; i++) {
             expecedHosts.push_back(remoteIp);
         }
-        // Lastly, overload the master with all the ranks we haven't been able
+        // Lastly, overload the main with all the ranks we haven't been able
         // to allocate anywhere
         int overloadMaster = worldSize - nLocalSlots - allocateRemotely;
         for (int i = 0; i < overloadMaster; i++) {

--- a/tests/dist/main.cpp
+++ b/tests/dist/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     // another function).
     int result;
     {
-        SPDLOG_INFO("Starting distributed test server on master");
+        SPDLOG_INFO("Starting distributed test server on main");
         faabric::runner::FaabricMain m(fac);
         m.startBackground();
 

--- a/tests/dist/mpi/examples/mpi_checks.cpp
+++ b/tests/dist/mpi/examples/mpi_checks.cpp
@@ -51,28 +51,28 @@ int checks()
 
         // Check response count (although will have hung if it's wrong)
         if (responseCount != worldSize - 1) {
-            printf("Did not get enough responses back to master (got %i)\n",
+            printf("Did not get enough responses back to main (got %i)\n",
                    responseCount);
             return 1;
-        } else {
-            printf("Got expected responses in master (%i)\n", responseCount);
         }
 
+        printf("Got expected responses in main (%i)\n", responseCount);
+
     } else if (rank > 0) {
-        // Check message from master
+        // Check message from main
         int receivedNumber = 0;
         int expectedNumber = -100 - rank;
         MPI_Recv(
           &receivedNumber, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
         if (receivedNumber != expectedNumber) {
-            printf("Got unexpected number from master (got %i, expected %i)\n",
+            printf("Got unexpected number from main (got %i, expected %i)\n",
                    receivedNumber,
                    expectedNumber);
             return 1;
         }
-        printf("Got expected number from master %i\n", receivedNumber);
+        printf("Got expected number from main %i\n", receivedNumber);
 
-        // Send success message back to master
+        // Send success message back to main
         MPI_Send(&rank, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
     }
 

--- a/tests/dist/mpi/examples/mpi_order.cpp
+++ b/tests/dist/mpi/examples/mpi_order.cpp
@@ -44,7 +44,7 @@ int order()
         }
         printf("MPI order check successful\n");
     } else if (rank > 0 && rank <= 3) {
-        // Echo message back to master
+        // Echo message back to main
         int receivedNumber = 0;
         MPI_Recv(
           &receivedNumber, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);

--- a/tests/dist/mpi/examples/mpi_send.cpp
+++ b/tests/dist/mpi/examples/mpi_send.cpp
@@ -59,11 +59,11 @@ int send()
         int sentNumber = 100 - rank;
         int receivedNumber = 0;
 
-        // Receive message from master
+        // Receive message from main
         MPI_Recv(
           &receivedNumber, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
         if (receivedNumber != expectedNumber) {
-            printf("Got unexpected number from master (got %i, expected %i)\n",
+            printf("Got unexpected number from main (got %i, expected %i)\n",
                    receivedNumber,
                    expectedNumber);
             return 1;

--- a/tests/dist/mpi/examples/mpi_send_many.cpp
+++ b/tests/dist/mpi/examples/mpi_send_many.cpp
@@ -62,7 +62,7 @@ int sendMany()
         int sentNumber = 100 - rank;
         int receivedNumber = 0;
 
-        // Receive message from master
+        // Receive message from main
         for (int i = 0; i < numMsg; i++) {
             MPI_Recv(&receivedNumber,
                      1,
@@ -73,7 +73,7 @@ int sendMany()
                      MPI_STATUS_IGNORE);
             if (receivedNumber != expectedNumber) {
                 printf(
-                  "Got unexpected number from master (got %i, expected %i)\n",
+                  "Got unexpected number from main (got %i, expected %i)\n",
                   receivedNumber,
                   expectedNumber);
                 return 1;

--- a/tests/dist/mpi/mpi_native.cpp
+++ b/tests/dist/mpi/mpi_native.cpp
@@ -808,8 +808,8 @@ void mpiMigrationPoint(int entrypointFuncArg)
 
         // Take snapshot of function and send it to the host we are migrating
         // to. Note that the scheduler only pushes snapshots as part of function
-        // chaining from the master host of the app, and
-        // we are most likely migrating from a non-master host. Thus, we must
+        // chaining from the main host of the app, and
+        // we are most likely migrating from a non-main host. Thus, we must
         // take and push the snapshot manually.
         auto* exec = faabric::scheduler::ExecutorContext::get()->getExecutor();
         auto snap =

--- a/tests/dist/mpi/test_multiple_mpi_worlds.cpp
+++ b/tests/dist/mpi/test_multiple_mpi_worlds.cpp
@@ -10,7 +10,7 @@
 namespace tests {
 
 TEST_CASE_METHOD(MpiDistTestsFixture,
-                 "Test concurrent MPI applications with same master host",
+                 "Test concurrent MPI applications with same main host",
                  "[mpi]")
 {
     // Prepare both requests
@@ -36,7 +36,7 @@ TEST_CASE_METHOD(MpiDistTestsFixture,
 }
 
 TEST_CASE_METHOD(MpiDistTestsFixture,
-                 "Test concurrent MPI applications with different master host",
+                 "Test concurrent MPI applications with different main host",
                  "[mpi]")
 {
     // Prepare the first request (local): 2 ranks locally, 2 remotely

--- a/tests/test/mpi/test_mpi_world.cpp
+++ b/tests/test/mpi/test_mpi_world.cpp
@@ -41,7 +41,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test world creation", "[mpi]")
         REQUIRE(actualCall.mpiworldsize() == worldSize);
     }
 
-    // Check that this host is registered as the master
+    // Check that this host is registered as the main
     const std::string actualHost = world.getHostForRank(0);
     REQUIRE(actualHost == faabric::util::getSystemConfig().endpointHost);
 

--- a/tests/test/mpi/test_multiple_mpi_worlds.cpp
+++ b/tests/test/mpi/test_multiple_mpi_worlds.cpp
@@ -100,7 +100,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test creating two MPI worlds", "[mpi]")
         }
     }
 
-    // Check that this host is registered as the master
+    // Check that this host is registered as the main
     const std::string actualHostA = worldA.getHostForRank(0);
     const std::string actualHostB = worldB.getHostForRank(0);
     REQUIRE(actualHostA == faabric::util::getSystemConfig().endpointHost);

--- a/tests/test/planner/test_planner_endpoint.cpp
+++ b/tests/test/planner/test_planner_endpoint.cpp
@@ -436,7 +436,7 @@ TEST_CASE_METHOD(PlannerEndpointExecTestFixture,
         REQUIRE(msgResult.timestamp() > 0);
         REQUIRE(msgResult.finishtimestamp() > 0);
         REQUIRE(!msgResult.executedhost().empty());
-        REQUIRE(!msgResult.masterhost().empty());
+        REQUIRE(!msgResult.mainhost().empty());
     }
 }
 

--- a/tests/test/scheduler/test_executor.cpp
+++ b/tests/test/scheduler/test_executor.cpp
@@ -589,7 +589,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
 }
 
 TEST_CASE_METHOD(TestExecutorFixture,
-                 "Test thread results returned on non-master",
+                 "Test thread results returned on non-main",
                  "[executor]")
 {
     faabric::util::setMockMode(true);
@@ -603,7 +603,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
     std::vector<uint32_t> messageIds;
     for (int i = 0; i < nThreads; i++) {
         faabric::Message& msg = req->mutable_messages()->at(i);
-        msg.set_masterhost(otherHost);
+        msg.set_mainhost(otherHost);
 
         messageIds.emplace_back(msg.id());
     }
@@ -794,7 +794,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
 }
 
 TEST_CASE_METHOD(TestExecutorFixture,
-                 "Test snapshot diffs returned to master",
+                 "Test snapshot diffs returned to main",
                  "[executor]")
 {
     int nThreads = 4;
@@ -816,11 +816,11 @@ TEST_CASE_METHOD(TestExecutorFixture,
     std::string mainThreadSnapshotKey =
       faabric::util::getMainThreadSnapshotKey(req->mutable_messages()->at(0));
 
-    // Set up some messages executing with a different master host
+    // Set up some messages executing with a different main host
     std::vector<uint32_t> messageIds;
     for (int i = 0; i < nThreads; i++) {
         faabric::Message& msg = req->mutable_messages()->at(i);
-        msg.set_masterhost(otherHost);
+        msg.set_mainhost(otherHost);
         msg.set_appidx(i);
 
         messageIds.emplace_back(msg.id());
@@ -828,11 +828,11 @@ TEST_CASE_METHOD(TestExecutorFixture,
 
     executeWithTestExecutor(req, true);
 
-    // Results aren't set on this host as it's not the master, so we have to
+    // Results aren't set on this host as it's not the main, so we have to
     // wait
     REQUIRE_RETRY({}, faabric::snapshot::getThreadResults().size() == nThreads);
 
-    // Check results have been sent back to the master host
+    // Check results have been sent back to the main host
     auto actualResults = faabric::snapshot::getThreadResults();
     REQUIRE(actualResults.size() == nThreads);
 
@@ -1052,7 +1052,7 @@ TEST_CASE_METHOD(TestExecutorFixture,
     int appId = msg.appid();
     std::vector<int> msgIds;
     for (auto& m : *req->mutable_messages()) {
-        m.set_masterhost(hostOverride);
+        m.set_mainhost(hostOverride);
         msgIds.push_back(m.id());
     }
 

--- a/tests/test/scheduler/test_function_migration.cpp
+++ b/tests/test/scheduler/test_function_migration.cpp
@@ -36,7 +36,7 @@ class FunctionMigrationTestFixture : public SchedulerFixture
 
   protected:
     FunctionMigrationThread migrationThread;
-    std::string masterHost = faabric::util::getSystemConfig().endpointHost;
+    std::string mainHost = faabric::util::getSystemConfig().endpointHost;
 
     // Helper method to set the available hosts and slots per host prior to
     // making a scheduling decision
@@ -53,7 +53,7 @@ class FunctionMigrationTestFixture : public SchedulerFixture
             resources.set_slots(slotsPerHost.at(i));
             resources.set_usedslots(usedSlotsPerHost.at(i));
 
-            // If setting resources for the master host, update the scheduler.
+            // If setting resources for the main host, update the scheduler.
             // Otherwise, queue the resource response
             if (i == 0) {
                 sch.setThisHostResources(resources);
@@ -151,7 +151,7 @@ TEST_CASE_METHOD(
 {
     // First set resources before calling the functions: one will be allocated
     // locally, another one in the remote host
-    std::vector<std::string> hosts = { masterHost, "hostA" };
+    std::vector<std::string> hosts = { mainHost, "hostA" };
     std::vector<int> slots = { 1, 1 };
     std::vector<int> usedSlots = { 0, 0 };
     setHostResources(hosts, slots, usedSlots);
@@ -204,7 +204,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
                  "Test checking for migration opportunities",
                  "[scheduler]")
 {
-    std::vector<std::string> hosts = { masterHost, "hostA" };
+    std::vector<std::string> hosts = { mainHost, "hostA" };
     std::vector<int> slots = { 1, 1 };
     std::vector<int> usedSlots = { 0, 0 };
     setHostResources(hosts, slots, usedSlots);
@@ -260,7 +260,7 @@ TEST_CASE_METHOD(
 {
     // First set resources before calling the functions: one request will be
     // allocated to each host
-    std::vector<std::string> hosts = { masterHost, "hostA", "hostB", "hostC" };
+    std::vector<std::string> hosts = { mainHost, "hostA", "hostB", "hostC" };
     std::vector<int> slots = { 1, 1, 1, 1 };
     std::vector<int> usedSlots = { 0, 0, 0, 0 };
     setHostResources(hosts, slots, usedSlots);
@@ -316,7 +316,7 @@ TEST_CASE_METHOD(
   "Test function migration thread detects migration opportunities",
   "[scheduler][.]")
 {
-    std::vector<std::string> hosts = { masterHost, "hostA" };
+    std::vector<std::string> hosts = { mainHost, "hostA" };
     std::vector<int> slots = { 1, 1 };
     std::vector<int> usedSlots = { 0, 0 };
     setHostResources(hosts, slots, usedSlots);
@@ -376,7 +376,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
 {
     auto req = faabric::util::batchExecFactory("foo", "sleep", 2);
     uint32_t appId = req->messages().at(0).appid();
-    std::vector<std::string> hosts = { masterHost, "hostA" };
+    std::vector<std::string> hosts = { mainHost, "hostA" };
     std::vector<std::pair<int, int>> migrations = { { 1, 0 } };
     auto expectedMigrations =
       buildPendingMigrationsExpectation(req, hosts, migrations);
@@ -396,7 +396,7 @@ TEST_CASE_METHOD(FunctionMigrationTestFixture,
                  "[scheduler]")
 {
     // Set up host resources
-    std::vector<std::string> hosts = { masterHost, "hostA" };
+    std::vector<std::string> hosts = { mainHost, "hostA" };
     std::vector<int> slots = { 2, 2 };
     std::vector<int> usedSlots = { 0, 0 };
     setHostResources(hosts, slots, usedSlots);

--- a/tests/test/scheduler/test_scheduler.cpp
+++ b/tests/test/scheduler/test_scheduler.cpp
@@ -781,7 +781,7 @@ TEST_CASE_METHOD(SlowExecutorTestFixture,
 }
 
 TEST_CASE_METHOD(SlowExecutorTestFixture,
-                 "Test non-master batch request returned to master",
+                 "Test non-main batch request returned to main",
                  "[scheduler]")
 {
     faabric::util::setMockMode(true);
@@ -790,14 +790,14 @@ TEST_CASE_METHOD(SlowExecutorTestFixture,
 
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory("blah", "foo", 1);
-    req->mutable_messages()->at(0).set_masterhost(otherHost);
+    req->mutable_messages()->at(0).set_mainhost(otherHost);
 
     faabric::batch_scheduler::SchedulingDecision decision =
       sch.callFunctions(req);
     REQUIRE(decision.hosts.empty());
     REQUIRE(decision.returnHost == otherHost);
 
-    // Check forwarded to master
+    // Check forwarded to main
     auto actualReqs = faabric::scheduler::getBatchRequests();
     REQUIRE(actualReqs.size() == 1);
     REQUIRE(actualReqs.at(0).first == otherHost);
@@ -865,7 +865,7 @@ TEST_CASE_METHOD(SlowExecutorTestFixture,
     faabric::util::setMockMode(true);
 
     faabric::Message msg = faabric::util::messageFactory("foo", "bar");
-    msg.set_masterhost("otherHost");
+    msg.set_mainhost("otherHost");
 
     // Set the thread result
     int returnValue = 123;

--- a/tests/test/scheduler/test_scheduling_decisions.cpp
+++ b/tests/test/scheduler/test_scheduling_decisions.cpp
@@ -295,23 +295,21 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     {
         config.slots = { 2, 2, 2, 2 };
         config.expectedHosts = { mainHost, mainHost, "hostA", "hostA",
-                                 "hostB",    "hostB",    "hostC", "hostC" };
+                                 "hostB",  "hostB",  "hostC", "hostC" };
     }
 
     SECTION("Uneven slot ditribution across hosts")
     {
         config.slots = { 3, 2, 2, 1 };
         config.expectedHosts = { mainHost, mainHost, mainHost, "hostA",
-                                 "hostA",    "hostB",    "hostB",    "hostC" };
+                                 "hostA",  "hostB",  "hostB",  "hostC" };
     }
 
     SECTION("Very uneven slot distribution across hosts")
     {
         config.slots = { 1, 0, 0, 0 };
-        config.expectedHosts = {
-            mainHost, mainHost, mainHost, mainHost,
-            mainHost, mainHost, mainHost, mainHost
-        };
+        config.expectedHosts = { mainHost, mainHost, mainHost, mainHost,
+                                 mainHost, mainHost, mainHost, mainHost };
     }
 
     SECTION("Decreasing to one and increasing slot distribution")
@@ -322,10 +320,8 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
         {
             config.topologyHint =
               faabric::batch_scheduler::SchedulingTopologyHint::NONE;
-            config.expectedHosts = {
-                mainHost, mainHost, "hostA", "hostA",
-                "hostB",    "hostC",    "hostC", mainHost
-            };
+            config.expectedHosts = { mainHost, mainHost, "hostA", "hostA",
+                                     "hostB",  "hostC",  "hostC", mainHost };
         }
 
         SECTION("Never alone topology hint")
@@ -333,7 +329,7 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
             config.topologyHint =
               faabric::batch_scheduler::SchedulingTopologyHint::NEVER_ALONE;
             config.expectedHosts = { mainHost, mainHost, "hostA", "hostA",
-                                     "hostC",    "hostC",    "hostC", "hostC" };
+                                     "hostC",  "hostC",  "hostC", "hostC" };
         }
     }
 
@@ -406,7 +402,7 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
         config.slots = { 2, 3, 1 };
         config.used = { 0, 0, 0 };
         config.expectedHosts = { mainHost, mainHost, "hostA",
-                                 "hostA",    "hostA",    "hostA" };
+                                 "hostA",  "hostA",  "hostA" };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
 

--- a/tests/test/scheduler/test_scheduling_decisions.cpp
+++ b/tests/test/scheduler/test_scheduling_decisions.cpp
@@ -27,7 +27,7 @@ class SchedulingDecisionTestFixture : public SchedulerFixture
     ~SchedulingDecisionTestFixture() { faabric::util::setMockMode(false); }
 
   protected:
-    std::string masterHost = faabric::util::getSystemConfig().endpointHost;
+    std::string mainHost = faabric::util::getSystemConfig().endpointHost;
 
     // Helper struct to configure one scheduling decision
     struct SchedulingConfig
@@ -80,12 +80,12 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 1, 1 },
         .used = { 0, 0 },
         .numReqs = 2,
         .topologyHint = faabric::batch_scheduler::SchedulingTopologyHint::NONE,
-        .expectedHosts = { masterHost, "hostA" },
+        .expectedHosts = { mainHost, "hostA" },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -99,7 +99,7 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 {
 
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA", "hostB" },
+        .hosts = { mainHost, "hostA", "hostB" },
         .slots = { 4, 4, 4 },
         .used = { 0, 0, 0 },
         .topologyHint = faabric::batch_scheduler::SchedulingTopologyHint::NONE,
@@ -110,32 +110,32 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
         config.used = { 2, 3, 2 };
         config.numReqs = 5;
         config.expectedHosts = {
-            masterHost, masterHost, "hostA", "hostB", "hostB"
+            mainHost, mainHost, "hostA", "hostB", "hostB"
         };
     }
 
-    SECTION("Non-master host overloaded")
+    SECTION("Non-main host overloaded")
     {
         config.used = { 2, 6, 2 };
         config.numReqs = 4;
-        config.expectedHosts = { masterHost, masterHost, "hostB", "hostB" };
+        config.expectedHosts = { mainHost, mainHost, "hostB", "hostB" };
     }
 
-    SECTION("Non-master host overloaded, insufficient capacity")
+    SECTION("Non-main host overloaded, insufficient capacity")
     {
         config.used = { 3, 6, 2 };
         config.numReqs = 5;
         config.expectedHosts = {
-            masterHost, "hostB", "hostB", masterHost, masterHost,
+            mainHost, "hostB", "hostB", mainHost, mainHost,
         };
     }
 
-    SECTION("Non-master host overloaded, master overloaded")
+    SECTION("Non-main host overloaded, main overloaded")
     {
         config.used = { 6, 6, 2 };
         config.numReqs = 5;
         config.expectedHosts = {
-            "hostB", "hostB", masterHost, masterHost, masterHost,
+            "hostB", "hostB", mainHost, mainHost, mainHost,
         };
     }
 
@@ -145,16 +145,16 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 }
 
 TEST_CASE_METHOD(SchedulingDecisionTestFixture,
-                 "Test overloading all resources defaults to master",
+                 "Test overloading all resources defaults to main",
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 1, 1 },
         .used = { 0, 0 },
         .numReqs = 3,
         .topologyHint = faabric::batch_scheduler::SchedulingTopologyHint::NONE,
-        .expectedHosts = { masterHost, "hostA", masterHost },
+        .expectedHosts = { mainHost, "hostA", mainHost },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -163,17 +163,17 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 }
 
 TEST_CASE_METHOD(SchedulingDecisionTestFixture,
-                 "Test force local forces executing at master",
+                 "Test force local forces executing at main",
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 1, 1 },
         .used = { 0, 0 },
         .numReqs = 2,
         .topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::FORCE_LOCAL,
-        .expectedHosts = { masterHost, "hostA" },
+        .expectedHosts = { mainHost, "hostA" },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -182,14 +182,14 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     {
         config.topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::NONE,
-        config.expectedHosts = { masterHost, "hostA" };
+        config.expectedHosts = { mainHost, "hostA" };
     }
 
     SECTION("Force local on")
     {
         config.topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::FORCE_LOCAL,
-        config.expectedHosts = { masterHost, masterHost };
+        config.expectedHosts = { mainHost, mainHost };
     }
 
     testActualSchedulingDecision(req, config);
@@ -200,13 +200,13 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 1, 1 },
         .used = { 0, 0 },
         .numReqs = 2,
         .topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::FORCE_LOCAL,
-        .expectedHosts = { masterHost, "hostA" },
+        .expectedHosts = { mainHost, "hostA" },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -215,12 +215,12 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     SECTION("Config. variable set")
     {
         faabricConf.noTopologyHints = "on";
-        config.expectedHosts = { masterHost, "hostA" };
+        config.expectedHosts = { mainHost, "hostA" };
     }
 
     SECTION("Config. variable not set")
     {
-        config.expectedHosts = { masterHost, masterHost };
+        config.expectedHosts = { mainHost, mainHost };
     }
 
     testActualSchedulingDecision(req, config);
@@ -229,11 +229,11 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 }
 
 TEST_CASE_METHOD(SchedulingDecisionTestFixture,
-                 "Test master running out of resources",
+                 "Test main running out of resources",
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 0, 2 },
         .used = { 0, 0 },
         .numReqs = 2,
@@ -251,12 +251,12 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA", "hostB" },
+        .hosts = { mainHost, "hostA", "hostB" },
         .slots = { 2, 0, 2 },
         .used = { 0, 0, 0 },
         .numReqs = 4,
         .topologyHint = faabric::batch_scheduler::SchedulingTopologyHint::NONE,
-        .expectedHosts = { masterHost, masterHost, "hostB", "hostB" },
+        .expectedHosts = { mainHost, mainHost, "hostB", "hostB" },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -281,12 +281,12 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA", "hostB", "hostC" },
+        .hosts = { mainHost, "hostA", "hostB", "hostC" },
         .slots = { 0, 0, 0, 0 },
         .used = { 0, 0, 0, 0 },
         .numReqs = 8,
         .topologyHint = faabric::batch_scheduler::SchedulingTopologyHint::NONE,
-        .expectedHosts = { masterHost, masterHost, masterHost, masterHost },
+        .expectedHosts = { mainHost, mainHost, mainHost, mainHost },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -294,14 +294,14 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     SECTION("Even slot distribution across hosts")
     {
         config.slots = { 2, 2, 2, 2 };
-        config.expectedHosts = { masterHost, masterHost, "hostA", "hostA",
+        config.expectedHosts = { mainHost, mainHost, "hostA", "hostA",
                                  "hostB",    "hostB",    "hostC", "hostC" };
     }
 
     SECTION("Uneven slot ditribution across hosts")
     {
         config.slots = { 3, 2, 2, 1 };
-        config.expectedHosts = { masterHost, masterHost, masterHost, "hostA",
+        config.expectedHosts = { mainHost, mainHost, mainHost, "hostA",
                                  "hostA",    "hostB",    "hostB",    "hostC" };
     }
 
@@ -309,8 +309,8 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     {
         config.slots = { 1, 0, 0, 0 };
         config.expectedHosts = {
-            masterHost, masterHost, masterHost, masterHost,
-            masterHost, masterHost, masterHost, masterHost
+            mainHost, mainHost, mainHost, mainHost,
+            mainHost, mainHost, mainHost, mainHost
         };
     }
 
@@ -323,8 +323,8 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
             config.topologyHint =
               faabric::batch_scheduler::SchedulingTopologyHint::NONE;
             config.expectedHosts = {
-                masterHost, masterHost, "hostA", "hostA",
-                "hostB",    "hostC",    "hostC", masterHost
+                mainHost, mainHost, "hostA", "hostA",
+                "hostB",    "hostC",    "hostC", mainHost
             };
         }
 
@@ -332,7 +332,7 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
         {
             config.topologyHint =
               faabric::batch_scheduler::SchedulingTopologyHint::NEVER_ALONE;
-            config.expectedHosts = { masterHost, masterHost, "hostA", "hostA",
+            config.expectedHosts = { mainHost, mainHost, "hostA", "hostA",
                                      "hostC",    "hostC",    "hostC", "hostC" };
         }
     }
@@ -345,31 +345,31 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 1, 1 },
         .used = { 0, 0 },
         .numReqs = 2,
         .topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::NEVER_ALONE,
-        .expectedHosts = { masterHost, "hostA" },
+        .expectedHosts = { mainHost, "hostA" },
     };
 
     std::shared_ptr<faabric::BatchExecuteRequest> req;
 
     SECTION("Test with hint we only schedule to new hosts pairs of requests")
     {
-        config.expectedHosts = { masterHost, masterHost };
+        config.expectedHosts = { mainHost, mainHost };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
 
     SECTION("Test with hint we may overload remote hosts")
     {
-        config.hosts = { masterHost, "hostA", "hostB" };
+        config.hosts = { mainHost, "hostA", "hostB" };
         config.numReqs = 5;
         config.slots = { 2, 2, 1 };
         config.used = { 0, 0, 0 };
         config.expectedHosts = {
-            masterHost, masterHost, "hostA", "hostA", "hostA"
+            mainHost, mainHost, "hostA", "hostA", "hostA"
         };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
@@ -377,35 +377,35 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     SECTION(
       "Test with hint we still overload correctly if running out of slots")
     {
-        config.hosts = { masterHost, "hostA" };
+        config.hosts = { mainHost, "hostA" };
         config.numReqs = 5;
         config.slots = { 2, 2 };
         config.used = { 0, 0 };
         config.expectedHosts = {
-            masterHost, masterHost, "hostA", "hostA", "hostA"
+            mainHost, mainHost, "hostA", "hostA", "hostA"
         };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
 
     SECTION("Test hint with uneven slot distribution")
     {
-        config.hosts = { masterHost, "hostA" };
+        config.hosts = { mainHost, "hostA" };
         config.numReqs = 5;
         config.slots = { 2, 3 };
         config.used = { 0, 0 };
         config.expectedHosts = {
-            masterHost, masterHost, "hostA", "hostA", "hostA"
+            mainHost, mainHost, "hostA", "hostA", "hostA"
         };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
 
     SECTION("Test hint with uneven slot distribution and overload")
     {
-        config.hosts = { masterHost, "hostA", "hostB" };
+        config.hosts = { mainHost, "hostA", "hostB" };
         config.numReqs = 6;
         config.slots = { 2, 3, 1 };
         config.used = { 0, 0, 0 };
-        config.expectedHosts = { masterHost, masterHost, "hostA",
+        config.expectedHosts = { mainHost, mainHost, "hostA",
                                  "hostA",    "hostA",    "hostA" };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
@@ -418,13 +418,13 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
                  "[scheduler]")
 {
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 2, 2 },
         .used = { 0, 0 },
         .numReqs = 2,
         .topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::UNDERFULL,
-        .expectedHosts = { masterHost, "hostA" },
+        .expectedHosts = { mainHost, "hostA" },
     };
 
     std::shared_ptr<faabric::BatchExecuteRequest> req;
@@ -437,14 +437,14 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     SECTION("Test hint does not affect other hosts")
     {
         config.numReqs = 3;
-        config.expectedHosts = { masterHost, "hostA", "hostA" };
+        config.expectedHosts = { mainHost, "hostA", "hostA" };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
 
-    SECTION("Test with hint we still overload to master")
+    SECTION("Test with hint we still overload to main")
     {
         config.numReqs = 4;
-        config.expectedHosts = { masterHost, "hostA", "hostA", masterHost };
+        config.expectedHosts = { mainHost, "hostA", "hostA", mainHost };
         req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
     }
 
@@ -457,13 +457,13 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 {
     // Set up a basic scenario
     SchedulingConfig config = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 2, 2 },
         .used = { 0, 0 },
         .numReqs = 4,
         .topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::CACHED,
-        .expectedHosts = { masterHost, masterHost, "hostA", "hostA" },
+        .expectedHosts = { mainHost, mainHost, "hostA", "hostA" },
     };
 
     auto req = faabric::util::batchExecFactory("foo", "bar", config.numReqs);
@@ -473,13 +473,13 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
     // Now change the setup so that another decision would do something
     // different
     SchedulingConfig hitConfig = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 0, 10 },
         .used = { 0, 0 },
         .numReqs = 4,
         .topologyHint =
           faabric::batch_scheduler::SchedulingTopologyHint::CACHED,
-        .expectedHosts = { masterHost, masterHost, "hostA", "hostA" },
+        .expectedHosts = { mainHost, mainHost, "hostA", "hostA" },
     };
 
     // Note we must preserve the app ID to get a cached decision
@@ -491,7 +491,7 @@ TEST_CASE_METHOD(SchedulingDecisionTestFixture,
 
     // Change app ID and confirm we get new decision
     SchedulingConfig missConfig = {
-        .hosts = { masterHost, "hostA" },
+        .hosts = { mainHost, "hostA" },
         .slots = { 0, 10 },
         .used = { 0, 0 },
         .numReqs = 4,

--- a/tests/test/state/test_state.cpp
+++ b/tests/test/state/test_state.cpp
@@ -27,7 +27,7 @@ class StateServerTestFixture
 {
   public:
     // Set up a local server with a *different* state instance to the main
-    // thread. This way we can fake the master/ non-master setup
+    // thread. This way we can fake the main/ non-main setup
     StateServerTestFixture()
       : remoteState(LOCALHOST)
       , stateServer(remoteState)
@@ -62,16 +62,16 @@ class StateServerTestFixture
             std::shared_ptr<InMemoryStateKeyValue> inMemKv =
               std::static_pointer_cast<InMemoryStateKeyValue>(kv);
 
-            // Check this kv "thinks" it's master
+            // Check this kv "thinks" it's main
             if (!inMemKv->isMaster()) {
-                SPDLOG_ERROR("Dummy state server not master for data");
+                SPDLOG_ERROR("Dummy state server not main for data");
                 throw std::runtime_error("Dummy state server failed");
             }
 
             // Set the data
             kv->set(dummyData.data());
             SPDLOG_DEBUG(
-              "Finished setting master for test {}/{}", kv->user, kv->key);
+              "Finished setting main for test {}/{}", kv->user, kv->key);
 
             conf.endpointHost = originalHost;
         }
@@ -945,7 +945,7 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(StateServerTestFixture,
-                 "Test state server as remote master",
+                 "Test state server as remote main",
                  "[state]")
 {
     REQUIRE(state.getKVCount() == 0);
@@ -963,7 +963,7 @@ TEST_CASE_METHOD(StateServerTestFixture,
     size_t actualSize = state.getStateSize(userA, keyA);
     REQUIRE(actualSize == dataA.size());
 
-    // Access locally and check not master
+    // Access locally and check not main
     auto localKv = getLocalKv();
     auto localStateKv =
       std::static_pointer_cast<InMemoryStateKeyValue>(localKv);

--- a/tests/test/state/test_state_server.cpp
+++ b/tests/test/state/test_state_server.cpp
@@ -157,7 +157,7 @@ TEST_CASE_METHOD(SimpleStateServerTestFixture,
     // Create a key-value locally
     auto localKv = getKv(userA, keyA, dataA.size());
 
-    // Check this host is the master
+    // Check this host is the main
     REQUIRE(localKv->isMaster());
 
     // Set the data and push, check nothing breaks
@@ -195,7 +195,7 @@ TEST_CASE_METHOD(SimpleStateServerTestFixture,
 }
 
 TEST_CASE_METHOD(SimpleStateServerTestFixture,
-                 "Test state server with local master",
+                 "Test state server with local main",
                  "[state]")
 {
     // Set and push

--- a/tests/test/transport/test_point_to_point.cpp
+++ b/tests/test/transport/test_point_to_point.cpp
@@ -457,7 +457,7 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
     rootMsg.set_appid(appId);
     rootMsg.set_groupsize(groupSize);
     rootMsg.set_groupid(groupId);
-    rootMsg.set_groupidx(POINT_TO_POINT_MASTER_IDX);
+    rootMsg.set_groupidx(POINT_TO_POINT_MAIN_IDX);
 
     faabric::batch_scheduler::SchedulingDecision decision(appId, groupId);
     decision.addMessage(thisHost, msg);

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -132,11 +132,8 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
         op = PointToPointCall::LOCK_GROUP;
 
         // Prepare response
-        broker.sendMessage(groupId,
-                           POINT_TO_POINT_MAIN_IDX,
-                           groupIdx,
-                           data.data(),
-                           data.size());
+        broker.sendMessage(
+          groupId, POINT_TO_POINT_MAIN_IDX, groupIdx, data.data(), data.size());
 
         group->lock(groupIdx, false);
     }
@@ -147,11 +144,8 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
         recursive = true;
 
         // Prepare response
-        broker.sendMessage(groupId,
-                           POINT_TO_POINT_MAIN_IDX,
-                           groupIdx,
-                           data.data(),
-                           data.size());
+        broker.sendMessage(
+          groupId, POINT_TO_POINT_MAIN_IDX, groupIdx, data.data(), data.size());
 
         group->lock(groupIdx, recursive);
     }

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -372,7 +372,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
 
     auto group = setUpGroup(appId, groupId, nThreads);
 
-    // Run threads in background to force a wait from the master
+    // Run threads in background to force a wait from the main
     std::vector<std::jthread> threads;
     for (int i = 1; i < nThreads; i++) {
         threads.emplace_back([&group, i, &actual] {

--- a/tests/test/transport/test_point_to_point_groups.cpp
+++ b/tests/test/transport/test_point_to_point_groups.cpp
@@ -133,7 +133,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
 
         // Prepare response
         broker.sendMessage(groupId,
-                           POINT_TO_POINT_MASTER_IDX,
+                           POINT_TO_POINT_MAIN_IDX,
                            groupIdx,
                            data.data(),
                            data.size());
@@ -148,7 +148,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
 
         // Prepare response
         broker.sendMessage(groupId,
-                           POINT_TO_POINT_MASTER_IDX,
+                           POINT_TO_POINT_MAIN_IDX,
                            groupIdx,
                            data.data(),
                            data.size());
@@ -183,7 +183,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
     REQUIRE(req.appid() == appId);
     REQUIRE(req.groupid() == groupId);
     REQUIRE(req.sendidx() == groupIdx);
-    REQUIRE(req.recvidx() == POINT_TO_POINT_MASTER_IDX);
+    REQUIRE(req.recvidx() == POINT_TO_POINT_MAIN_IDX);
 }
 
 TEST_CASE_METHOD(PointToPointGroupFixture,
@@ -302,7 +302,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
     }
 
     for (int i = 0; i < nSums; i++) {
-        group->barrier(POINT_TO_POINT_MASTER_IDX);
+        group->barrier(POINT_TO_POINT_MAIN_IDX);
         REQUIRE(sharedSums.at(i).load() == (i + 1) * (nThreads - 1));
     }
 
@@ -385,7 +385,7 @@ TEST_CASE_METHOD(PointToPointGroupFixture,
 
     // Master thread to await, should only go through once all threads have
     // finished
-    group->notify(POINT_TO_POINT_MASTER_IDX);
+    group->notify(POINT_TO_POINT_MAIN_IDX);
 
     for (int i = 0; i < nThreads; i++) {
         REQUIRE(actual[i] == i);

--- a/tests/test/util/test_exec_graph.cpp
+++ b/tests/test/util/test_exec_graph.cpp
@@ -140,7 +140,7 @@ TEST_CASE_METHOD(MpiBaseTestFixture, "Test MPI execution graph", "[scheduler]")
 
     world.create(msg, worldId, worldSize);
 
-    // Update the result for the master message
+    // Update the result for the main message
     sch.setFunctionResult(msg);
 
     // Build expected graph

--- a/tests/utils/fixtures.h
+++ b/tests/utils/fixtures.h
@@ -192,7 +192,7 @@ class SchedulerFixture
 
             sch.addHostToGlobalSet(hosts.at(i));
 
-            // If setting resources for the master host, update the scheduler.
+            // If setting resources for the main host, update the scheduler.
             // Otherwise, queue the resource response
             if (i == 0) {
                 sch.setThisHostResources(resources);
@@ -496,7 +496,7 @@ class RemoteMpiTestFixture : public MpiBaseTestFixture
         // Update message
         msg.set_mpiworldsize(worldSize);
 
-        // Set up the first world, holding the master rank (which already takes
+        // Set up the first world, holding the main rank (which already takes
         // one slot).
         // Note that any excess ranks will also be allocated to this world when
         // the scheduler is overloaded.


### PR DESCRIPTION
Everywhere in the code base (including variable names). The most representative change is the one in the `Message` protobuf structure, where we change `masterhost` to `mainhost`.