### PR TITLE
migration: fix re-entrant bug

### DIFF
--- a/include/faabric/mpi/MpiWorld.h
+++ b/include/faabric/mpi/MpiWorld.h
@@ -57,7 +57,9 @@ class MpiWorld
 
     int getSize() const;
 
-    void destroy();
+    // Returns true if the world is empty in this host and can be cleared from
+    // the registry
+    bool destroy();
 
     void getCartesianRank(int rank,
                           int maxDims,
@@ -209,6 +211,8 @@ class MpiWorld
     int size = -1;
     std::string thisHost;
     faabric::util::TimePoint creationTime;
+
+    std::atomic<int> activeLocalRanks = 0;
 
     std::atomic_flag isDestroyed = false;
 

--- a/include/faabric/mpi/MpiWorldRegistry.h
+++ b/include/faabric/mpi/MpiWorldRegistry.h
@@ -19,6 +19,8 @@ class MpiWorldRegistry
 
     bool worldExists(int worldId);
 
+    void clearWorld(int worldId);
+
     void clear();
 
   private:

--- a/src/executor/Executor.cpp
+++ b/src/executor/Executor.cpp
@@ -399,7 +399,19 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             if (msg.ismpi()) {
                 auto& mpiWorldRegistry = faabric::mpi::getMpiWorldRegistry();
                 if (mpiWorldRegistry.worldExists(msg.mpiworldid())) {
-                    mpiWorldRegistry.getWorld(msg.mpiworldid()).destroy();
+                    bool mustClear =
+                      mpiWorldRegistry.getWorld(msg.mpiworldid()).destroy();
+
+                    if (mustClear) {
+                        SPDLOG_DEBUG("{}:{}:{} clearing world {} from host {}",
+                                     msg.appid(),
+                                     msg.groupid(),
+                                     msg.groupidx(),
+                                     msg.mpiworldid(),
+                                     msg.executedhost());
+
+                        mpiWorldRegistry.clearWorld(msg.mpiworldid());
+                    }
                 }
             }
         } catch (const std::exception& ex) {
@@ -414,7 +426,19 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             if (msg.ismpi()) {
                 auto& mpiWorldRegistry = faabric::mpi::getMpiWorldRegistry();
                 if (mpiWorldRegistry.worldExists(msg.mpiworldid())) {
-                    mpiWorldRegistry.getWorld(msg.mpiworldid()).destroy();
+                    bool mustClear =
+                      mpiWorldRegistry.getWorld(msg.mpiworldid()).destroy();
+
+                    if (mustClear) {
+                        SPDLOG_DEBUG("{}:{}:{} clearing world {} from host {}",
+                                     msg.appid(),
+                                     msg.groupid(),
+                                     msg.groupidx(),
+                                     msg.mpiworldid(),
+                                     msg.executedhost());
+
+                        mpiWorldRegistry.clearWorld(msg.mpiworldid());
+                    }
                 }
             }
         }

--- a/src/mpi/MpiWorldRegistry.cpp
+++ b/src/mpi/MpiWorldRegistry.cpp
@@ -86,6 +86,11 @@ MpiWorld& MpiWorldRegistry::getWorld(int worldId)
     return *world;
 }
 
+void MpiWorldRegistry::clearWorld(int worldId)
+{
+    worldMap.erase(worldId);
+}
+
 bool MpiWorldRegistry::worldExists(int worldId)
 {
     return worldMap.contains(worldId);

--- a/tests/dist/mpi/mpi_native.cpp
+++ b/tests/dist/mpi/mpi_native.cpp
@@ -35,8 +35,21 @@ static void notImplemented(const std::string& funcName)
 
 int terminateMpi()
 {
+    auto* msg = &faabric::executor::ExecutorContext::get()->getMsg();
+
     // Destroy the MPI world
-    getExecutingWorld().destroy();
+    bool mustClear = getExecutingWorld().destroy();
+
+    if (mustClear) {
+        SPDLOG_DEBUG("{}:{}:{} clearing world {} from host {}",
+                     msg->appid(),
+                     msg->groupid(),
+                     msg->groupidx(),
+                     msg->mpiworldid(),
+                     msg->executedhost());
+
+        getMpiWorldRegistry().clearWorld(msg->mpiworldid());
+    }
 
     return MPI_SUCCESS;
 }


### PR DESCRIPTION
This PR fixes a rare race condition that only happened in enviornments where the same app is migrated many times.

In particular, this bug only appeared when the same application migrated away from one host, and then migrated back into it. Migrating into a new host (wrt the previous scheduling decision) requires one of the migrated-to ranks to run the world initialisation to set the local-remote leaders and in-memory queues. However, the second migration above was not triggering the "new world" migration procedure because the world had lingered in the per-node registry.

This bug materialised in applications having an old version of the host-port mappings, and failing to start.

The fix involves knowing when we are evicting a host for a given world id, and clearing it from the registry if so.