### PR TITLE
Allow different messages in BER to have different function names

### DIFF
--- a/src/util/batch.cpp
+++ b/src/util/batch.cpp
@@ -55,7 +55,8 @@ bool isBatchExecRequestValid(std::shared_ptr<faabric::BatchExecuteRequest> ber)
         auto msg = ber->messages(i);
         // We allow chained messages in the BER to have different function
         // names (for chaining), but not empty
-        if (msg.user() != user || msg.function().empty() || msg.appid() != appId) {
+        if (msg.user() != user || msg.function().empty() ||
+            msg.appid() != appId) {
             SPDLOG_ERROR("Malformed message in BER");
             SPDLOG_ERROR("Got: (id: {} - user: {} - func: {} - app: {})",
                          msg.id(),

--- a/src/util/batch.cpp
+++ b/src/util/batch.cpp
@@ -1,6 +1,7 @@
 #include <faabric/util/batch.h>
 #include <faabric/util/func.h>
 #include <faabric/util/gids.h>
+#include <faabric/util/logging.h>
 
 namespace faabric::util {
 std::shared_ptr<faabric::BatchExecuteRequest> batchExecFactory()
@@ -52,8 +53,20 @@ bool isBatchExecRequestValid(std::shared_ptr<faabric::BatchExecuteRequest> ber)
     // All messages in the BER must have the same app id, user, and function
     for (int i = 0; i < ber->messages_size(); i++) {
         auto msg = ber->messages(i);
-        if (msg.user() != user || msg.function() != func ||
-            msg.appid() != appId) {
+        // We allow chained messages in the BER to have different function
+        // names (for chaining), but not empty
+        if (msg.user() != user || msg.function().empty() || msg.appid() != appId) {
+            SPDLOG_ERROR("Malformed message in BER");
+            SPDLOG_ERROR("Got: (id: {} - user: {} - func: {} - app: {})",
+                         msg.id(),
+                         msg.user(),
+                         msg.function(),
+                         msg.appid());
+            SPDLOG_ERROR("Expected: (id: {} - user: {} - func: {} - app: {})",
+                         msg.id(),
+                         user,
+                         func,
+                         appId);
             return false;
         }
     }

--- a/tests/test/util/test_batch.cpp
+++ b/tests/test/util/test_batch.cpp
@@ -61,7 +61,8 @@ TEST_CASE("Test batch. exec request sanity checks")
         ber->mutable_messages(0)->set_user("");
     }
 
-    // An empty function deems a BER invalid
+    // An empty function (or a different function name) is admissible to allow
+    // for function chaining by name
     SECTION("Empty function")
     {
         isBerValid = false;
@@ -75,10 +76,11 @@ TEST_CASE("Test batch. exec request sanity checks")
         ber->mutable_messages(1)->set_user("foo");
     }
 
-    // A function mismatch between the messages deems a BER invalid
+    // A function mismatch between the messages is acceptable to allow for
+    // function chaining
     SECTION("Function mismatch")
     {
-        isBerValid = false;
+        isBerValid = true;
         ber->mutable_messages(1)->set_function("foo");
     }
 


### PR DESCRIPTION
This is necessary to correctly chain functions by name.