### PR TITLE
Override CPU count in tests

### DIFF
--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -27,7 +27,7 @@ TEST_ENV = {
 
 # If executing in CI, give us some extra CPU cores to run the tests
 if IS_CI:
-    TEST_ENV["OVERRIDE_CPU_COUNT"] = 5
+    TEST_ENV["OVERRIDE_CPU_COUNT"] = "5"
 
 
 @task(default=True)

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -4,6 +4,8 @@ from os.path import join
 from subprocess import run
 from tasks.util.env import FAABRIC_STATIC_BUILD_DIR, PROJ_ROOT
 
+IS_CI = "HOST_TYPE" in environ and environ["HOST_TYPE"] == "ci"
+
 TEST_ENV = {
     "LOG_LEVEL": "info",
     "PLANNER_HOST": "localhost",
@@ -22,6 +24,10 @@ TEST_ENV = {
     ),
     "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1",
 }
+
+# If executing in CI, give us some extra CPU cores to run the tests
+if IS_CI:
+    TEST_ENV["OVERRIDE_CPU_COUNT"] = 5
 
 
 @task(default=True)

--- a/tests/test/util/test_config.cpp
+++ b/tests/test/util/test_config.cpp
@@ -21,7 +21,6 @@ TEST_CASE("Test default system config initialisation", "[util]")
     REQUIRE(conf.redisPort == "6379");
 
     REQUIRE(conf.noScheduler == 0);
-    REQUIRE(conf.overrideCpuCount == 0);
     REQUIRE(conf.noTopologyHints == "off");
     REQUIRE(conf.noSingleHostOptimisations == 0);
     REQUIRE(conf.batchSchedulerMode == "bin-pack");

--- a/tests/test/util/test_environment.cpp
+++ b/tests/test/util/test_environment.cpp
@@ -42,10 +42,10 @@ TEST_CASE("Test setting environment variables", "[util]")
 
 TEST_CASE("Test overriding CPU count", "[util]")
 {
-    // Check default cores is same as available concurrency
+    // Check default cores is same as usable cores
     auto& conf = getSystemConfig();
     unsigned int defaultCores = getUsableCores();
-    REQUIRE(defaultCores == std::thread::hardware_concurrency());
+    REQUIRE(defaultCores == getUsableCores());
 
     // Check it can be overridden
     conf.overrideCpuCount = 1234;


### PR DESCRIPTION
In the tests, we sometimes need a minimum (percvieved) hardware concurrency to, for example, run threaded tests. After #345 is merged in, the scheduler does not overload, so we need to set a minimum default higher than the one in GHA (2).