### PR TITLE
mpi: fix setting local ranks

### DIFF
--- a/include/faabric/mpi/MpiWorld.h
+++ b/include/faabric/mpi/MpiWorld.h
@@ -212,7 +212,11 @@ class MpiWorld
     std::string thisHost;
     faabric::util::TimePoint creationTime;
 
-    std::atomic<int> activeLocalRanks = 0;
+    // Latch used to clear the world from the registry when we are migrating
+    // out of it (i.e. evicting it). Note that this clean-up is only necessary
+    // for migration, as we want to clean things up in case we ever migrate
+    // again back into this host
+    std::atomic<int> evictionLatch = 0;
 
     std::atomic_flag isDestroyed = false;
 

--- a/include/faabric/transport/PointToPointBroker.h
+++ b/include/faabric/transport/PointToPointBroker.h
@@ -119,6 +119,8 @@ class PointToPointBroker
 
     std::set<int> getIdxsRegisteredForGroup(int groupId);
 
+    std::set<std::string> getHostsRegisteredForGroup(int groupId);
+
     void updateHostForIdx(int groupId, int groupIdx, std::string newHost);
 
     void sendMessage(int groupId,

--- a/src/executor/Executor.cpp
+++ b/src/executor/Executor.cpp
@@ -426,19 +426,7 @@ void Executor::threadPoolThread(std::stop_token st, int threadPoolIdx)
             if (msg.ismpi()) {
                 auto& mpiWorldRegistry = faabric::mpi::getMpiWorldRegistry();
                 if (mpiWorldRegistry.worldExists(msg.mpiworldid())) {
-                    bool mustClear =
-                      mpiWorldRegistry.getWorld(msg.mpiworldid()).destroy();
-
-                    if (mustClear) {
-                        SPDLOG_DEBUG("{}:{}:{} clearing world {} from host {}",
-                                     msg.appid(),
-                                     msg.groupid(),
-                                     msg.groupidx(),
-                                     msg.mpiworldid(),
-                                     msg.executedhost());
-
-                        mpiWorldRegistry.clearWorld(msg.mpiworldid());
-                    }
+                    mpiWorldRegistry.getWorld(msg.mpiworldid()).destroy();
                 }
             }
         }

--- a/src/transport/PointToPointBroker.cpp
+++ b/src/transport/PointToPointBroker.cpp
@@ -539,6 +539,21 @@ std::set<int> PointToPointBroker::getIdxsRegisteredForGroup(int groupId)
     return groupIdIdxsMap[groupId];
 }
 
+std::set<std::string> PointToPointBroker::getHostsRegisteredForGroup(
+  int groupId)
+{
+    faabric::util::SharedLock lock(brokerMutex);
+    std::set<int> indexes = groupIdIdxsMap[groupId];
+
+    std::set<std::string> hosts;
+    for (const auto& idx : indexes) {
+        std::string key = getPointToPointKey(groupId, idx);
+        hosts.insert(mappings.at(key));
+    }
+
+    return hosts;
+}
+
 void PointToPointBroker::initSequenceCounters(int groupId)
 {
     if (currentGroupId != NO_CURRENT_GROUP_ID) {

--- a/tests/test/transport/test_point_to_point.cpp
+++ b/tests/test/transport/test_point_to_point.cpp
@@ -44,6 +44,8 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
 
     REQUIRE(broker.getIdxsRegisteredForGroup(appIdA).empty());
     REQUIRE(broker.getIdxsRegisteredForGroup(appIdB).empty());
+    REQUIRE(broker.getHostsRegisteredForGroup(appIdA).empty());
+    REQUIRE(broker.getHostsRegisteredForGroup(appIdB).empty());
 
     faabric::PointToPointMappings mappingsA;
     mappingsA.set_appid(appIdA);
@@ -73,6 +75,8 @@ TEST_CASE_METHOD(PointToPointClientServerFixture,
 
     REQUIRE(broker.getIdxsRegisteredForGroup(groupIdA).size() == 2);
     REQUIRE(broker.getIdxsRegisteredForGroup(groupIdB).size() == 1);
+    REQUIRE(broker.getHostsRegisteredForGroup(groupIdA).size() == 2);
+    REQUIRE(broker.getHostsRegisteredForGroup(groupIdB).size() == 1);
 
     REQUIRE(broker.getHostForReceiver(groupIdA, groupIdxA1) == hostA);
     REQUIRE(broker.getHostForReceiver(groupIdA, groupIdxA2) == hostB);


### PR DESCRIPTION
In very constrained environments like GHA it may sometimes happen that some ranks _completely_ finish (i.e. call destroy) before others have even called Init.

With our current implementation, this meant that the world may have been removed from the registry, even though there were still active local ranks to run.

To fix this, we set the number of active local ranks once, at the beginning, and decrement it on a per-thread basis. Note that this does not invaliate the fix to the previous race condition because, in fact, what we fixed is that we now _always_ init a world when we execute in it.