### PR TITLE
transport(tcp): make send sockets blocking

### DIFF
--- a/src/transport/tcp/RecvSocket.cpp
+++ b/src/transport/tcp/RecvSocket.cpp
@@ -2,7 +2,9 @@
 #include <faabric/transport/tcp/SocketOptions.h>
 #include <faabric/util/logging.h>
 
+#ifdef FAABRIC_USE_SPINLOCK
 #include <emmintrin.h>
+#endif
 #include <poll.h>
 
 namespace faabric::transport::tcp {


### PR DESCRIPTION
Under high-load we are seeing some ::send operations fail with EAGAIN/EWOULDBLOCK. This is because we set send sockets as non-blocking, but we do not handle the EAGAIN/EWOULDBLOCK situation in the send loop. As a first iteration, we attempt setting the send sockets as blocking.

Note that, irrespective of wether send sockets block or not, partial writes may still happen.