### PR TITLE
Remove message from scheduling decision

### DIFF
--- a/include/faabric/batch-scheduler/SchedulingDecision.h
+++ b/include/faabric/batch-scheduler/SchedulingDecision.h
@@ -99,6 +99,8 @@ class SchedulingDecision
                     int32_t appIdx,
                     int32_t groupIdx);
 
+    void removeMessage(int32_t messageId);
+
     std::set<std::string> uniqueHosts();
 
     void print(const std::string& logLevel = "debug");

--- a/src/batch-scheduler/SchedulingDecision.cpp
+++ b/src/batch-scheduler/SchedulingDecision.cpp
@@ -54,6 +54,26 @@ SchedulingDecision SchedulingDecision::fromPointToPointMappings(
     return decision;
 }
 
+void SchedulingDecision::removeMessage(int32_t messageId)
+{
+    nFunctions--;
+
+    // Work out the index for the to-be-deleted message
+    auto idxItr = std::find(messageIds.begin(), messageIds.end(), messageId);
+    if (idxItr == messageIds.end()) {
+        SPDLOG_ERROR("Attempting to remove a message id ({}) that is not in "
+                     "the scheduling decision!",
+                     messageId);
+        throw std::runtime_error("Removing non-existant message!");
+    }
+    int idx = std::distance(messageIds.begin(), idxItr);
+
+    hosts.erase(hosts.begin() + idx);
+    messageIds.erase(messageIds.begin() + idx);
+    appIdxs.erase(appIdxs.begin() + idx);
+    groupIdxs.erase(groupIdxs.begin() + idx);
+}
+
 std::set<std::string> SchedulingDecision::uniqueHosts()
 {
     return std::set<std::string>(hosts.begin(), hosts.end());

--- a/src/batch-scheduler/SchedulingDecision.cpp
+++ b/src/batch-scheduler/SchedulingDecision.cpp
@@ -56,8 +56,6 @@ SchedulingDecision SchedulingDecision::fromPointToPointMappings(
 
 void SchedulingDecision::removeMessage(int32_t messageId)
 {
-    nFunctions--;
-
     // Work out the index for the to-be-deleted message
     auto idxItr = std::find(messageIds.begin(), messageIds.end(), messageId);
     if (idxItr == messageIds.end()) {
@@ -68,6 +66,7 @@ void SchedulingDecision::removeMessage(int32_t messageId)
     }
     int idx = std::distance(messageIds.begin(), idxItr);
 
+    nFunctions--;
     hosts.erase(hosts.begin() + idx);
     messageIds.erase(messageIds.begin() + idx);
     appIdxs.erase(appIdxs.begin() + idx);


### PR DESCRIPTION
This PR adds a utility method to remove a message from a scheduling decision.

Useful for #353