### PR TITLE
transport(tcp): set TCP_NODELAY and TCP_QUICKACK

### DIFF
--- a/include/faabric/transport/tcp/SendSocket.h
+++ b/include/faabric/transport/tcp/SendSocket.h
@@ -50,6 +50,6 @@ class SendSocket
     std::string host;
     int port;
 
-    setSocketOptions(int connFd);
+    void setSocketOptions(int connFd);
 };
 }

--- a/include/faabric/transport/tcp/SendSocket.h
+++ b/include/faabric/transport/tcp/SendSocket.h
@@ -49,5 +49,7 @@ class SendSocket
 
     std::string host;
     int port;
+
+    setSocketOptions(int connFd);
 };
 }

--- a/include/faabric/transport/tcp/SocketOptions.h
+++ b/include/faabric/transport/tcp/SocketOptions.h
@@ -1,9 +1,9 @@
 #pragma once
 
 namespace faabric::transport::tcp {
-void reuseAddr(int connFd);
-void noDelay(int connFd);
-void quickAck(int connFd);
+void setReuseAddr(int connFd);
+void setNoDelay(int connFd);
+void setQuickAck(int connFd);
 
 void setNonBlocking(int connFd);
 void setBlocking(int connFd);

--- a/include/faabric/transport/tcp/SocketOptions.h
+++ b/include/faabric/transport/tcp/SocketOptions.h
@@ -2,6 +2,8 @@
 
 namespace faabric::transport::tcp {
 void reuseAddr(int connFd);
+void noDelay(int connFd);
+void quickAck(int connFd);
 
 void setNonBlocking(int connFd);
 void setBlocking(int connFd);

--- a/src/transport/tcp/RecvSocket.cpp
+++ b/src/transport/tcp/RecvSocket.cpp
@@ -21,7 +21,7 @@ RecvSocket::~RecvSocket()
 void RecvSocket::listen()
 {
     int connFd = sock.get();
-    reuseAddr(connFd);
+    setReuseAddr(connFd);
     if (!isNonBlocking(connFd)) {
         setNonBlocking(connFd);
     }

--- a/src/transport/tcp/SendSocket.cpp
+++ b/src/transport/tcp/SendSocket.cpp
@@ -1,4 +1,5 @@
 #include <faabric/transport/tcp/SendSocket.h>
+#include <faabric/transport/tcp/SocketOptions.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/macros.h>
 
@@ -22,6 +23,8 @@ void SendSocket::dial()
     }
 
     int connFd = sock.get();
+    noDelay(connFd);
+    quickAck(connFd);
 
     // Re-dial a number of times to accoun for races during initialisation.
     // This number must be rather high for higher-latency environments with

--- a/src/transport/tcp/SendSocket.cpp
+++ b/src/transport/tcp/SendSocket.cpp
@@ -16,6 +16,12 @@ SendSocket::SendSocket(const std::string& host, int port)
   , port(port)
 {}
 
+void SendSocket::setSocketOptions(int connFd)
+{
+    setNoDelay(connFd);
+    setQuickAck(connFd);
+}
+
 void SendSocket::dial()
 {
     if (connected) {
@@ -23,8 +29,7 @@ void SendSocket::dial()
     }
 
     int connFd = sock.get();
-    setNoDelay(connFd);
-    setQuickAck(connFd);
+    setSocketOptions(connFd);
 
     // Re-dial a number of times to accoun for races during initialisation.
     // This number must be rather high for higher-latency environments with

--- a/src/transport/tcp/SendSocket.cpp
+++ b/src/transport/tcp/SendSocket.cpp
@@ -23,8 +23,8 @@ void SendSocket::dial()
     }
 
     int connFd = sock.get();
-    noDelay(connFd);
-    quickAck(connFd);
+    setNoDelay(connFd);
+    setQuickAck(connFd);
 
     // Re-dial a number of times to accoun for races during initialisation.
     // This number must be rather high for higher-latency environments with

--- a/src/transport/tcp/SocketOptions.cpp
+++ b/src/transport/tcp/SocketOptions.cpp
@@ -2,19 +2,37 @@
 #include <faabric/util/logging.h>
 
 #include <fcntl.h>
+#include <netinet/in.h>  // IPPROTO_TCP
+#include <netinet/tcp.h> // TCP_NODELAY, TCP_QUICKACK
 #include <sys/socket.h>
 
 namespace faabric::transport::tcp {
 void reuseAddr(int connFd)
 {
-    // TODO: do we need to check the value populated in enable?
-    int enable = 1;
-
-    int ret =
-      setsockopt(connFd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+    // TODO: do we need to check the value populated in opt?
+    int opt = 1;
+    int ret = setsockopt(connFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
     if (ret < 0) {
         SPDLOG_ERROR("setsockopt(SO_REUSEADDR) failed on fd: {}", connFd);
         throw std::runtime_error("Error setting socket option: SO_REUSADDR");
+    }
+}
+
+void noDelay(int connFd)
+{
+    int opt = 1;
+    int ret = setsockopt(connFd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
+    if (ret < 0) {
+        SPDLOG_ERROR("setsockopt(TCP_NODELAY) failed on fd: {}", connFd);
+    }
+}
+
+void quickAck(int connFd)
+{
+    int opt = 1;
+    int ret = setsockopt(connFd, IPPROTO_TCP, TCP_QUICKACK, &opt, sizeof(opt));
+    if (ret < 0) {
+        SPDLOG_ERROR("setsockopt(TCP_QUICKACK) failed on fd: {}", connFd);
     }
 }
 

--- a/src/transport/tcp/SocketOptions.cpp
+++ b/src/transport/tcp/SocketOptions.cpp
@@ -7,7 +7,7 @@
 #include <sys/socket.h>
 
 namespace faabric::transport::tcp {
-void reuseAddr(int connFd)
+void setReuseAddr(int connFd)
 {
     // TODO: do we need to check the value populated in opt?
     int opt = 1;
@@ -18,7 +18,7 @@ void reuseAddr(int connFd)
     }
 }
 
-void noDelay(int connFd)
+void setNoDelay(int connFd)
 {
     int opt = 1;
     int ret = setsockopt(connFd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
@@ -27,7 +27,7 @@ void noDelay(int connFd)
     }
 }
 
-void quickAck(int connFd)
+void setQuickAck(int connFd)
 {
     int opt = 1;
     int ret = setsockopt(connFd, IPPROTO_TCP, TCP_QUICKACK, &opt, sizeof(opt));


### PR DESCRIPTION
```
-----------------------------------------------------------------------------------------------------------------
local/S       local/L       remote/S      remote/L      commit                                                 
-----------------------------------------------------------------------------------------------------------------
0.294         8.855         0.020         8.665         mpi                                                    
0.024 (0.08)  4.411 (0.50)  0.001 (0.05)  1.107 (0.13)  d9810b0d5dec2ff36ee9fdbda015137bb145364d # main        
0.031 (0.11)  4.528 (0.51)  0.001 (0.05)  1.329 (0.15)  26568f78c368256eae5aa3cb74c94bc737bbd85a # mpi-struct  
0.027 (0.09)  4.530 (0.51)  0.001 (0.05)  1.046 (0.12)  8eb27e0985b9d87834d822676a104b74faafb9a1 # ptp-struct  
0.078 (0.27)  5.220 (0.59)  0.001 (0.05)  1.184 (0.14)  0b0f1b117ea03c2e8e0641ab56a9c8e4e97954a7 # spinlock    
0.028 (0.10)  4.470 (0.50)  0.001 (0.05)  1.124 (0.13)  7b17b30706166ee777d8c05379ef37ca74029eb3 # ptp-no-order
-----------------------------------------------------------------------------------------------------------------
0.028 (0.10)  4.498 (0.51)  0.002 (0.10)  1.664 (0.19)  c3dbe3ba090e58d9488f9b3da0562265725a2e0d # new-main    
0.038 (0.13)  4.839 (0.55)  0.002 (0.10)  1.771 (0.20)  63beeaffe0fbb7728628f616529d465f16614ccc # mpi-affinity
--------------------------------------------------------------------------------------------------------- (Mar 27)
0.162 (0.55)  5.443 (0.61)  0.000 (0.00)  0.183 (0.02)  e42395ac5c0fbad3c68cefaf93d8356163e9d4a9 # good 
--------------------------------------------------------------------------------------------------------- (April 4)
0.030 (0.10)  4.513 (0.51)  0.005 (0.25)  0.747 (0.09)  a7d01b60d0df85a0e87a826f30f94068c8ab247d # mpi-st
--------------------------------------------------------------------------------------------------------- (April 5)
0.026 (0.09)  4.463 (0.50)  0.004 (0.20)  0.757 (0.09)  3e34a053140050907d8a8b77b6c22b691933b7ee # main-before-sock-opt
0.028 (0.10)  4.478 (0.51)  0.005 (0.25)  3.655 (0.42)  75b58f98fe6788f159ff6cd008251b6b4cdcdc65 # sock-opt (this PR)
```