### PR TITLE
tests(tcp): add test for blocking recv sockets

### DIFF
--- a/src/transport/tcp/RecvSocket.cpp
+++ b/src/transport/tcp/RecvSocket.cpp
@@ -139,6 +139,13 @@ void RecvSocket::recvOne(int conn, uint8_t* buffer, size_t bufferSize)
                          std::strerror(errno));
             throw std::runtime_error("TCP error receiving!");
         }
+#ifndef FAABRIC_USE_SPINLOCK
+        if (got == 0 && bufferSize != 0) {
+            SPDLOG_ERROR(
+              "TCP socket trying to receive from disconnected client");
+            throw std::runtime_error("TCP socket client disconnected");
+        }
+#endif
 
         buffer += got;
         numRecvd += got;

--- a/src/transport/tcp/SocketOptions.cpp
+++ b/src/transport/tcp/SocketOptions.cpp
@@ -108,7 +108,7 @@ void setRecvTimeoutMs(int connFd, int timeoutMs)
 {
     struct timeval timeVal;
     timeVal.tv_sec = timeoutMs / 1000;
-    timeVal.tv_usec = 0;
+    timeVal.tv_usec = (timeoutMs % 1000) * 1e3;
 
     int ret = ::setsockopt(
       connFd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeVal, sizeof(timeVal));

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -23,6 +23,7 @@ def cmake(
     coverage=False,
     prof=False,
     cpu=None,
+    disable_spinlock=False,
 ):
     """
     Configures the build
@@ -52,6 +53,9 @@ def cmake(
         "-DFAABRIC_USE_SANITISER={}".format(sanitiser),
         "-DFAABRIC_SELF_TRACING=ON" if prof else "",
         "-DFAABRIC_CODE_COVERAGE=ON" if coverage else "",
+        "-DFAABRIC_USE_SPINLOCK={}".format(
+            "OFF" if disable_spinlock else "ON"
+        ),
         "-DFAABRIC_TARGET_CPU={}".format(cpu) if cpu else "",
         PROJ_ROOT,
     ]


### PR DESCRIPTION
Add test for blocking RECV TCP sockets and add a catch for when we are trying to receive from a client that has already disconnected.