### PR TITLE
transport(tcp): support multi-part sends

### DIFF
--- a/include/faabric/transport/tcp/SendSocket.h
+++ b/include/faabric/transport/tcp/SendSocket.h
@@ -30,15 +30,21 @@ class SendSocket
             totalSize += sizeArray.at(i);
         }
 
-        auto nSent = ::writev(sock.get(), msgs.data(), N);
-        if (nSent != totalSize) {
-            SPDLOG_ERROR("Error sending many to {}:{} ({}/{}): {}",
-                         host,
-                         port,
-                         nSent,
-                         totalSize,
-                         std::strerror(errno));
-            throw std::runtime_error("TCP SendSocket sendMany error!");
+        size_t totalNumSent = 0;
+        while (totalNumSent < totalSize) {
+            auto nSent = ::writev(sock.get(), msgs.data(), N);
+            if (nSent == -1) {
+                SPDLOG_ERROR("Error sending many to {}:{} ({}/{}): {} (no: {})",
+                             host,
+                             port,
+                             nSent,
+                             totalSize,
+                             std::strerror(errno),
+                             errno);
+                throw std::runtime_error("TCP SendSocket sendMany error!");
+            }
+
+            totalNumSent += nSent;
         }
     }
 

--- a/src/transport/tcp/SendSocket.cpp
+++ b/src/transport/tcp/SendSocket.cpp
@@ -68,16 +68,22 @@ void SendSocket::dial()
 
 void SendSocket::sendOne(const uint8_t* buffer, size_t bufferSize)
 {
-    size_t sent = ::send(sock.get(), buffer, bufferSize, 0);
-    if (sent != bufferSize) {
-        SPDLOG_ERROR(
-          "TCP client error sending TCP message to {}:{} ({}/{}): {}",
-          host,
-          port,
-          sent,
-          bufferSize,
-          std::strerror(errno));
-        throw std::runtime_error("TCP client error sending message!");
+    size_t totalNumSent = 0;
+
+    while (totalNumSent < bufferSize) {
+        size_t nSent = ::send(sock.get(), buffer, bufferSize, 0);
+        if (nSent == -1) {
+            SPDLOG_ERROR(
+              "TCP client error sending TCP message to {}:{} ({}/{}): {}",
+              host,
+              port,
+              nSent,
+              bufferSize,
+              std::strerror(errno));
+            throw std::runtime_error("TCP client error sending message!");
+        }
+
+        totalNumSent += nSent;
     }
 }
 }


### PR DESCRIPTION
It is not an error for ::send or ::writev to write less bytes than the buffer size, as long as the return value is a positive value.

In addition, EAGAIN and EWOULDBLOCK have different meanings for blocking and non-blocking sockets.