### PR TITLE
migration(mpi): fix race conditions

### DIFF
--- a/include/faabric/batch-scheduler/SchedulingDecision.h
+++ b/include/faabric/batch-scheduler/SchedulingDecision.h
@@ -101,6 +101,14 @@ class SchedulingDecision
                     int32_t appIdx,
                     int32_t groupIdx);
 
+    // Add a message in a specific position
+    void addMessageInPosition(int32_t pos,
+                              const std::string& host,
+                              int32_t messageId,
+                              int32_t appIdx,
+                              int32_t groupIdx,
+                              int32_t mpiPort);
+
     // Returns the MPI port that we have vacated
     int32_t removeMessage(int32_t messageId);
 

--- a/include/faabric/mpi/MpiWorld.h
+++ b/include/faabric/mpi/MpiWorld.h
@@ -200,7 +200,9 @@ class MpiWorld
 
     /* Function Migration */
 
-    void prepareMigration(int thisRank, bool thisRankMustMigrate);
+    void prepareMigration(int newGroupId,
+                          int thisRank,
+                          bool thisRankMustMigrate);
 
   private:
     int id = -1;

--- a/src/batch-scheduler/SchedulingDecision.cpp
+++ b/src/batch-scheduler/SchedulingDecision.cpp
@@ -38,6 +38,33 @@ void SchedulingDecision::addMessage(const std::string& host,
     mpiPorts.push_back(0);
 }
 
+void SchedulingDecision::addMessageInPosition(int32_t pos,
+                                              const std::string& host,
+                                              int32_t messageId,
+                                              int32_t appIdx,
+                                              int32_t groupIdx,
+                                              int32_t mpiPort)
+{
+    nFunctions++;
+
+    int desiredSize = std::max<int>(pos + 1, nFunctions);
+    bool mustResize = desiredSize > hosts.size();
+
+    if (mustResize) {
+        hosts.resize(desiredSize);
+        messageIds.resize(desiredSize);
+        appIdxs.resize(desiredSize);
+        groupIdxs.resize(desiredSize);
+        mpiPorts.resize(desiredSize);
+    }
+
+    hosts.at(pos) = host;
+    messageIds.at(pos) = messageId;
+    appIdxs.at(pos) = appIdx;
+    groupIdxs.at(pos) = groupIdx;
+    mpiPorts.at(pos) = mpiPort;
+}
+
 SchedulingDecision SchedulingDecision::fromPointToPointMappings(
   faabric::PointToPointMappings& mappings)
 {

--- a/tests/dist/mpi/mpi_native.cpp
+++ b/tests/dist/mpi/mpi_native.cpp
@@ -790,7 +790,8 @@ void mpiMigrationPoint(int entrypointFuncArg)
 
         if (call->ismpi()) {
             auto& mpiWorld = getMpiWorldRegistry().getWorld(call->mpiworldid());
-            mpiWorld.prepareMigration(call->mpirank(), funcMustMigrate);
+            mpiWorld.prepareMigration(
+              call->groupid(), call->mpirank(), funcMustMigrate);
         }
     }
 

--- a/tests/test/batch-scheduler/test_binpack_scheduler.cpp
+++ b/tests/test/batch-scheduler/test_binpack_scheduler.cpp
@@ -523,6 +523,30 @@ TEST_CASE_METHOD(BinPackSchedulerTestFixture,
           { "foo", "foo", "foo", "bar", "bar", "bar", "bar", "foo", "foo" });
     }
 
+    SECTION("BinPack will minimise the number of messages to migrate (ii)")
+    {
+        config.hostMap =
+          buildHostMap({ "foo", "bar", "baz" }, { 5, 3, 2 }, { 2, 3, 2 });
+        ber = faabric::util::batchExecFactory("bat", "man", 7);
+        ber->set_type(BatchExecuteRequest_BatchExecuteType_MIGRATION);
+        config.inFlightReqs = buildInFlightReqs(
+          ber, 7, { "bar", "bar", "bar", "baz", "baz", "foo", "foo" });
+        config.expectedDecision = buildExpectedDecision(
+          ber, { "bar", "bar", "foo", "foo", "foo", "foo", "foo" });
+    }
+
+    SECTION("BinPack will minimise the number of messages to migrate (iii)")
+    {
+        config.hostMap =
+          buildHostMap({ "foo", "bar", "baz" }, { 3, 3, 3 }, { 2, 3, 2 });
+        ber = faabric::util::batchExecFactory("bat", "man", 7);
+        ber->set_type(BatchExecuteRequest_BatchExecuteType_MIGRATION);
+        config.inFlightReqs = buildInFlightReqs(
+          ber, 7, { "foo", "foo", "bar", "bar", "bar", "baz", "baz" });
+        config.expectedDecision = buildExpectedDecision(
+          ber, { "foo", "foo", "bar", "bar", "bar", "baz", "foo" });
+    }
+
     actualDecision = *batchScheduler->makeSchedulingDecision(
       config.hostMap, config.inFlightReqs, ber);
     compareSchedulingDecisions(actualDecision, config.expectedDecision);


### PR DESCRIPTION
In this PR we fix a couple of bugs and race conditions that only appear when doing many migrations over large node and core counts.