### PR TITLE
scheduler: tag executors with app id

### DIFF
--- a/src/util/func.cpp
+++ b/src/util/func.cpp
@@ -24,7 +24,7 @@ std::string funcToString(const faabric::Message& msg, bool includeId)
     std::string str = msg.user() + "/" + msg.function();
 
     if (includeId) {
-        str += ":" + std::to_string(msg.id());
+        str += ":" + std::to_string(msg.appid());
     }
 
     return str;


### PR DESCRIPTION
Thus far, we tagged executors with the (user, function) pair. This is needed in multi-threaded environments, where different threads must share the same executor. However, using only the (user, function) pair prevents the execution concurrent applications with the same pair.

Instead, the correct thing to do is to track applications using the (user, function) pair in conjunction with the application id.