### PR TITLE
transport(tcp): better error reporting on timeout

### DIFF
--- a/include/faabric/transport/tcp/Socket.h
+++ b/include/faabric/transport/tcp/Socket.h
@@ -5,7 +5,7 @@
 
 namespace faabric::transport::tcp {
 
-const int SocketTimeoutMs = 3000;
+const int SocketTimeoutMs = 5000;
 
 class Socket
 {

--- a/src/transport/tcp/SendSocket.cpp
+++ b/src/transport/tcp/SendSocket.cpp
@@ -89,12 +89,22 @@ void SendSocket::sendOne(const uint8_t* buffer, size_t bufferSize)
                 continue;
             };
 #endif
-            SPDLOG_ERROR("Error error sending TCP message to {}:{} ({}/{}): {}",
-                         host,
-                         port,
-                         totalNumSent,
-                         bufferSize,
-                         std::strerror(errno));
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                SPDLOG_ERROR(
+                  "Error sending TCP message to {}:{} ({}/{}: timed-out)",
+                  host,
+                  port,
+                  totalNumSent,
+                  bufferSize);
+            } else {
+                SPDLOG_ERROR("Error sending TCP message to {}:{} ({}/{}): {}",
+                             host,
+                             port,
+                             totalNumSent,
+                             bufferSize,
+                             std::strerror(errno));
+            }
+
             throw std::runtime_error("Error sending TCP message!");
         }
 


### PR DESCRIPTION
Turns out there is a situation in which a blocking socket returns EAGAIN or EWOULDBLOCK. This is when the socket is configured with SO_SNDTIMEO and the operation times-out.

We amend the error logging to inform of it accordignly.